### PR TITLE
Don't include stack frame within PHP error handler

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -264,12 +264,14 @@ class Raven_Client
              * was thrown, so we have to stuff it in ourselves. Ugh.
              */
             $trace = $exc->getTrace();
-            $frame_where_exception_thrown = array(
-                'file' => $exc->getFile(),
-                'line' => $exc->getLine(),
-            );
-
-            array_unshift($trace, $frame_where_exception_thrown);
+            // Don't include the frame within the error handler for ErrorExceptions
+            if (!($exc instanceof ErrorException)) {
+                $frame_where_exception_thrown = array(
+                    'file' => $exc->getFile(),
+                    'line' => $exc->getLine(),
+                );
+                array_unshift($trace, $frame_where_exception_thrown);
+            }
 
             // manually trigger autoloading, as it's not done in some edge cases due to PHP bugs (see #60149)
             if (!class_exists('Raven_Stacktrace')) {


### PR DESCRIPTION
For `ErrorException`s (thrown by the error handler for PHP errors), we should skip the point at which it was thrown in the trace, as it points to the error handler instead of the actual error origin.
