### PR TITLE
Fix encoding errors for exceptions

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -679,6 +679,9 @@ class Raven_Client
         if (!empty($data['stacktrace']) && !empty($data['stacktrace']['frames'])) {
             $data['stacktrace']['frames'] = $serializer->serialize($data['stacktrace']['frames']);
         }
+        if (!empty($data['exception'])) {
+            $data['exception'] = $serializer->serialize($data['exception'], 7);
+        }
 
         $serializer->serialize($data);
     }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -410,8 +410,8 @@ class Raven_Client
 
             $exc_data['stacktrace'] = array(
                 'frames' => Raven_Stacktrace::get_stack_info(
-                    $trace, $this->serializer, $this->reprSerializer, $this->trace, $this->shift_vars, $vars,
-                    $this->message_limit, $this->prefixes, $this->app_path, $this->serializer
+                    $trace, $this->trace, $this->shift_vars, $vars, $this->message_limit, $this->prefixes,
+                    $this->app_path, $this->serializer, $this->reprSerializer
                 ),
             );
 
@@ -644,8 +644,8 @@ class Raven_Client
             if (!isset($data['stacktrace']) && !isset($data['exception'])) {
                 $data['stacktrace'] = array(
                     'frames' => Raven_Stacktrace::get_stack_info(
-                        $stack, $this->serializer, $this->reprSerializer, $this->trace, $this->shift_vars, $vars,
-                        $this->message_limit, $this->prefixes, $this->app_path, $this->serializer
+                        $stack, $this->trace, $this->shift_vars, $vars, $this->message_limit, $this->prefixes,
+                        $this->app_path, $this->serializer, $this->reprSerializer
                     ),
                 );
             }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -682,8 +682,6 @@ class Raven_Client
         if (!empty($data['exception'])) {
             $data['exception'] = $serializer->serialize($data['exception'], 7);
         }
-
-        $serializer->serialize($data);
     }
 
     /**

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -13,10 +13,14 @@ class Raven_Stacktrace
         'require_once',
     );
 
-    public static function get_stack_info($frames, Raven_Serializer $serializer, Raven_ReprSerializer $reprSerializer, $trace = false, $shiftvars = true, $errcontext = null,
+    public static function get_stack_info($frames, $trace = false, $shiftvars = true, $errcontext = null,
                                           $frame_var_limit = Raven_Client::MESSAGE_LIMIT, $strip_prefixes = null,
-                                          $app_path = null)
+                                          $app_path = null, Raven_Serializer $serializer = null,
+                                          Raven_ReprSerializer $reprSerializer = null)
     {
+        $serializer = $serializer ?: new Raven_Serializer();
+        $reprSerializer = $reprSerializer ?: new Raven_ReprSerializer();
+
         /**
          * PHP's way of storing backstacks seems bass-ackwards to me
          * 'function' is not the function you're in; it's any function being

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -13,7 +13,7 @@ class Raven_Stacktrace
         'require_once',
     );
 
-    public static function get_stack_info($frames, $trace = false, $shiftvars = true, $errcontext = null,
+    public static function get_stack_info($frames, Raven_Serializer $serializer, Raven_ReprSerializer $reprSerializer, $trace = false, $shiftvars = true, $errcontext = null,
                                           $frame_var_limit = Raven_Client::MESSAGE_LIMIT, $strip_prefixes = null,
                                           $app_path = null)
     {
@@ -87,9 +87,9 @@ class Raven_Stacktrace
                 'lineno' => (int) $context['lineno'],
                 'module' => $module,
                 'function' => isset($nextframe['function']) ? $nextframe['function'] : null,
-                'pre_context' => $context['prefix'],
+                'pre_context' => $serializer->serialize($context['prefix']),
                 'context_line' => $context['line'],
-                'post_context' => $context['suffix'],
+                'post_context' => $serializer->serialize($context['suffix']),
             );
 
             // detect in_app based on app path
@@ -100,10 +100,9 @@ class Raven_Stacktrace
             // dont set this as an empty array as PHP will treat it as a numeric array
             // instead of a mapping which goes against the defined Sentry spec
             if (!empty($vars)) {
-                $serializer = new Raven_ReprSerializer();
                 $cleanVars = array();
                 foreach ($vars as $key => $value) {
-                    $value = $serializer->serialize($value);
+                    $value = $reprSerializer->serialize($value);
                     if (is_string($value) || is_numeric($value)) {
                         $cleanVars[$key] = substr($value, 0, $frame_var_limit);
                     } else {

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -684,6 +684,26 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ), $event['extra']);
     }
 
+    public function testCaptureExceptionInLatin1File()
+    {
+        // If somebody has a non-utf8 codebase, she/he should add the encoding to the detection order
+        $options = ['mb_detect_order' => ['ISO-8859-1', 'ASCII', 'UTF-8']];
+
+        $client = new Dummy_Raven_Client($options);
+
+        // we need a non-utf8 string here.
+        // nobody writes non-utf8 in exceptions, but it is the easiest way to test.
+        // in real live non-utf8 may be somewhere in the exception's stacktrace
+        $utf8String = 'äöü';
+        $latin1String = utf8_decode($utf8String);
+        $client->captureException(new \Exception($latin1String));
+
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+
+        $this->assertEquals($event['exception']['values'][0]['value'], $utf8String);
+    }
+
     public function testGetLastEventID()
     {
         $client = new Dummy_Raven_Client();

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -687,8 +687,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     public function testCaptureExceptionInLatin1File()
     {
         // If somebody has a non-utf8 codebase, she/he should add the encoding to the detection order
-        $options = ['mb_detect_order' => ['ISO-8859-1', 'ASCII', 'UTF-8']];
-
+        $options = array(
+            'mb_detect_order' => array(
+                'ISO-8859-1', 'ASCII', 'UTF-8'
+            )
+        );
+        
         $client = new Dummy_Raven_Client($options);
 
         // we need a non-utf8 string here.

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -57,7 +57,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true);
+        $frames = Raven_Stacktrace::get_stack_info($stack, true);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -92,7 +92,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, false);
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, false);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -134,7 +134,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             "baz" => "zoom"
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, true, $vars);
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, true, $vars);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -179,7 +179,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             "foo" => &$iAmFoo
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, true, $vars, 5);
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, true, $vars, 5);
 
         // Check we haven't modified our vars.
         $this->assertEquals($originalFoo, $vars["foo"]);
@@ -215,7 +215,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             "baz" => "zoom"
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, false, $vars);
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, false, $vars);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -240,7 +240,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
          */
         $stack = raven_test_create_stacktrace();
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true);
+        $frames = Raven_Stacktrace::get_stack_info($stack, true);
         // just grab the last few frames
         $frames = array_slice($frames, -5);
         $frame = $frames[0];
