### PR TITLE
Warnings get raised when port is not returned by parse_url

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -246,7 +246,7 @@ class Raven_Client
     private function send_remote($url, $data, $headers=array())
     {
         $parts = parse_url($url);
-        $parts['netloc'] = $parts['host'].($parts['port'] ? ':'.$parts['port'] : null);
+        $parts['netloc'] = $parts['host'].(array_key_exists('port', $parts) ? ':'.$parts['port'] : null);
 
         if ($parts['scheme'] === 'udp')
             return $this->send_udp($parts['netloc'], $data, $headers['X-Sentry-Auth']);


### PR DESCRIPTION
Hi,

the elements returned by parse_url do not always contain the 'port' element. It raises warning from php. I just checked its presence with array_key_exists.

Feel free it integrate it.

Matthieu.
