### PR TITLE
Overhaul stacktrace generation

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -94,7 +94,7 @@ class Raven_Client
         $this->setAppPath(Raven_Util::get($options, 'app_path', null));
         $this->setExcludedAppPaths(Raven_Util::get($options, 'excluded_app_paths', null));
         // a list of prefixes used to coerce absolute paths into relative
-        $this->setPrefixes(Raven_Util::get($options, 'prefixes', null));
+        $this->setPrefixes(Raven_Util::get($options, 'prefixes', $this->getDefaultPrefixes()));
         $this->processors = $this->setProcessorsFromOptions($options);
 
         $this->_lasterror = null;
@@ -156,6 +156,12 @@ class Raven_Client
     {
         $this->environment = $value;
         return $this;
+    }
+
+    private function getDefaultPrefixes()
+    {
+        $value = get_include_path();
+        return explode(':', $value);
     }
 
     private function _convertPath($value)
@@ -422,7 +428,6 @@ class Raven_Client
             $exc_data = array(
                 'value' => $this->serializer->serialize($exc->getMessage()),
                 'type' => get_class($exc),
-                'module' => $exc->getFile() .':'. $exc->getLine(),
             );
 
             /**'exception'
@@ -444,7 +449,7 @@ class Raven_Client
 
             $exc_data['stacktrace'] = array(
                 'frames' => Raven_Stacktrace::get_stack_info(
-                    $trace, $this->trace, $this->shift_vars, $vars, $this->message_limit, $this->prefixes,
+                    $trace, $this->trace, $vars, $this->message_limit, $this->prefixes,
                     $this->app_path, $this->excluded_app_paths, $this->serializer, $this->reprSerializer
                 ),
             );
@@ -678,7 +683,7 @@ class Raven_Client
             if (!isset($data['stacktrace']) && !isset($data['exception'])) {
                 $data['stacktrace'] = array(
                     'frames' => Raven_Stacktrace::get_stack_info(
-                        $stack, $this->trace, $this->shift_vars, $vars, $this->message_limit, $this->prefixes,
+                        $stack, $this->trace, $vars, $this->message_limit, $this->prefixes,
                         $this->app_path, $this->excluded_app_paths, $this->serializer, $this->reprSerializer
                     ),
                 );

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -76,7 +76,6 @@ class Raven_Client
         $this->message_limit = Raven_Util::get($options, 'message_limit', self::MESSAGE_LIMIT);
         $this->exclude = Raven_Util::get($options, 'exclude', array());
         $this->severity_map = null;
-        $this->shift_vars = (bool) Raven_Util::get($options, 'shift_vars', true);
         $this->http_proxy = Raven_Util::get($options, 'http_proxy');
         $this->extra_data = Raven_Util::get($options, 'extra', array());
         $this->send_callback = Raven_Util::get($options, 'send_callback', null);

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -48,7 +48,6 @@ class Raven_ErrorHandler
      * A 'null' value implies "whatever error_reporting is at time of error".
      */
     private $error_types = null;
-    private $_last_handled_error = null;
 
     public function __construct($client, $send_errors_last = false, $error_types = null,
                                 $__error_types = null)
@@ -81,12 +80,6 @@ class Raven_ErrorHandler
         // The following error types cannot be handled with a user defined function: E_ERROR,
         // E_PARSE, E_CORE_ERROR, E_CORE_WARNING, E_COMPILE_ERROR, E_COMPILE_WARNING, and
         // most of E_STRICT raised in the file where set_error_handler() is called.
-
-        // we always need to bind _last_handled_error in the case of a suppressed
-        // error getting passed to handleFatalError. In PHP 5.x it seems that
-        // ``error_get_last`` is not always populated, so we instead always bind
-        // it to the last value (rather than whatever error we're handling now)
-        $this->_last_handled_error = error_get_last();
 
         $e = new ErrorException($message, 0, $type, $file, $line);
 

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -157,41 +157,6 @@ class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
         trigger_error('Warning', E_USER_WARNING);
     }
 
