### PR TITLE
Added public method to set user data

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -601,11 +601,10 @@ class Raven_Client
         $this->severity_map = $map;
     }
 
-    public function set_user_data($is_authenticated, $id=null, $data=null) {
-        $this->user = array(
-            "is_authenticated" => $is_authenticated,
-            "id"               => $id,
-            "data"             => $data
-        );
+    public function set_user_data($id, $email=null, $data=array()) {
+        $this->user = array_merge(array(
+            "id"    => $id,
+            "email" => $email
+        ), $data);
     }
 }


### PR DESCRIPTION
Added a public method to set user data. In cases where people are using a custom session implementation the default data is not very useful.

If data is not set it fall backs to standard user information set.
