### PR TITLE
Caller frame unshifted context

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -135,9 +135,9 @@ class Raven_Client
      * Deprecated
      */
     public function message($message, $params=array(), $level=self::INFO,
-                            $stack=false)
+                            $stack=false, $vars = null)
     {
-        return $this->captureMessage($message, $params, $level, $stack);
+        return $this->captureMessage($message, $params, $level, $stack, $vars);
     }
 
     /**
@@ -152,7 +152,7 @@ class Raven_Client
      * Log a message to sentry
      */
     public function captureMessage($message, $params=array(), $level_or_options=array(),
-                            $stack=false)
+                            $stack=false, $vars = null)
     {
         // Gracefully handle messages which contain formatting characters, but were not
         // intended to be used with formatting.
@@ -178,13 +178,13 @@ class Raven_Client
             'params' => $params,
         );
 
-        return $this->capture($data, $stack);
+        return $this->capture($data, $stack, $vars);
     }
 
     /**
      * Log an exception to sentry
      */
-    public function captureException($exception, $culprit_or_options=null, $logger=null)
+    public function captureException($exception, $culprit_or_options=null, $logger=null, $vars=null)
     {
         if (in_array(get_class($exception), $this->exclude)) {
             return null;
@@ -235,7 +235,7 @@ class Raven_Client
 
         array_unshift($trace, $frame_where_exception_thrown);
 
-        return $this->capture($data, $trace);
+        return $this->capture($data, $trace, $vars);
     }
 
     /**
@@ -308,7 +308,7 @@ class Raven_Client
         return array();
     }
 
-    public function capture($data, $stack)
+    public function capture($data, $stack, $vars = null)
     {
         $event_id = $this->uuid4();
 
@@ -339,7 +339,7 @@ class Raven_Client
         if (!empty($stack)) {
             if (!isset($data['sentry.interfaces.Stacktrace'])) {
                 $data['sentry.interfaces.Stacktrace'] = array(
-                    'frames' => Raven_Stacktrace::get_stack_info($stack, $this->trace, $this->shift_vars),
+                    'frames' => Raven_Stacktrace::get_stack_info($stack, $this->trace, $this->shift_vars, $vars),
                 );
             }
         }

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -34,9 +34,9 @@ class Raven_ErrorHandler
         $this->client = $client;
     }
 
-    public function handleException($e, $isError = false)
+    public function handleException($e, $isError = false, $vars = null)
     {
-        $e->event_id = $this->client->getIdent($this->client->captureException($e));
+        $e->event_id = $this->client->getIdent($this->client->captureException($e, null, null, $vars));
 
         if (!$isError && $this->call_existing_exception_handler && $this->old_exception_handler) {
             call_user_func($this->old_exception_handler, $e);
@@ -49,7 +49,7 @@ class Raven_ErrorHandler
         if (!error_reporting()) { return; }
 
         $e = new ErrorException($message, 0, $code, $file, $line);
-        $this->handleException($e, true);
+        $this->handleException($e, true, $context);
 
         if ($this->call_existing_error_handler && $this->old_error_handler) {
             call_user_func($this->old_error_handler, $code, $message, $file, $line, $context);

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -13,7 +13,7 @@ class Raven_Stacktrace
         'require_once',
     );
 
-    public static function get_stack_info($frames, $trace=false, $shiftvars=true)
+    public static function get_stack_info($frames, $trace=false, $shiftvars=true, $errcontext = null)
     {
         /**
          * PHP's way of storing backstacks seems bass-ackwards to me
@@ -60,14 +60,19 @@ class Raven_Stacktrace
                 $module .= ':' . $nextframe['class'];
             }
 
-            if ($trace) {
-                if ($shiftvars) {
-                    $vars = self::get_frame_context($nextframe);
-                } else {
-                    $vars = self::get_caller_frame_context($frame);
-                }
+            if (empty($result) && isset($errcontext)) {
+                // If we've been given an error context that can be used as the vars for the first frame.
+                $vars = $errcontext;
             } else {
-                $vars = array();
+                if ($trace) {
+                    if ($shiftvars) {
+                        $vars = self::get_frame_context($nextframe);
+                    } else {
+                        $vars = self::get_caller_frame_context($frame);
+                    }
+                } else {
+                    $vars = array();
+                }
             }
 
             $result[] = array(

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -112,6 +112,94 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
 
     }
 
+    public function testShiftedCaptureVars()
+    {
+        $stack = array(
+            array(
+                "file" => dirname(__FILE__) . "/resources/a.php",
+                "line" => 11,
+                "function" => "a_test",
+                "args"=> array(
+                    "friend",
+                ),
+            ),
+            array(
+                "file" => dirname(__FILE__) . "/resources/b.php",
+                "line" => 3,
+                "args"=> array(
+                    "/tmp/a.php",
+                ),
+                "function" => "include_once",
+            ),
+        );
+
+        $vars = array(
+            "foo" => "bar",
+            "baz" => "zoom"
+        );
+
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, true, $vars);
+
+        $frame = $frames[0];
+        $this->assertEquals('b.php', $frame["module"]);
+        $this->assertEquals(3, $frame["lineno"]);
+        $this->assertNull($frame["function"]);
+        $this->assertEquals("include_once '/tmp/a.php';", $frame["context_line"]);
+        $this->assertEquals(array(), $frame['vars']);
+        $frame = $frames[1];
+        $this->assertEquals('a.php', $frame["module"]);
+        $this->assertEquals(11, $frame["lineno"]);
+        $this->assertEquals('include_once', $frame["function"]);
+        $this->assertEquals('a_test($foo);', $frame["context_line"]);
+        $this->assertEquals($vars, $frame['vars']);
+
+
+    }
+
+    public function testUnshiftedCaptureVars()
+    {
+        $stack = array(
+            array(
+                "file" => dirname(__FILE__) . "/resources/a.php",
+                "line" => 11,
+                "function" => "a_test",
+                "args"=> array(
+                    "friend",
+                ),
+            ),
+            array(
+                "file" => dirname(__FILE__) . "/resources/b.php",
+                "line" => 3,
+                "args"=> array(
+                    "/tmp/a.php",
+                ),
+                "function" => "include_once",
+            ),
+        );
+
+        $vars = array(
+            "foo" => "bar",
+            "baz" => "zoom"
+        );
+
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, false, $vars);
+
+        $frame = $frames[0];
+        $this->assertEquals('b.php', $frame["module"]);
+        $this->assertEquals(3, $frame["lineno"]);
+        $this->assertNull($frame["function"]);
+        $this->assertEquals(array('param1' => '/tmp/a.php'), $frame['vars']);
+        $this->assertEquals("include_once '/tmp/a.php';", $frame["context_line"]);
+        $frame = $frames[1];
+        $this->assertEquals('a.php', $frame["module"]);
+        $this->assertEquals(11, $frame["lineno"]);
+        $this->assertEquals('include_once', $frame["function"]);
+        $this->assertEquals($vars, $frame['vars']);
+        $this->assertEquals('a_test($foo);', $frame["context_line"]);
+
+
+    }
+
     public function testDoesFixFrameInfo()
     {
         /**


### PR DESCRIPTION
Added the ability to show calling vars (as param1, param2, etc), rather than trying to shift them to look like local scope.
Added the ability to pass in a set of variables to use for the local scope of the top stack frame. This allows the PHP error handler's $errcontext to be passed in, giving us the local variables for the one stack frame that PHP does provide them for.
