### PR TITLE
Lower timeouts to Sentry server and give ability to do millisecond level timeouts.

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -476,8 +476,8 @@ class Raven_Client
         curl_setopt($curl, CURLOPT_VERBOSE, false);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->timeout);
-        curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT_MS, $this->timeout * 1E3);
+        curl_setopt($curl, CURLOPT_TIMEOUT_MS, $this->timeout * 1E3);
         $ret = curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $success = ($code == 200);


### PR DESCRIPTION
Lowering the default timeout from 5 secs to 2 secs when connecting to sentry server.
I'm setting my app to have a timeout of 0.6 seconds.
