### PR TITLE
Make serializer  transcoding more resilient

### DIFF
--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -37,8 +37,11 @@ class Raven_ReprSerializer extends Raven_Serializer
         } else {
             $value = (string) $value;
 
-            if (function_exists('mb_convert_encoding')) {
-                $value = mb_convert_encoding($value, 'UTF-8', 'auto');
+            if (function_exists('mb_detect_encoding')
+                && function_exists('mb_convert_encoding')
+                && $currentEncoding = mb_detect_encoding($value, 'auto')
+            ) {
+                $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
             }
 
             return $value;

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -59,8 +59,11 @@ class Raven_Serializer
         } else {
             $value = (string) $value;
 
-            if (function_exists('mb_convert_encoding')) {
-                $value = mb_convert_encoding($value, 'UTF-8', 'auto');
+            if (function_exists('mb_detect_encoding')
+                && function_exists('mb_convert_encoding')
+                && $currentEncoding = mb_detect_encoding($value, 'auto')
+            ) {
+                $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
             }
 
             return $value;


### PR DESCRIPTION
`mb_convert_encoding` throws a `E_WARNING` if it can't  detect the encoding. The warning are flooding log-files. You can prevent this by using mb_detect_encoding before conversion.