### PR TITLE
Validate error_reporting to hide silented errors

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -53,7 +53,7 @@ class Raven_ErrorHandler
 
     public function handleError($code, $message, $file = '', $line = 0, $context=array())
     {
-        if ($this->error_types & $code) {
+        if ($this->error_types & $code & error_reporting()) {
           $e = new ErrorException($message, 0, $code, $file, $line);
           $this->handleException($e, true, $context);
         }
@@ -88,9 +88,9 @@ class Raven_ErrorHandler
         $this->call_existing_exception_handler = $call_existing_exception_handler;
     }
 
-    public function registerErrorHandler($call_existing_error_handler = true, $error_types = null)
+    public function registerErrorHandler($call_existing_error_handler = true, $error_types = -1)
     {
-        $this->error_types = (null === $error_types) ? error_reporting() : $error_types;
+        $this->error_types = $error_types;
         $this->old_error_handler = set_error_handler(array($this, 'handleError'));
         $this->call_existing_error_handler = $call_existing_error_handler;
     }

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -11,6 +11,18 @@
 
 class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
 {
+    private $errorLevel;
+
+    public function setUp()
+    {
+        $this->errorLevel = error_reporting();
+    }
+
+    public function tearDown()
+    {
+        error_reporting($this->errorLevel);
+    }
+
     public function testErrorsAreLoggedAsExceptions()
     {
         $client = $this->getMock('Client', array('captureException', 'getIdent'));
@@ -33,5 +45,43 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
 
         $handler = new Raven_ErrorHandler($client);
         $handler->handleException($e);
+    }
+
+    public function testErrorHandlerCheckSilentReporting()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
+        @trigger_error('Silent', E_USER_WARNING);
+    }
+
+    public function testErrorHandlerBlockErrorReporting()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->never())
+               ->method('captureException');
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
+        error_reporting(E_USER_ERROR);
+        trigger_error('Warning', E_USER_WARNING);
+    }
+
+    public function testErrorHandlerPassErrorReportingPass()
+    {
+        $client = $this->getMock('Client', array('captureException', 'getIdent'));
+        $client->expects($this->once())
+               ->method('captureException');
+
+        $handler = new Raven_ErrorHandler($client);
+        $handler->registerErrorHandler(false);
+
+        error_reporting(E_USER_WARNING);
+        trigger_error('Warning', E_USER_WARNING);
     }
 }


### PR DESCRIPTION
After pushing #118 on production, I realized that silenced errors are reported to Sentry. This is because the '@' modifier internally modify the value of `error_reporting`.

I've added `error_reporting()` check in `handleError()` (reverting to the behavior of #104 of @m8rge).

With this code, errors will be sent to Sentry only if:
1. The error code matches `error_reporting()`
2. And the error code matches `$error_types` set in `registerErrorHandler()`. (-1 = 1111111111... is all by default).
