### PR TITLE
fixed client when the Raven URL is null

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -406,6 +406,10 @@ class Raven_Client
 
     public function send($data)
     {
+        if (!$this->servers) {
+            return;
+        }
+
         $message = Raven_Compat::json_encode($data);
         
         if (function_exists("gzcompress")) {


### PR DESCRIPTION
In the protocol, it is specified that the Raven URL can be null to disable the client. But that does not work well as the send() method relies on getting an array line 419.

To avoid a PHP notice, I've added a check to just return if the servers array is not configured.
