### PR TITLE
fabpot/php-cs-fixer is abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require-dev": {
-        "fabpot/php-cs-fixer": "^1.8.0",
+        "friendsofphp/php-cs-fixer": "^1.8.0",
         "phpunit/phpunit": "^4.6.6"
     },
     "require": {


### PR DESCRIPTION
https://packagist.org/packages/fabpot/php-cs-fixer
> The author suggests using the friendsofphp/php-cs-fixer package instead.