### PR TITLE
updated branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.7.x-dev"
+            "dev-master": "0.8.x-dev"
         }
     }
 }


### PR DESCRIPTION
Since the release of 0.8.0, the master branch represents the current 0.8 instead of the now-legacy 0.7.
