### PR TITLE
Fix typo in Raven_Client

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -232,7 +232,7 @@ class Raven_Client
     public function setProcessorsFromOptions($options)
     {
         $processors = array();
-        foreach (Raven_util::get($options, 'processors', self::getDefaultProcessors()) as $processor) {
+        foreach (Raven_Util::get($options, 'processors', self::getDefaultProcessors()) as $processor) {
             $new_processor = new $processor($this);
 
             if (isset($options['processorOptions']) && is_array($options['processorOptions'])) {


### PR DESCRIPTION
Changed `u` to `U`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/344)
<!-- Reviewable:end -->
