### PR TITLE
only set data['culprit'] if != null

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -184,9 +184,10 @@ class Raven_Client
         }
 
         if (!is_array($culprit_or_options)) {
-            $data = array(
-                'culprit' => $culprit_or_options,
-            );
+            $data = array();
+            if ($culprit_or_options !== null) {
+                $data['culprit'] = $culprit_or_options;
+            }
         } else {
             $data = $culprit_or_options;
         }


### PR DESCRIPTION
a change in commit 0b368e3636f06a580f5e8619565d362f928530ab always set culprit even if it was null.  This was resulting in Events having a title of NULL in Sentry.  

I checked the contents of data array in captureException before this change and after this change and noticed the difference was the setting of culprit = null.
