### PR TITLE
add conflict rule for raven/raven

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "ext-curl": "*",
         "monolog/monolog": "*"
     },
+    "conflict": {
+        "raven/raven": "*"
+    },
     "bin": [
         "bin/sentry"
     ],


### PR DESCRIPTION
Both packages cannot be installed at the same time as they use the same
class names.