### PR TITLE
Disable verbose logging in low level curl command

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -288,7 +288,7 @@ class Raven_Client
         curl_setopt($curl, CURLOPT_POST, 1);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $new_headers);
         curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-        curl_setopt($curl, CURLOPT_VERBOSE, true);
+        curl_setopt($curl, CURLOPT_VERBOSE, false);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
         $ret = curl_exec($curl);


### PR DESCRIPTION
This information is irrelevant on production, and the verbosity means it fills log files
