### PR TITLE
Use CURLOPT_TIMEOUT, CURLOPT_CONNECTTIMEOUT instead of same *_MS functions.

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -433,8 +433,8 @@ class Raven_Client
         curl_setopt($curl, CURLOPT_VERBOSE, false);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, $this->timeout * 1000);
-        curl_setopt($curl, CURLOPT_TIMEOUT_MS, $this->timeout * 1000);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->timeout);
+        curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
         $ret = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $success = ($code == 200);


### PR DESCRIPTION
The __MS (milliseconds) functions were introduced in cURL 7.16.2. but a lot of Linux distros still use cURL 7.15._. In order to make this work on e.g. CentOS, use the options without _MS. They are not needed since the number is anyways multiplied with 1000.
