### PR TITLE
add is_numeric check to substr()

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -163,7 +163,7 @@ class Raven_Stacktrace
                 // Assign the argument by the parameter name
                 if (is_array($arg)) {
                   foreach ($arg as $key => $value) {
-                    if (is_string($value)) {
+                    if (is_string($value) || is_numeric($value)) {
                       $arg[$key] = substr($value, 0, 1024);
                     }
                   }


### PR DESCRIPTION
add is_numeric since those can be implicitly converted to strings