-    public function testHandleFatalError()
-    {
-        $client = $this->getMock('Client', array('captureException'));
-        $client->expects($this->once())
-               ->method('captureException');
-
-        $handler = new Raven_ErrorHandler($client);
-
-        # http://php.net/manual/en/function.error-get-last.php#113518
-        set_error_handler('var_dump', 0);
-        @$undef_var;
-        restore_error_handler();
-
-        $handler->handleFatalError();
-    }
-
-    public function testHandleFatalErrorDuplicate()
-    {
-        $client = $this->getMock('Client', array('captureException'));
-        $client->expects($this->once())
-               ->method('captureException');
-
-        $handler = new Raven_ErrorHandler($client);
-
-        # http://php.net/manual/en/function.error-get-last.php#113518
-        set_error_handler('var_dump', 0);
-        @$undef_var;
-        restore_error_handler();
-
-        $error = error_get_last();
-
-        $handler->handleError($error['type'], $error['message'], $error['file'], $error['line']);
-        $handler->handleFatalError();
-    }
-
     public function testFluidInterface()
     {
         $client = $this->getMock('Client', array('captureException'));

--- a/test/Raven/Tests/IntegrationTest.php
+++ b/test/Raven/Tests/IntegrationTest.php
@@ -28,6 +28,10 @@ class DummyIntegration_Raven_Client extends Raven_Client
     {
         return true;
     }
+    // short circuit breadcrumbs
+    public function registerDefaultBreadcrumbHandlers()
+    {
+    }
 }
 
 class Raven_Tests_IntegrationTest extends PHPUnit_Framework_TestCase
@@ -60,6 +64,6 @@ class Raven_Tests_IntegrationTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exc['value'], 'mkdir(): No such file or directory');
         $stack = $exc['stacktrace']['frames'];
         $lastFrame = $stack[count($stack) - 1];
-        $this->assertEquals(@$lastFrame['filename'], __file__);
+        $this->assertEquals(@$lastFrame['filename'], 'test/Raven/Tests/IntegrationTest.php');
     }
 }

--- a/test/Raven/Tests/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/SanitizeDataProcessorTest.php
@@ -32,7 +32,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $client = new Raven_Client();
+        $client = new Dummy_Raven_Client();
         $processor = new Raven_SanitizeDataProcessor($client);
         $processor->process($data);
 
@@ -59,7 +59,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $client = new Raven_Client();
+        $client = new Dummy_Raven_Client();
         $processor = new Raven_SanitizeDataProcessor($client);
         $processor->process($data);
 
@@ -75,7 +75,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $client = new Raven_Client();
+        $client = new Dummy_Raven_Client();
         $processor = new Raven_SanitizeDataProcessor($client);
         $processor->process($data);
 
@@ -88,7 +88,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      */
     public function testSettingProcessorOptions()
     {
-        $client     = new Raven_Client();
+        $client     = new Dummy_Raven_Client();
         $processor  = new Raven_SanitizeDataProcessor($client);
 
         $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i', 'got default fields');
@@ -114,7 +114,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
      */
     public function testOverrideOptions($processorOptions, $client_options, $dsn)
     {
-        $client = new Raven_Client($dsn, $client_options);
+        $client = new Dummy_Raven_Client($dsn, $client_options);
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
@@ -150,7 +150,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $client = new Raven_Client($dsn, $client_options);
+        $client = new Dummy_Raven_Client($dsn, $client_options);
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);

--- a/test/Raven/Tests/resources/a.php
+++ b/test/Raven/Tests/resources/a.php
@@ -1,6 +1,4 @@
 <?php
-// filename: /tmp/a.php
-
 function a_test($str)
 {
     echo "\nHi: $str";

--- a/test/Raven/Tests/resources/b.php
+++ b/test/Raven/Tests/resources/b.php
@@ -1,3 +1,2 @@
 <?php
-// filename: /tmp/b.php
-include_once '/tmp/a.php';
+include_once 'a.php';


### PR DESCRIPTION
- Bring back anonymous (etc) frames
- Remove shift_vars configurability
- Remove module usage
- Better handle empty context
- Correct alignment of filename (current frame) + function (caller frame)
- Add default prefixes using include paths
- Restore correct fatal error handling (fixes error suppression)
- Clean up breadcrumb registration in tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/359)
<!-- Reviewable:end -->
