### PR TITLE
Fix typo in Raven_Client

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -79,7 +79,7 @@ class Raven_Client
         $this->send_callback = Raven_Util::get($options, 'send_callback', null);
         $this->curl_method = Raven_Util::get($options, 'curl_method', 'sync');
         $this->curl_path = Raven_Util::get($options, 'curl_path', 'curl');
-        $this->curl_ipv4 = Raven_util::get($options, 'curl_ipv4', true);
+        $this->curl_ipv4 = Raven_Util::get($options, 'curl_ipv4', true);
         $this->ca_cert = Raven_Util::get($options, 'ca_cert', $this->get_default_ca_cert());
         $this->verify_ssl = Raven_Util::get($options, 'verify_ssl', true);
         $this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');


### PR DESCRIPTION
Changed `u` to `U`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/340)
<!-- Reviewable:end -->
