### PR TITLE
Fixed pre-5.3.0 PHP undefined constant notice

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -538,8 +538,12 @@ class Raven_Client
             case E_USER_NOTICE:        return Raven_Client::INFO;
             case E_STRICT:             return Raven_Client::INFO;
             case E_RECOVERABLE_ERROR:  return Raven_Client::ERROR;
+        }
+        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+          switch ($severity) {
             case E_DEPRECATED:         return Raven_Client::WARN;
             case E_USER_DEPRECATED:    return Raven_Client::WARN;
+          }
         }
         return Raven_Client::ERROR;
     }


### PR DESCRIPTION
With PHP < 5.3.0, the use of [E_DEPRECATED](http://php.net/manual/errorfunc.constants.php#errorfunc.constants.errorlevels.e-deprecated-error) and [E_USER_DEPRECATED](http://php.net/manual/errorfunc.constants.php#errorfunc.constants.errorlevels.e-user-deprecated) in `lib/Raven/Client.php` [[1]](https://github.com/getsentry/raven-php/blob/6a4031ef13f93c456b1561fa0ca30d246e4b7ef7/lib/Raven/Client.php#L541) [[2]](https://github.com/getsentry/raven-php/blob/6a4031ef13f93c456b1561fa0ca30d246e4b7ef7/lib/Raven/Client.php#L542) could throw a PHP notice under certain circumstances.
