### PR TITLE
Make the Travis_CI image link to the Travis CI page instead of to the image (ReST default).

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,10 @@
 raven-php
 =========
 
-.. image:: https://secure.travis-ci.org/getsentry/raven-php.png?branch=master
+|travis-ci|_
+
+.. |travis-ci| image:: https://secure.travis-ci.org/getsentry/raven-php.png?branch=master
+.. _travis-ci: https://secure.travis-ci.org/getsentry/raven-php 
 
 raven-php is an experimental PHP client for `Sentry <http://aboutsentry.com/>`_.
 


### PR DESCRIPTION
See http://groups.google.com/group/showmedo/browse_thread/thread/c731cd528fc1096b
