### PR TITLE
Allow extra data in client constructor.

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -27,6 +27,7 @@ class Raven_Client
     const FATAL = 'fatal';
 
     var $severity_map;
+    var $extra_data;
 
     var $store_errors_for_bulk_send = false;
 
@@ -61,6 +62,7 @@ class Raven_Client
         $this->severity_map = NULL;
         $this->shift_vars = (bool) Raven_Util::get($options, 'shift_vars', true);
         $this->http_proxy = Raven_Util::get($options, 'http_proxy');
+        $this->extra_data = Raven_Util::get($options, 'extra', array());
 
         $this->processors = array();
         foreach (Raven_util::get($options, 'processors', self::getDefaultProcessors()) as $processor) {
@@ -325,7 +327,7 @@ class Raven_Client
 
     protected function get_extra_data()
     {
-        return array();
+        return $this->extra_data;
     }
 
     public function get_default_data()

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -179,6 +179,17 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->site, 'foo');
     }
 
+    public function testOptionsExtraData()
+    {
+        $client = new Dummy_Raven_Client(array('extra' => array('foo' => 'bar')));
+
+        $client->captureMessage('Test Message %s', array('foo'));
+        $events = $client->getSentEvents();
+        $this->assertEquals(count($events), 1);
+        $event = array_pop($events);
+        $this->assertEquals($event['extra']['foo'], 'bar');
+    }
+
     public function testCaptureMessageDoesHandleUninterpolatedMessage()
     {
         $client = new Dummy_Raven_Client();


### PR DESCRIPTION
This PR allows a user to pass 'extra' data to the `Raven_Client` constructor that will be recorded with every event.

My use case for this is events from command-line PHP scripts, which share an error handling system with web-facing code. The command-line events currently do not have any environment information recorded with them. This PR allows me to conditionally add the `$_SERVER` variable to the 'extra' information if the PHP SAPI is 'cli'.
