### PR TITLE
Provide a more helpful default for exceptions without messages

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -216,7 +216,7 @@ class Raven_Client
         // TODO(dcramer): DRY this up
         $message = $exception->getMessage();
         if (empty($message)) {
-            $message = '<unknown exception>';
+            $message = get_class($exception);
         }
 
         $exc = $exception;


### PR DESCRIPTION
It bugged me that Sentry is showing `<unknown exception>` and panics
me when it fact it was just a ResourceNotFoundException in Symfony.
Having the class name directly visible is more helpful.
