### PR TITLE
Remove env data from HTTP

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -470,15 +470,13 @@ class Raven_Client
 
     protected function get_http_data()
     {
-        $env = $headers = array();
+        $headers = array();
 
         foreach ($_SERVER as $key => $value) {
             if (0 === strpos($key, 'HTTP_')) {
                 $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))))] = $value;
             } elseif (in_array($key, array('CONTENT_TYPE', 'CONTENT_LENGTH')) && $value !== '') {
                 $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))))] = $value;
-            } else {
-                $env[$key] = $value;
             }
         }
 
@@ -498,9 +496,6 @@ class Raven_Client
         }
         if (!empty($headers)) {
             $result['headers'] = $headers;
-        }
-        if (!empty($env)) {
-            $result['env'] = $env;
         }
 
         return array(

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -529,15 +529,6 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
                     'Content-Type'    => 'text/xml',
                     'Content-Length'  => '99',
                 ),
-                'env' => array(
-                    'REDIRECT_STATUS' => '200',
-                    'SERVER_PORT'     => '443',
-                    'SERVER_PROTOCOL' => 'HTTP/1.1',
-                    'REQUEST_METHOD'  => 'PATCH',
-                    'QUERY_STRING'    => 'q=bitch&l=en',
-                    'REQUEST_URI'     => '/welcome/',
-                    'SCRIPT_NAME'     => '/index.php',
-                ),
             )
         );
 


### PR DESCRIPTION
This contains potentially sensitive information, and as we move forward with Sentry it no longer logically makes sense for it to exist as part of this. If users want it they can use ``extra_context``.

@getsentry/php

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/326)
<!-- Reviewable:end -->
