### PR TITLE
Always submit environment data

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -351,19 +351,20 @@ class Raven_Client
             }
         }
 
-        if (!$this->is_http_request()) {
-            return array('request' => $result);
+        if ($this->is_http_request()) {
+            $result += array(
+                'method' => $this->_server_variable('REQUEST_METHOD'),
+                'url' => $this->get_current_url(),
+                'query_string' => $this->_server_variable('QUERY_STRING'),
+                'data' => $_POST,
+                'cookies' => $_COOKIE
+            );
+        } else {
+            $result['extra']['env'] = $result['env'];
+            unset($result['env']);
         }
 
-        $result += array(
-            'method' => $this->_server_variable('REQUEST_METHOD'),
-            'url' => $this->get_current_url(),
-            'query_string' => $this->_server_variable('QUERY_STRING'),
-            'data' => $_POST,
-            'cookies' => $_COOKIE
-        );
         $result = array_filter($result);
-
         return array('request' => $result);
     }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -328,11 +328,14 @@ class Raven_Client
     }
 
     /**
-     * NOT just http data - it's the environment/request
+     * Parse the environment data into sentry-expected format
+     *
+     * Always returns environment data, if it's a http request, also returns
+     * request headers, request parameters, post data and cookies
      *
      * @return array
      */
-    protected function get_http_data()
+    protected function get_env_data()
     {
         $result = array();
 
@@ -362,6 +365,14 @@ class Raven_Client
         $result = array_filter($result);
 
         return array('request' => $result);
+    }
+
+    /**
+     * @deprecated replaced by get_env_data
+     */
+    protected function get_http_data()
+    {
+        return $this->get_env_data();
     }
 
     protected function get_user_data()
@@ -424,7 +435,7 @@ class Raven_Client
 
         $data = array_merge($this->get_default_data(), $data);
 
-        $data = array_merge($this->get_http_data(), $data);
+        $data = array_merge($this->get_env_data(), $data);
 
         $data = array_merge($this->get_user_data(), $data);
 

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -33,9 +33,9 @@ class Dummy_Raven_Client extends Raven_Client
     {
         return parent::get_auth_header($timestamp, $client, $api_key, $secret_key);
     }
-    public function get_http_data()
+    public function get_env_data()
     {
-        return parent::get_http_data();
+        return parent::get_env_data();
     }
     public function get_user_data()
     {
@@ -453,10 +453,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_default_data());
     }
 
-    /**
-     * @backupGlobals
-     */
-    public function testGetHttpData()
+    public function testGetEnvData()
     {
         $_SERVER = array(
             'REDIRECT_STATUS'     => '200',
@@ -512,7 +509,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         );
 
         $client = new Dummy_Raven_Client();
-        $this->assertEquals($expected, $client->get_http_data());
+        $this->assertEquals($expected, $client->get_env_data());
     }
 
     public function testGetUserDataWithSetUser()


### PR DESCRIPTION
If an exception is caught in a cli process - no environment information is submitted. 

This can make debugging cli problems difficult if there is more than one possible cli candidate-process. In my own situation, from sentry's info alone, I usually have to guess which process is throwing the exception based upon class names in a stack trace.

Annoyingly, whilst this does what I intended (add env data to the info submitted to sentry) it's considered invalid:

![screenshot from 2015-12-02 12-18-32](https://cloud.githubusercontent.com/assets/33387/11529670/e2513d3e-98ee-11e5-9793-496d42a56584.png)

What's the correct way to submit env data to sentry for cli processes? It should be automatic imo, and not "extra", I'm not sure which page in the spec-docs I should be referring to.