### PR TITLE
Allow overriding of default parameters with custom values

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -330,7 +330,7 @@ class Raven_Client
         if (!isset($data['timestamp'])) $data['timestamp'] = gmdate('Y-m-d\TH:i:s\Z');
         if (!isset($data['level'])) $data['level'] = self::ERROR;
 
-        $data = array_merge($data, $this->get_default_data());
+        $data = array_merge($this->get_default_data(), $data);
         $data['event_id'] = $event_id;
 
         if ($this->is_http_request()) {


### PR DESCRIPTION
A change in array merging order enables us to optionally override the default, http and user data in user land without having to subclass the Raven_Client class.
