### PR TITLE
Increase exec timeout.

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -650,7 +650,7 @@ class Raven_Client
         }
         $cmd .= '-d \''. $data .'\' ';
         $cmd .= '\''. $url .'\' ';
-        $cmd .= '-m 5 ';  // 5 second timeout for the whole process (connect + send)
+        $cmd .= '-m 10 ';  // 10 second timeout for the whole process (connect + send)
         $cmd .= '> /dev/null 2>&1 &'; // ensure exec returns immediately while curl runs in the background
 
         exec($cmd);


### PR DESCRIPTION
getsentry.com wasn't receiving my errors because my virtualbox in vagrant was adding a 5s delay related to the DNS resolution on top of the 2.5s it would take on my host system. It's fixable by configuring virtualbox to do DNS through the host:

``` ruby
config.vm.provider "virtualbox" do |v|
  v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
  v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
end
```

I reckon it beneficial if it works out of the box with vagrant even for us that are halfway around the world.
