### PR TITLE
Report E_STRICT errors on PHP < 5.4

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -77,8 +77,11 @@ class Raven_ErrorHandler
         $this->call_existing_exception_handler = $call_existing_exception_handler;
     }
 
-    public function registerErrorHandler($call_existing_error_handler = true, $error_types = E_ALL)
+    public function registerErrorHandler($call_existing_error_handler = true, $error_types = null)
     {
+        if (null === $error_types) {
+            $error_types = E_ALL | E_STRICT;
+        }
         $this->old_error_handler = set_error_handler(array($this, 'handleError'), $error_types);
         $this->call_existing_error_handler = $call_existing_error_handler;
     }


### PR DESCRIPTION
The E_ALL constant does not contain E_STRICT in PHP < 5.4
http://www.php.net/manual/en/errorfunc.constants.php