@@ -275,7 +275,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, null, null, 0, null, dirname(__FILE__));
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, null, null, 0, null, dirname(__FILE__));
 
         $this->assertEquals($frames[0]['in_app'], true);
         $this->assertEquals($frames[1]['in_app'], true);
@@ -296,7 +296,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, null, null, 0, array(dirname(__FILE__)));
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, null, null, 0, array(dirname(__FILE__)));
 
         $this->assertEquals($frames[0]['filename'], 'resources/b.php');
         $this->assertEquals($frames[1]['filename'], 'resources/a.php');
@@ -312,7 +312,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer());
+        $frames = Raven_Stacktrace::get_stack_info($stack);
         $this->assertEquals($frames[0]['filename'], dirname(__FILE__) . '/resources/a.php');
     }
 
@@ -322,7 +322,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             eval("throw new Exception('foobar');");
         } catch (Exception $ex) {
             $trace = $ex->getTrace();
-            $frames = Raven_Stacktrace::get_stack_info($trace, new Raven_Serializer(), new Raven_ReprSerializer());
+            $frames = Raven_Stacktrace::get_stack_info($trace);
         }
         $this->assertEquals($frames[count($frames) -1]['filename'], __FILE__);
     }

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -57,7 +57,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -92,7 +92,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true, false);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, false);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -134,7 +134,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             "baz" => "zoom"
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true, true, $vars);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, true, $vars);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -179,7 +179,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             "foo" => &$iAmFoo
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true, true, $vars, 5);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, true, $vars, 5);
 
         // Check we haven't modified our vars.
         $this->assertEquals($originalFoo, $vars["foo"]);
@@ -215,7 +215,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             "baz" => "zoom"
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true, false, $vars);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, false, $vars);
 
         $frame = $frames[0];
         $this->assertEquals('b.php', $frame["module"]);
@@ -240,7 +240,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
          */
         $stack = raven_test_create_stacktrace();
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true);
         // just grab the last few frames
         $frames = array_slice($frames, -5);
         $frame = $frames[0];
@@ -275,7 +275,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true, null, null, 0, null, dirname(__FILE__));
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, null, null, 0, null, dirname(__FILE__));
 
         $this->assertEquals($frames[0]['in_app'], true);
         $this->assertEquals($frames[1]['in_app'], true);
@@ -296,7 +296,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack, true, null, null, 0, array(dirname(__FILE__)));
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer(), true, null, null, 0, array(dirname(__FILE__)));
 
         $this->assertEquals($frames[0]['filename'], 'resources/b.php');
         $this->assertEquals($frames[1]['filename'], 'resources/a.php');
@@ -312,7 +312,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $frames = Raven_Stacktrace::get_stack_info($stack);
+        $frames = Raven_Stacktrace::get_stack_info($stack, new Raven_Serializer(), new Raven_ReprSerializer());
         $this->assertEquals($frames[0]['filename'], dirname(__FILE__) . '/resources/a.php');
     }
 
@@ -322,7 +322,7 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             eval("throw new Exception('foobar');");
         } catch (Exception $ex) {
             $trace = $ex->getTrace();
-            $frames = Raven_Stacktrace::get_stack_info($trace);
+            $frames = Raven_Stacktrace::get_stack_info($trace, new Raven_Serializer(), new Raven_ReprSerializer());
         }
         $this->assertEquals($frames[count($frames) -1]['filename'], __FILE__);
     }

--- a/test/Raven/Tests/resources/captureExceptionInLatin1File.php
+++ b/test/Raven/Tests/resources/captureExceptionInLatin1File.php
@@ -1,0 +1,4 @@
+<?php
+// This file is encoded in latin1
+// הצü
+$client->captureException(new \Exception());


### PR DESCRIPTION
$data['exception'] is not encoded to utf8 via sanitized(). This causes problems, if sourcecode (stacktrace) or the exception's message are not in utf8 and contain special characters (e.g. german umlauts)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/342)
<!-- Reviewable:end -->
