### PR TITLE
Fix level detection in Raven_Client::captureException()

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -218,7 +218,7 @@ class Raven_Client
             $message = '<unknown exception>';
         }
 
-		$exc = $exception;
+        $exc = $exception;
         do {
             $exc_data = array(
                 'value' => $exc->getMessage(),

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -320,30 +320,30 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
     }
 
-	public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug() {
-		if (version_compare(PHP_VERSION, '5.3.0', '<')) {
-			$this->markTestSkipped('PHP 5.3 required for chained exceptions.');
-		}
+    public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug() {
+        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+            $this->markTestSkipped('PHP 5.3 required for chained exceptions.');
+        }
 
-		$client = new Dummy_Raven_Client();
-		$e1 = new ErrorException('First', 0, E_DEPRECATED);
-		$e2 = new ErrorException('Second', 0, E_NOTICE, __FILE__, __LINE__, $e1);
-		$e3 = new ErrorException('Third', 0, E_ERROR, __FILE__, __LINE__, $e2);
+        $client = new Dummy_Raven_Client();
+        $e1 = new ErrorException('First', 0, E_DEPRECATED);
+        $e2 = new ErrorException('Second', 0, E_NOTICE, __FILE__, __LINE__, $e1);
+        $e3 = new ErrorException('Third', 0, E_ERROR, __FILE__, __LINE__, $e2);
 
-		$client->captureException($e1);
-		$client->captureException($e2);
-		$client->captureException($e3);
-		$events = $client->getSentEvents();
+        $client->captureException($e1);
+        $client->captureException($e2);
+        $client->captureException($e3);
+        $events = $client->getSentEvents();
 
-		$event = array_pop($events);
-		$this->assertEquals($event['level'], Dummy_Raven_Client::ERROR);
+        $event = array_pop($events);
+        $this->assertEquals($event['level'], Dummy_Raven_Client::ERROR);
 
-		$event = array_pop($events);
-		$this->assertEquals($event['level'], Dummy_Raven_Client::INFO);
+        $event = array_pop($events);
+        $this->assertEquals($event['level'], Dummy_Raven_Client::INFO);
 
-		$event = array_pop($events);
-		$this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
-	}
+        $event = array_pop($events);
+        $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
+    }
 
     public function testCaptureExceptionHandlesOptionsAsSecondArg()
     {


### PR DESCRIPTION
Since PHP 5.3, no matter what exception severity parameter was set (e.g. in error handler), Sentry always received event with `level => 'error'`.

Variable `$exception` is always set to `NULL` in order to end the while loop, resulting in `method_exists()` to never pass.
