### PR TITLE
Force values to strings when sanitizing

### DIFF
--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -51,7 +51,7 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
             return;
         }
 
-        if (preg_match($this->values_re, $item)) {
+        if (preg_match($this->values_re, (string)$item)) {
             $item = self::MASK;
         }
 
@@ -59,7 +59,7 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
             return;
         }
 
-        if (preg_match($this->fields_re, $key)) {
+        if (preg_match($this->fields_re, (string)$key)) {
             $item = self::MASK;
         }
     }


### PR DESCRIPTION
I'm unclear if this is enough to ensure non-strings are sanitizable, or if we need to do stronger checks.

Refs GH-300