### PR TITLE
Updated documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ raven-php is an experimental PHP client for `Sentry <http://aboutsentry.com/>`_.
 
     // Install error handlers
     $error_handler = new Raven_ErrorHandler($client);
-    set_error_handler(array($error_handler, 'handleError');
-    set_exception_handler(array($error_handler, 'handleException'));
+    $error_handler->registerExceptionHandler();
+	$error_handler->registerErrorHandler();
 
 Installation
 ------------


### PR DESCRIPTION
I've updated the documentation to refer to the registerExceptionHandler() and registerErrorHandler() methods of the Raven_ErrorHandler class; previously, the documentation advised you to call set_error_handler() and set_exception_handler() directly. 
