### PR TITLE
Avoid double declaration of the contant RAVEN_CLIENT_END_REACHED

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -104,6 +104,8 @@ class Raven_ErrorHandler
     }
     
     public function detectShutdown() {
-        @define('RAVEN_CLIENT_END_REACHED', true);
+        if (!defined('RAVEN_CLIENT_END_REACHED')) {
+            define('RAVEN_CLIENT_END_REACHED', true);
+        }
     }
 }


### PR DESCRIPTION
Warning suppression is not a good pratice (for perf and debug reasons).

Alternative to fa7158134f262d99e919e908503a44046fd9224e
