### PR TITLE
Check for Object in Stacktrace

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -163,7 +163,7 @@ class Raven_Stacktrace
                 // Assign the argument by the parameter name
                 if (is_array($arg)) {
                   foreach ($arg as $key => $value) {
-                    if (!is_array($value)) {
+                    if (!is_array($value) and ! is_object($value)) {
                       $arg[$key] = substr($value, 0, 1024);
                     }
                   }


### PR DESCRIPTION
Stacktrace is only checking for an array, not objects. It will still try to substr objects.
