### PR TITLE
Proper register autoloder in static class method

### DIFF
--- a/lib/Raven/Autoloader.php
+++ b/lib/Raven/Autoloader.php
@@ -22,15 +22,13 @@ class Raven_Autoloader
     public static function register()
     {
         ini_set('unserialize_callback_func', 'spl_autoload_call');
-        spl_autoload_register(array(new self, 'autoload'));
+        spl_autoload_register(array('Raven_Autoloader', 'autoload'));
     }
 
     /**
      * Handles autoloading of classes.
      *
      * @param string $class A class name.
-     *
-     * @return boolean Returns true if the class has been loaded
      */
     public static function autoload($class)
     {


### PR DESCRIPTION
callable to static method fixed (http://php.net/manual/ru/language.types.callable.php)
removed wrong phpdoc
