### PR TITLE
Syntax bug in README example client options.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ An array of tags to apply to events in this context.
 ::
 
     'tags' => array(
-        'php_version': phpversion(),
+        'php_version' => phpversion(),
     )
 
 ``signing``


### PR DESCRIPTION
Just a little syntax error in the README.

I'm sure it just snuck over from the Python dict syntax.
