### PR TITLE
fixed composer.json version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "A PHP client for Sentry (http://getsentry.com)",
     "keywords": ["log", "logging"],
     "homepage": "http://getsentry.com",
-    "version": "0.6.0",
     "license": "BSD",
     "authors": [
         {
@@ -24,6 +23,11 @@
     "autoload": {
         "psr-0" : {
             "Raven_" : "lib/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.6.x-dev"
         }
     }
 }


### PR DESCRIPTION
The version in `composer.json` was not in sync with the version declared with `Raven_Client::VERSION` (0.6.0 vs 0.6.1).

Anyway, one of the best practice when using Composer is to avoid setting a version in the `composer.json` file, and add a `branch-alias` instead. That way, Packagist can automatically create a dev version for master and automatically get the real version from the tags.
