### PR TITLE
message_limit option added to allow adjust message size.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,10 +187,17 @@ Caveats:
 - The option is only currently used within the synchronous curl transport.
 
 ``curl_ssl_version``
-~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 The SSL version (2 or 3) to use.
 By default PHP will try to determine this itself, although in some cases this must be set manually.
+
+``message_limit``
+~~~~~~~~~~~~~~~~~
+
+Defaults to 1024 characters.
+
+This value is used to truncate message and frame variables. However it is not guarantee that length of whole message will be restricted by this value.
 
 
 Providing Request Context

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -13,7 +13,8 @@ class Raven_Stacktrace
         'require_once',
     );
 
-    public static function get_stack_info($frames, $trace=false, $shiftvars=true, $errcontext = null)
+    public static function get_stack_info($frames, $trace = false, $shiftvars = true, $errcontext = null,
+                            $frame_var_limit = Raven_Client::MESSAGE_LIMIT)
     {
         /**
          * PHP's way of storing backstacks seems bass-ackwards to me
@@ -66,7 +67,7 @@ class Raven_Stacktrace
             } else {
                 if ($trace) {
                     if ($shiftvars) {
-                        $vars = self::get_frame_context($nextframe);
+                        $vars = self::get_frame_context($nextframe, $frame_var_limit);
                     } else {
                         $vars = self::get_caller_frame_context($frame);
                     }
@@ -90,7 +91,7 @@ class Raven_Stacktrace
             if (!empty($vars)) {
                 foreach ($vars as $key => $value) {
                     if (is_string($value) || is_numeric($value)) {
-                        $vars[$key] = substr($value, 0, 1024);
+                        $vars[$key] = substr($value, 0, $frame_var_limit);
                     }
                 }
                 $frame['vars'] = $vars;
@@ -118,7 +119,7 @@ class Raven_Stacktrace
 
     }
 
-    public static function get_frame_context($frame)
+    public static function get_frame_context($frame, $frame_arg_limit = Raven_Client::MESSAGE_LIMIT)
     {
         // The reflection API seems more appropriate if we associate it with the frame
         // where the function is actually called (since we're treating them as function context)
@@ -169,7 +170,7 @@ class Raven_Stacktrace
                 if (is_array($arg)) {
                   foreach ($arg as $key => $value) {
                     if (is_string($value) || is_numeric($value)) {
-                      $arg[$key] = substr($value, 0, 1024);
+                      $arg[$key] = substr($value, 0, $frame_arg_limit);
                     }
                   }
                 }
@@ -184,7 +185,7 @@ class Raven_Stacktrace
         return $args;
     }
 
-    private static function read_source_file($filename, $lineno, $context_lines=5)
+    private static function read_source_file($filename, $lineno, $context_lines = 5)
     {
         $frame = array(
             'prefix' => array(),


### PR DESCRIPTION
I noticed that you use "magic" constants to restrict message size and from time to time you decrease them.
https://github.com/getsentry/raven-php/pull/139/files
https://github.com/getsentry/raven-php/pull/160/files
As I understand it is almost impossible (or very hard) to intelligently restrict message size without using of hardcoded constants. Problem goes from complexity of data and usage of such functions like `Raven_Compat::json_encode`, `gzcompress` and `base64_encode` etc.
As I understand main restriction of message size goes from UDP. Probably 1024 is still too much and you will need to decrease this value again. However HTTP POST allows rather large amount of data. Since I usually use HTTP and verbose error messages, I would like to have messages with more than 1024 characters in Sentry. This pull request introduces `message_limit` option, which allows to developer to set his own value for limit. However as before it does not guarantee length of whole message.

Please review changes and let me know whether need to fix something.

I personally don't like such calls:

```
Raven_Stacktrace::get_stack_info($trace, $this->trace, $this->shift_vars, $vars, $this->message_limit);
```

may be it makes sense to use whole `$this` object as parameter, however it will cause notable changes in method and it will be needed to rewrite some unit tests.
