### PR TITLE
Removing unneeded closing ?> from ErrorHandler.php.

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -62,4 +62,3 @@ class Raven_ErrorHandler
     private $old_error_handler = null;
     private $call_existing_error_handler = false;
 }
-?>


### PR DESCRIPTION
The other PHP files lack the closing ?>.  Removing it from ErrorHandler.php as well.
