### PR TITLE
Add link to full documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -262,6 +262,7 @@ You may now use phpunit :
 Resources
 ---------
 
+* `Documentation <https://docs.getsentry.com/hosted/clients/php/>`_
 * `Bug Tracker <http://github.com/getsentry/sentry-php/issues>`_
 * `Code <http://github.com/getsentry/sentry-php>`_
 * `Mailing List <https://groups.google.com/group/getsentry>`_


### PR DESCRIPTION
I think it would be a good idea to link to the docs site from the README, not just the main Sentry website.

(I only just discovered there's a separate documentation site - although I've read the README on GitHub more than once, I've never clicked the Docs link on the main Sentry website (or noticed the `docs/` folder). This means I never discovered things like [Filtering Out Errors](https://docs.getsentry.com/hosted/clients/php/usage/#filtering-out-errors) which is only in the full docs, not the README.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/336)
<!-- Reviewable:end -->
