### PR TITLE
Add registerExceptionHandler() and registerErrorHandler() methods to Raven_ErrorHandler.

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -14,8 +14,8 @@
  *
  * $client = new Raven_Client('http://public:secret/example.com/1');
  * $error_handler = new Raven_ErrorHandler($client);
- * set_error_handler(array($error_handler, 'handleError');
- * set_exception_handler(array($error_handler, 'handleException'));
+ * $error_handler->registerExceptionHandler();
+ * $error_handler->registerErrorHandler();
  *
  * @package raven
  */
@@ -26,13 +26,38 @@ class Raven_ErrorHandler
         $this->client = $client;
     }
 
-    function handleException($e) {
-        $this->client->captureException($e);
+    function handleException($e, $isError = false) {
+        $e->event_id = $this->client->getIdent($this->client->captureException($e));
+
+        if (!$isError && $this->call_existing_exception_handler && $this->old_exception_handler) {
+            call_user_func($this->old_exception_handler, $e);
+        }
     }
 
     function handleError($code, $message, $file='', $line=0, $context=array()) {
         $e = new ErrorException($message, 0, $code, $file, $line);
-        $this->handleException($e);
+        $this->handleException($e, $isError = true);
+
+        if ($this->call_existing_error_handler && $this->old_error_handler) {
+            call_user_func($this->old_exception_handler, $code, $message, $file, $line, $context);
+        }
     }
+
+    function registerExceptionHandler($call_existing_exception_handler = true)
+    {
+        $this->old_exception_handler = set_exception_handler(array($this, 'handleException'));
+        $this->call_existing_exception_handler = $call_existing_exception_handler;
+    }
+
+    function registerErrorHandler($call_existing_error_handler = true, $error_types = E_ALL)
+    {
+        $this->old_error_handler = set_error_handler(array($this, 'handleError'), $error_types);
+        $this->call_existing_error_handler = $call_existing_error_handler;
+    }
+
+    private $old_exception_handler = null;
+    private $call_existing_exception_handler = false;
+    private $old_error_handler = null;
+    private $call_existing_error_handler = false;
 }
 ?>

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -13,7 +13,7 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
 {
     public function testErrorsAreLoggedAsExceptions()
     {
-        $client = $this->getMock('Client', array('captureException'));
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
         $client->expects($this->once())
                ->method('captureException')
                ->with($this->isInstanceOf('ErrorException'));
@@ -24,7 +24,7 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
 
     public function testExceptionsAreLogged()
     {
-        $client = $this->getMock('Client', array('captureException'));
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
         $client->expects($this->once())
                ->method('captureException')
                ->with($this->isInstanceOf('ErrorException'));


### PR DESCRIPTION
By default, these call existing handlers in the new handler so we're extending rather than overwriting previous handling behavior. This makes it easier to log to sentry AND display an error message to the user (with or without a link to Sentry).

If the client uses the old way of registering handlers manually, then the existing handlers will not be called, so we are not changing the semantics for existing code.
