### PR TITLE
Verify peers on SSL connections

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -501,7 +501,7 @@ class Raven_Client
         curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
         curl_setopt($curl, CURLOPT_VERBOSE, false);
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
         if ($this->http_proxy) {
             curl_setopt($curl, CURLOPT_PROXY, $this->http_proxy);
         }


### PR DESCRIPTION
Given the amount and nature of data you send, it's not really OK to make it easy to MITM the system.

If you're aware that people use self signed certs, it should be a config key, with a sane default.
