### PR TITLE
Fixed issues with static methods.

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -134,6 +134,8 @@ class Raven_Stacktrace
         if (isset($frame['class'])) {
             if (method_exists($frame['class'], $frame['function'])) {
                 $reflection = new ReflectionMethod($frame['class'], $frame['function']);
+            } elseif ($frame['type'] === '::') {
+                $reflection = new ReflectionMethod($frame['class'], '__callStatic');
             } else {
                 $reflection = new ReflectionMethod($frame['class'], '__call');
             }


### PR DESCRIPTION
`Stacktrace::get_frame_context()` assumes that if the method doesn't exist it's available through `__call`. However, if it's a static method it won't find it (and throw a `ReflectionException`). I fixed this by checking if `$frame['type']` is `::` and, if that's the case, it calls `__callStatic` instead.
