### PR TITLE
Changed private get_curl_options to protected

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -524,7 +524,7 @@ class Raven_Client
         return true;
     }
 
-    private function get_curl_options(){
+    protected function get_curl_options(){
         $options = array(
             CURLOPT_VERBOSE => false,
             CURLOPT_SSL_VERIFYHOST => 2,


### PR DESCRIPTION
Changed get_curl_options from a private to protected method to allow extension of the current options.
