### PR TITLE
make send_http_asynchronous_curl_exec method protected

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -753,7 +753,7 @@ class Raven_Client
      * @param array     $headers    Associative array of headers
      * @return bool
      */
-    private function send_http_asynchronous_curl_exec($url, $data, $headers)
+    protected function send_http_asynchronous_curl_exec($url, $data, $headers)
     {
         // TODO(dcramer): support ca_cert
         $cmd = $this->curl_path.' -X POST ';


### PR DESCRIPTION
Hello,
I am facing issues with ```send_http_asynchronous_curl_exec``` method : It makes some zombie curl process on my server.
I would like to inherit ```send_http_asynchronous_curl_exec``` to use Guzzle but I need this method not to be private anymore.
Please let me know if there is any chance for this PR to be accepted.

If you would like to use Guzzle directly in this project, I suppose I can make a PR for this instead.

Cheers