### PR TITLE
Respect error_reporting() when registering error handler.

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -91,7 +91,7 @@ class Raven_ErrorHandler
     public function registerErrorHandler($call_existing_error_handler = true, $error_types = -1)
     {
         $this->error_types = $error_types;
-        $this->old_error_handler = set_error_handler(array($this, 'handleError'));
+        $this->old_error_handler = set_error_handler(array($this, 'handleError'), error_reporting());
         $this->call_existing_error_handler = $call_existing_error_handler;
     }
 


### PR DESCRIPTION
Setting an error handler without error types makes it catch every error (set_error_handler() default to E_ALL | E_STRICT).
Even with a declaration of $error_types on registerErrorHandler(), handleError() would pass errors previously not reported to the old error handler, causing unexpected results.
