### PR TITLE
Fix Raven_Tests_ClientTest::testGetAuthHeader

### DIFF
--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -509,7 +509,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $timestamp = '1234341324.340000';
 
         $expected = "Sentry sentry_timestamp={$timestamp}, sentry_client={$clientstring}, " .
-                    "sentry_version=4, sentry_key=publickey, sentry_secret=secretkey";
+                    "sentry_version=" . Dummy_Raven_Client::PROTOCOL . ", " .
+                    "sentry_key=publickey, sentry_secret=secretkey";
 
         $this->assertEquals($expected, $client->get_auth_header($timestamp, 'raven-php/test', 'publickey', 'secretkey'));
     }


### PR DESCRIPTION
```
$ phpunit
PHPUnit 3.7.34 by Sebastian Bergmann.

Configuration read from /projects/raven-php/phpunit.xml.dist

................................F............I.............

Time: 203 ms, Memory: 6.00Mb

There was 1 failure:

1) Raven_Tests_ClientTest::testGetAuthHeader
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Sentry sentry_timestamp=1234341324.340000, sentry_client=raven-php/test, sentry_version=4, sentry_key=publickey, sentry_secret=secretkey'
+'Sentry sentry_timestamp=1234341324.340000, sentry_client=raven-php/test, sentry_version=5, sentry_key=publickey, sentry_secret=secretkey'

/projects/raven-php/test/Raven/Tests/ClientTest.php:514
/usr/bin/phpunit:46

FAILURES!
Tests: 59, Assertions: 160, Failures: 1, Incomplete: 1.
```
