### PR TITLE
More flexibility in the stacktrace generation.

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -69,7 +69,7 @@ class Raven_Stacktrace
             $result[] = array(
                 'abs_path' => $abs_path,
                 'filename' => $context['filename'],
-                'lineno' => $context['lineno'],
+                'lineno' => (int) $context['lineno'],
                 'module' => $module,
                 'function' => $nextframe['function'],
                 'vars' => $vars,


### PR DESCRIPTION
The proposed modification allows to send the backtrace to Sentry, but without loading the context. In order to do so, pass `'file' => null`. 

Instead of hitting the `continue;` statement and skip the entire frame, the `read_source_file` function will be called, and will return the empty template since `$filename` will be null.

Tests : OK
