### PR TITLE
Add transaction handling

### DIFF
--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_TransactionStack
+{
+    public function __construct()
+    {
+        $this->stack = array();
+    }
+
+    public function clear()
+    {
+        $this->stack = array();
+    }
+
+    public function peek()
+    {
+        $len = count($this->stack);
+        if ($len === 0) {
+            return null;
+        }
+        return $this->stack[$len - 1];
+    }
+
+    public function push($context)
+    {
+        $this->stack[] = $context;
+    }
+
+    public function pop($context=null)
+    {
+        if (!$context) {
+            return array_pop($this->stack);
+        }
+        while (!empty($this->stack)) {
+            if (array_pop($this->stack) === $context) {
+                return $context;
+            }
+        }
+    }
+}

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -435,17 +435,6 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['culprit'], 'test');
     }
 
-    public function testCaptureExceptionHandlesCulpritAsSecondArg()
-    {
-        $client = new Dummy_Raven_Client();
-        $ex = $this->create_exception();
-        $client->captureException($ex, 'test');
-        $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
-        $event = array_pop($events);
-        $this->assertEquals($event['culprit'], 'test');
-    }
-
     public function testCaptureExceptionHandlesExcludeOption()
     {
         $client = new Dummy_Raven_Client(array(
@@ -514,6 +503,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     public function testGetDefaultData()
     {
         $client = new Dummy_Raven_Client();
+        $client->transaction->push('test');
         $expected = array(
             'platform' => 'php',
             'project' => $client->project,
@@ -525,6 +515,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
                 'name' => 'sentry-php',
                 'version' => $client::VERSION,
             ),
+            'culprit' => 'test',
         );
         $this->assertEquals($expected, $client->get_default_data());
     }


### PR DESCRIPTION
This replaces the arbitrary culprit detection schemes with named transactions using the Python implementation as reference.

```php
$ctx = $client->transaction->push('/route/name');
routeName();
$client->transaction->pop($ctx);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-php/361)
<!-- Reviewable:end -->
