### PR TITLE
add mechanism to exclude exceptions by name from getting logged

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -54,6 +54,7 @@ class Raven_Client
         $this->site = Raven_Util::get($options, 'site', $this->_server_variable('SERVER_NAME'));
         $this->tags = Raven_Util::get($options, 'tags', array());
         $this->trace = (bool) Raven_Util::get($options, 'trace', true);
+        $this->exclude = Raven_Util::get($options, 'exclude', array());
         $this->severity_map = NULL;
 
         // XXX: Signing is disabled by default as it is no longer required by modern versions of Sentrys
@@ -183,6 +184,10 @@ class Raven_Client
      */
     public function captureException($exception, $culprit_or_options=null, $logger=null)
     {
+        if (in_array(get_class($exception), $this->exclude)) {
+            return null;
+        }
+
         $exc_message = $exception->getMessage();
         if (empty($exc_message)) {
             $exc_message = '<unknown exception>';

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -274,6 +274,17 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['culprit'], 'test');
     }
 
+    public function testCaptureExceptionHandlesExcludeOption()
+    {
+        $client = new Dummy_Raven_Client(array(
+            'exclude' => array('Exception'),
+        ));
+        $ex = $this->create_exception();
+        $client->captureException($ex, 'test');
+        $events = $client->getSentEvents();
+        $this->assertEquals(count($events), 0);
+    }
+
     public function testDoesRegisterProcessors()
     {
         $client = new Dummy_Raven_Client(array(


### PR DESCRIPTION
- add client 'exclude' option
- get exception class name and skip if it's in exclude list
### Use Case

The framework we use (Kohana) handles 404s using an exception 'Kohana_404_Exception'.  This is a simple way to have Sentry ignore these when using the global Sentry exception handler. It has worked well for us in production.
