### PR TITLE
Fix array key for adding user context

### DIFF
--- a/docs/integrations/monolog.rst
+++ b/docs/integrations/monolog.rst
@@ -22,7 +22,7 @@ Capturing context can be done via a monolog processor:
     $monolog->pushProcessor(function ($record) {
         // record the current user
         $user = Acme::getCurrentUser();
-        $record['user'] = array(
+        $record['context']['user'] = array(
             'name' => $user->getName(),
             'username' => $user->getUsername(),
             'email' => $user->getEmail(),


### PR DESCRIPTION
Working through adding a monolog integration for sentry and noticed that user context information was not being passed to sentry until I made the proposed change. Not sure if something changed with monolog.

Using "monolog/monolog:1.x-dev" and "raven/raven:0.13.0"