### PR TITLE
Fix release value from being masked

### DIFF
--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -47,6 +47,10 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
      */
     public function sanitize(&$item, $key)
     {
+        if ($key === 'release') {
+            return;
+        }
+
         if (empty($item)) {
             return;
         }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -290,6 +290,21 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['message'], 'Test Message foo');
     }
 
+    public function testCaptureMessageDoesHandleInterpolatedMessageWithRelease()
+    {
+        $client = new Dummy_Raven_Client();
+        $client->setRelease(20160909144742);
+
+        $this->assertEquals(20160909144742, $client->getRelease());
+
+        $client->captureMessage('Test Message %s', array('foo'));
+        $events = $client->getSentEvents();
+        $this->assertEquals(count($events), 1);
+        $event = array_pop($events);
+        $this->assertEquals($event['release'], 20160909144742);
+        $this->assertEquals($event['message'], 'Test Message foo');
+    }
+
     public function testCaptureMessageSetsInterface()
     {
         $client = new Dummy_Raven_Client();


### PR DESCRIPTION
With this fix the release value is prevented from being masked, without this fix a release value that contains only numbers can be masked if match `VALUES_RE` regex. The [release api](https://docs.sentry.io/hosted/api/releases/post-project-releases/) don't mask the release value and the php sdk should have the same behaviour.

**Example release value from a release done with the release api:**

<img width="234" alt="skarmavbild 2016-09-11 kl 10 47 48" src="https://cloud.githubusercontent.com/assets/14610/18416198/4365e234-780d-11e6-88aa-fb16a78124d1.png">

**Example release value from sentry.io on a event:**

<img width="240" alt="skarmavbild 2016-09-11 kl 10 44 29" src="https://cloud.githubusercontent.com/assets/14610/18416179/c5818c9c-780c-11e6-962c-4dca1d4fb0d5.png">

**Test Before:**
```
Release: 20160909144742
Sanitized: **********
```

**Test After:**
```
Release: 20160909144742
Sanitized: 20160909144742
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/347)
<!-- Reviewable:end -->
