### PR TITLE
Remove error_reporting check from handleError

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -29,7 +29,7 @@ class Raven_ErrorHandler
     private $call_existing_error_handler = false;
     private $reservedMemory;
     private $send_errors_last = false;
-    private $error_types = E_ALL;
+    private $error_types = -1;
 
     public function __construct($client, $send_errors_last = false)
     {
@@ -90,7 +90,7 @@ class Raven_ErrorHandler
 
     public function registerErrorHandler($call_existing_error_handler = true, $error_types = null)
     {
-        $this->error_types = (null === $error_types) ? E_ALL | E_STRICT : $error_types;
+        $this->error_types = (null === $error_types) ? error_reporting() : $error_types;
         $this->old_error_handler = set_error_handler(array($this, 'handleError'));
         $this->call_existing_error_handler = $call_existing_error_handler;
     }


### PR DESCRIPTION
Since d327d143704c834151b441a2476018d2ca0e8670, I can't get warning to be sent to sentry.

The **error_reporting** config should not be used to filter which error are reported to sentry. This config is only for errors handled by PHP (displayed and logged). 

The error level must be configured as 2nd parameter of `registerErrorHandler`.

@m8rge What is the use case for your commit?
