### PR TITLE
invert arguments in some assertEquals() calls

### DIFF
--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -429,7 +429,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         );
 
         $client = new Dummy_Raven_Client();
-        $this->assertEquals($client->get_http_data(), $expected);
+        $this->assertEquals($expected, $client->get_http_data());
     }
 
     public function testGetUserDataWithSetUser() {
@@ -452,7 +452,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $this->assertEquals($client->get_user_data(), $expected);
+        $this->assertEquals($expected, $client->get_user_data());
     }
 
     public function testGetUserDataWithNoUser() {
@@ -463,7 +463,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
                 'id' => session_id(),
             )
         );
-        $this->assertEquals($client->get_user_data(), $expected);
+        $this->assertEquals($expected, $client->get_user_data());
     }
 
     public function testGetAuthHeader() {
@@ -475,7 +475,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $expected = "Sentry sentry_timestamp={$timestamp}, sentry_client={$clientstring}, " .
                     "sentry_version=4, sentry_key=publickey, sentry_secret=secretkey";
 
-        $this->assertEquals($client->get_auth_header($timestamp, 'raven-php/test', 'publickey', 'secretkey'), $expected);
+        $this->assertEquals($expected, $client->get_auth_header($timestamp, 'raven-php/test', 'publickey', 'secretkey'));
     }
 
     public function testCaptureMessageWithUserContext()
@@ -486,11 +486,11 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['sentry.interfaces.User'], array(
+        $this->assertEquals(array(
             'email' => 'foo@example.com',
-        ));
+        ), $event['sentry.interfaces.User']);
     }
 
     public function testCaptureMessageWithTagsContext()
@@ -503,12 +503,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['tags'], array(
+        $this->assertEquals(array(
             'foo' => 'bar',
             'biz' => 'baz',
-        ));
+        ), $event['tags']);
     }
 
     public function testCaptureMessageWithExtraContext()
@@ -521,21 +521,21 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['extra'], array(
+        $this->assertEquals(array(
             'foo' => 'bar',
             'biz' => 'baz',
-        ));
+        ), $event['extra']);
     }
 
     public function cb1($data) {
-        $this->assertEquals($data['message'], 'test');
+        $this->assertEquals('test', $data['message']);
         return false;
     }
 
     public function cb2($data) {
-        $this->assertEquals($data['message'], 'test');
+        $this->assertEquals('test', $data['message']);
         return true;
     }
 
@@ -545,12 +545,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb1')));
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 0);
+        $this->assertEquals(0, count($events));
 
         $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb2')));
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
     }
 }
 

--- a/test/Raven/Tests/CompatTest.php
+++ b/test/Raven/Tests/CompatTest.php
@@ -20,18 +20,18 @@ class Raven_Tests_CompatTest extends PHPUnit_Framework_TestCase
     public function test_hash_hmac()
     {
         $result = Raven_Compat::hash_hmac('sha1', 'foo', 'bar');
-        $this->assertEquals($result, '85d155c55ed286a300bd1cf124de08d87e914f3a');
+        $this->assertEquals('85d155c55ed286a300bd1cf124de08d87e914f3a', $result);
 
         $result = Raven_Compat::_hash_hmac('sha1', 'foo', 'bar');
-        $this->assertEquals($result, '85d155c55ed286a300bd1cf124de08d87e914f3a');
+        $this->assertEquals('85d155c55ed286a300bd1cf124de08d87e914f3a', $result);
     }
 
     public function test_json_encode()
     {
         $result = Raven_Compat::json_encode(array('foo' => array('bar' => 1)));
-        $this->assertEquals($result, '{"foo":{"bar":1}}');
+        $this->assertEquals('{"foo":{"bar":1}}', $result);
 
         $result = Raven_Compat::_json_encode(array('foo' => array('bar' => 1)));
-        $this->assertEquals($result, '{"foo":{"bar":1}}');
+        $this->assertEquals('{"foo":{"bar":1}}', $result);
     }
 }

--- a/test/Raven/Tests/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/SanitizeDataProcessorTest.php
@@ -32,11 +32,11 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
 
         $vars = $data['sentry.interfaces.Http']['data'];
         $this->assertEquals($vars['foo'], 'bar');
-        $this->assertEquals($vars['password'], Raven_SanitizeDataProcessor::$mask);
-        $this->assertEquals($vars['the_secret'], Raven_SanitizeDataProcessor::$mask);
-        $this->assertEquals($vars['a_password_here'], Raven_SanitizeDataProcessor::$mask);
-        $this->assertEquals($vars['mypasswd'], Raven_SanitizeDataProcessor::$mask);
-        $this->assertEquals($vars['authorization'], Raven_SanitizeDataProcessor::$mask);
+        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['password']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['the_secret']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['a_password_here']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['mypasswd']);
+        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $vars['authorization']);
     }
 
     public function testDoesFilterCreditCard()
