### PR TITLE
Runtime created function

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -193,6 +193,16 @@ class Raven_Stacktrace
             $frame['lineno'] = $lineno = $matches[2];
         }
 
+        // In the case of an anonymous function, the filename is sent as:
+        // "</path/to/filename>(<lineno>) : runtime-created function"
+        // Extract the correct filename + linenumber from the string.
+        $matches = array();
+        $matched = preg_match("/^(.*?)\((\d+)\) : runtime-created function$/",
+            $filename, $matches);
+        if ($matched) {
+            $frame['filename'] = $filename = $matches[1];
+            $frame['lineno'] = $lineno = $matches[2];
+        }
 
         try {
             $file = new SplFileObject($filename);


### PR DESCRIPTION
Using PHP 5.2.17, we hit the case when exceptions occurred in runtime created functions.
We had to slightly modify Stacktrace.php to handle this case.
