### PR TITLE
Support data mutation

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -700,7 +700,7 @@ class Raven_Client
      */
     public function send(&$data)
     {
-        if (is_callable($this->send_callback) && call_user_func($this->send_callback, $data) === false) {
+        if (is_callable($this->send_callback) && call_user_func_array($this->send_callback, array(&$data)) === false) {
             // if send_callback returns false, end native send
             return;
         }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -19,7 +19,7 @@ class Dummy_Raven_Client extends Raven_Client
     }
     public function send(&$data)
     {
-        if (is_callable($this->send_callback) && !call_user_func($this->send_callback, $data)) {
+        if (is_callable($this->send_callback) && call_user_func_array($this->send_callback, array(&$data)) === false) {
             // if send_callback returns falsely, end native send
             return;
         }


### PR DESCRIPTION
I think part of the reason `$data` cannot be manipulated is because the `call_user_func` function is passing the `$data` array by value rather than reference. With the `call_user_func_array` function, we can specify that it's passed by reference, which will enable us to manipulate correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/325)
<!-- Reviewable:end -->
