### PR TITLE
Tags can be specified by event in method capture()

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -268,8 +268,10 @@ class Raven_Client
             $data = $this->remove_invalid_utf8($data);
         }
 
-        // TODO: allow tags to be specified per event
-        $data['tags'] = $this->tags;
+        // Merge tags from constructor and event specified by event (if available)
+        $data['tags'] = (array_key_exists('tags', $data)) 
+            ? $data['tags'] = array_merge($data['tags'],$this->tags)
+            : $data['tags'] = $this->tags;   
 
         $this->sanitize($data);
         $this->process($data);


### PR DESCRIPTION
If $data contains a field 'tags' those tags will be merged with the tags which have been set in the constructor from Raven_Client.

This way you'll be able to extend Raven_Client, create a method MyRavenClient::myCaptureMessage() and pass an array with tags in $data to parent::capture(). 

Please note, that this is my first pull request in github, so please be patient, if I got something completly wrong... :-)
