### PR TITLE
Proposed fix for issue #300

### DIFF
--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -47,7 +47,7 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
      */
     public function sanitize(&$item, $key)
     {
-        if (empty($item)) {
+        if (empty($item) || !is_string($item)) {
             return;
         }
 


### PR DESCRIPTION
The `sanitize` method is expecting a string for the `preg_match` check.

In some cases, other data than a string is passed through the method and this makes the client fail.

My proposed fix is to verify the contents of `$item` before moving forward with the sanitizing.