### PR TITLE
Expose curl error message

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -71,7 +71,6 @@ class Raven_Client
         }
 
         $this->_lasterror = null;
-        $this->_lasterror_message = null;
         $this->_user = null;
         $this->context = new Raven_Context();
     }
@@ -126,11 +125,6 @@ class Raven_Client
     public function getLastError()
     {
         return $this->_lasterror;
-    }
-
-    public function getLastErrorMessage()
-    {
-        return $this->_lasterror_message;
     }
 
     /**
@@ -528,16 +522,14 @@ class Raven_Client
             curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $timeout);
             curl_setopt($curl, CURLOPT_TIMEOUT, $timeout);
         }
-        $ret = curl_exec($curl);
+        curl_exec($curl);
         $code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $success = ($code == 200);
         if (!$success) {
             // It'd be nice just to raise an exception here, but it's not very PHP-like
-            $this->_lasterror = $ret;
-            $this->_lasterror_message = curl_error($curl);
+            $this->_lasterror = curl_error($curl);
         } else {
             $this->_lasterror = null;
-            $this->_lasterror_message = null;
         }
         curl_close($curl);
 


### PR DESCRIPTION
## Why

In case of error `getLastError()` contains the return of `curl_exec`, which always returns `false` on failure. This make failures hard to diagnose without modifying `Raven_Client`. We added `getLastErrorMessage()`, and it proved useful while integrating our system with Sentry, so we think it might be worth adding it to the standard library.
## Could we re-use `getLastError()`?

I think it would make sense for `getLastError()` to return the actual error. The problem with that is that it changes the interface. Right now `$client->getLastError() === false` is the only way to check if an error happened, but if we change it to return the error message then it will suddenly evaluate to `false` when an error happened.

No idea if people are actually using `getLastError()`, but I opted for adding a new method to maintain backward compatibility.
