### PR TITLE
Fixes _server_variable name mismatch in Client

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -314,7 +314,7 @@ class Raven_Client
         return $schema . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
     }
 
-    private function _server_var($key)
+    private function _server_variable($key)
     {
         if (isset($_SERVER[$key])) {
             return $_SERVER[$key];


### PR DESCRIPTION
Fixes
Fatal error: Call to undefined method Raven_Client::_server_variable() in lib/Raven/Client.php on line 171
