### PR TITLE
only run substr() on strings in Stacktrace.php

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -163,7 +163,7 @@ class Raven_Stacktrace
                 // Assign the argument by the parameter name
                 if (is_array($arg)) {
                   foreach ($arg as $key => $value) {
-                    if (!is_array($value) and ! is_object($value)) {
+                    if (is_string($value)) {
                       $arg[$key] = substr($value, 0, 1024);
                     }
                   }


### PR DESCRIPTION
can only do substr() on strings, so let's not try otherwise. (Was getting an issue where with a Guzzle exception the $value was showing up as a resource. It is working with this change)
