### PR TITLE
Remove serialization of user-provided values

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -475,28 +475,22 @@ class Raven_Client
             $this->context->extra,
             $data['extra']);
 
-        // manually trigger autoloading, as it's not done in some edge cases due to PHP bugs (see #60149)
-        if (!class_exists('Raven_Serializer')) {
-            spl_autoload_call('Raven_Serializer');
-        }
-
-        $serializer = new Raven_Serializer();
-        // avoid empty arrays (which dont convert to dicts)
         if (empty($data['extra'])) {
             unset($data['extra']);
         } else {
-            $data['extra'] = $serializer->serialize($data['extra']);
+            $data['extra'] = $data['extra'];
         }
+
         if (empty($data['tags'])) {
             unset($data['tags']);
         } else {
-            $data['tags'] = $serializer->serialize($data['tags']);
+            $data['tags'] = $data['tags'];
         }
         if (!empty($data['user'])) {
-            $data['user'] = $serializer->serialize($data['user']);
+            $data['user'] = $data['user'];
         }
         if (!empty($data['request'])) {
-            $data['request'] = $serializer->serialize($data['request']);
+            $data['request'] = $data['request'];
         }
 
         if (!$this->breadcrumbs->is_empty()) {


### PR DESCRIPTION
We can trust that users are not providing objects/etc. If they do, its their own responsibility to fix it.

Will likely combine the serializers again, since we only need it for automated things (e.g. Stacktrace).

Refs GH-281