### PR TITLE
Encodes the stacktrace, if available.

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -87,7 +87,7 @@ class Raven_Client
         // app path is used to determine if code is part of your application
         $this->app_path = Raven_Util::get($options, 'app_path', null);
         $this->transport = Raven_Util::get($options, 'transport', null);
-        ;
+        $this->mb_detect_order = Raven_Util::get($options, 'mb_detect_order', null);
 
         $this->processors = $this->setProcessorsFromOptions($options);
 
@@ -652,7 +652,7 @@ class Raven_Client
     public function sanitize(&$data)
     {
         // attempt to sanitize any user provided data
-        $serializer = new Raven_Serializer();
+        $serializer = new Raven_Serializer($this->mb_detect_order);
         if (!empty($data['request'])) {
             $data['request'] = $serializer->serialize($data['request']);
         }
@@ -665,6 +665,11 @@ class Raven_Client
         if (!empty($data['tags'])) {
             $data['tags'] = $serializer->serialize($data['tags']);
         }
+        if (!empty($data['stacktrace']) && !empty($data['stacktrace']['frames'])) {
+            $data['stacktrace']['frames'] = $serializer->serialize($data['stacktrace']['frames']);
+        }
+
+        $serializer->serialize($data);
     }
 
     /**

--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -39,7 +39,7 @@ class Raven_ReprSerializer extends Raven_Serializer
 
             if (function_exists('mb_detect_encoding')
                 && function_exists('mb_convert_encoding')
-                && $currentEncoding = mb_detect_encoding($value, 'auto')
+                && $currentEncoding = mb_detect_encoding($value, $this->getMbDetectOrder())
             ) {
                 $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
             }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -26,6 +26,34 @@
  */
 class Raven_Serializer
 {
+    /*
+     * The default mb detect order
+     *
+     * @see http://php.net/manual/en/function.mb-detect-encoding.php
+     */
+    const DEFAULT_MB_DETECT_ORDER = 'auto';
+
+    /*
+     * Suggested detect order for western countries
+     */
+    const WESTERN_MB_DETECT_ORDER = 'UTF-8, ASCII, ISO-8859-1, ISO-8859-2, ISO-8859-3, ISO-8859-4, ISO-8859-5, ISO-8859-6, ISO-8859-7, ISO-8859-8, ISO-8859-9, ISO-8859-10, ISO-8859-13, ISO-8859-14, ISO-8859-15, ISO-8859-16, Windows-1251, Windows-1252, Windows-1254';
+
+    /**
+     * This is the default mb detect order for the detection of encoding
+     *
+     * @var string
+     */
+    private $mb_detect_order= self::DEFAULT_MB_DETECT_ORDER;
+
+    /**
+     * @param null|string $mb_detect_order
+     */
+    public function __construct($mb_detect_order = null)
+    {
+        if ($mb_detect_order != null) {
+            $this->mb_detect_order = $mb_detect_order;
+        }
+    }
     /**
      * Serialize an object (recursively) into something safe for data
      * sanitization and encoding.
@@ -58,15 +86,35 @@ class Raven_Serializer
             return 'Array of length ' . count($value);
         } else {
             $value = (string) $value;
-
             if (function_exists('mb_detect_encoding')
                 && function_exists('mb_convert_encoding')
-                && $currentEncoding = mb_detect_encoding($value, 'auto')
+                && $currentEncoding = mb_detect_encoding($value, $this->mb_detect_order)
             ) {
                 $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
             }
 
             return $value;
         }
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getMbDetectOrder()
+    {
+        return $this->mb_detect_order;
+    }
+
+    /**
+     * @param string $mb_detect_order
+     *
+     * @return Raven_Serializer
+     */
+    public function setMbDetectOrder($mb_detect_order)
+    {
+        $this->mb_detect_order = $mb_detect_order;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Also provides the possibily to provide an own mb_detect_order for a more reliable detection of encoding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/320)
<!-- Reviewable:end -->
