### PR TITLE
Fix: Encoding for context_line missing

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -92,7 +92,7 @@ class Raven_Stacktrace
                 'module' => $module,
                 'function' => isset($nextframe['function']) ? $nextframe['function'] : null,
                 'pre_context' => $serializer->serialize($context['prefix']),
-                'context_line' => $context['line'],
+                'context_line' => $serializer->serialize($context['line']),
                 'post_context' => $serializer->serialize($context['suffix']),
             );
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/345)
<!-- Reviewable:end -->