@@ -49,6 +49,6 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $processor = new Raven_SanitizeDataProcessor($client);
         $processor->process($data);
 
-        $this->assertEquals($data['ccnumba'], Raven_SanitizeDataProcessor::$mask);
+        $this->assertEquals(Raven_SanitizeDataProcessor::$mask, $data['ccnumba']);
     }
 }

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -20,14 +20,14 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
     {
         $input = array(1, 2, 3);
         $result = Raven_Serializer::serialize($input);
-        $this->assertEquals($result, array('1', '2', '3'));
+        $this->assertEquals(array('1', '2', '3'), $result);
     }
 
     public function testObjectsAreStrings()
     {
         $input = new Raven_StacktraceTestObject();
         $result = Raven_Serializer::serialize($input);
-        $this->assertEquals($result, 'Object Raven_StacktraceTestObject');
+        $this->assertEquals('Object Raven_StacktraceTestObject', $result);
     }
 
     public function testIntsAreInts()
@@ -35,7 +35,7 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
         $input = 1;
         $result = Raven_Serializer::serialize($input);
         $this->assertTrue(is_integer($result));
-        $this->assertEquals($result, 1);
+        $this->assertEquals(1, $result);
     }
 
     public function testRecursionMaxDepth()
@@ -43,7 +43,7 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
         $input = array();
         $input[] = &$input;
         $result = Raven_Serializer::serialize($input, 3);
-        $this->assertEquals($result, array(array(array('Array of length 1'))));
+        $this->assertEquals(array(array(array('Array of length 1'))), $result);
     }
 
 }

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -213,19 +213,19 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
         // just grab the last few frames
         $frames = array_slice($frames, -5);
         $frame = $frames[0];
-        $this->assertEquals($frame['module'], 'StacktraceTest.php:Raven_Tests_StacktraceTest');
-        $this->assertEquals($frame['function'], 'testDoesFixFrameInfo');
+        $this->assertEquals('StacktraceTest.php:Raven_Tests_StacktraceTest', $frame['module']);
+        $this->assertEquals('testDoesFixFrameInfo', $frame['function']);
         $frame = $frames[1];
-        $this->assertEquals($frame['module'], 'StacktraceTest.php');
-        $this->assertEquals($frame['function'], 'raven_test_create_stacktrace');
+        $this->assertEquals('StacktraceTest.php', $frame['module']);
+        $this->assertEquals('raven_test_create_stacktrace', $frame['function']);
         $frame = $frames[2];
-        $this->assertEquals($frame['module'], 'StacktraceTest.php');
-        $this->assertEquals($frame['function'], 'raven_test_recurse');
+        $this->assertEquals('StacktraceTest.php', $frame['module']);
+        $this->assertEquals('raven_test_recurse', $frame['function']);
         $frame = $frames[3];
-        $this->assertEquals($frame['module'], 'StacktraceTest.php');
-        $this->assertEquals($frame['function'], 'raven_test_recurse');
+        $this->assertEquals('StacktraceTest.php', $frame['module']);
+        $this->assertEquals('raven_test_recurse', $frame['function']);
         $frame = $frames[4];
-        $this->assertEquals($frame['module'], 'StacktraceTest.php');
-        $this->assertEquals($frame['function'], 'raven_test_recurse');
+        $this->assertEquals('StacktraceTest.php', $frame['module']);
+        $this->assertEquals('raven_test_recurse', $frame['function']);
     }
 }

--- a/test/Raven/Tests/UtilTest.php
+++ b/test/Raven/Tests/UtilTest.php
@@ -20,13 +20,13 @@ class Raven_Tests_UtilTest extends PHPUnit_Framework_TestCase
     {
         $input = array('foo' => 'bar');
         $result = Raven_Util::get($input, 'baz', 'foo');
-        $this->assertEquals($result, 'foo');
+        $this->assertEquals('foo', $result);
     }
 
     public function testGetReturnsPresentValuesEvenWhenEmpty()
     {
         $input = array('foo' => '');
         $result = Raven_Util::get($input, 'foo', 'bar');
-        $this->assertEquals($result, '');
+        $this->assertEquals('', $result);
     }
 }


### PR DESCRIPTION
The first argument should always be the expected result, not the actual
data.
