### PR TITLE
Reduce message size (again)

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -380,6 +380,10 @@ class Raven_Client
         if (!isset($data['extra'])) $data['extra'] = array();
         if (!isset($data['event_id'])) $data['event_id'] = $this->uuid4();
 
+        if (isset($data['message'])) {
+            $data['message'] = substr($data['message'], 0, 1024);
+        }
+
         $data = array_merge($this->get_default_data(), $data);
 
         if ($this->is_http_request()) {

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -88,6 +88,11 @@ class Raven_Stacktrace
             // dont set this as an empty array as PHP will treat it as a numeric array
             // instead of a mapping which goes against the defined Sentry spec
             if (!empty($vars)) {
+                foreach ($vars as $key => $value) {
+                    if (is_string($value) || is_numeric($value)) {
+                        $vars[$key] = substr($value, 0, 1024);
+                    }
+                }
                 $frame['vars'] = $vars;
             }
 


### PR DESCRIPTION
Following #139.

We still got some case where the message is really big (a case with an XML exception on a big XML) and it fails to send data using udp because of the message size
