### PR TITLE
work around PHP bug #50688

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -81,14 +81,13 @@ class Raven_ErrorHandler
         // E_PARSE, E_CORE_ERROR, E_CORE_WARNING, E_COMPILE_ERROR, E_COMPILE_WARNING, and
         // most of E_STRICT raised in the file where set_error_handler() is called.
 
-        $e = new ErrorException($message, 0, $type, $file, $line);
-
         if (error_reporting() !== 0) {
             $error_types = $this->error_types;
             if ($error_types === null) {
                 $error_types = error_reporting();
             }
             if ($error_types & $type) {
+                $e = new ErrorException($message, 0, $type, $file, $line);
                 $this->handleException($e, true, $context);
             }
         }


### PR DESCRIPTION
if any descendant of Exception is instantiated from within a callback passed into the various array sorting functions, then PHP (< 7.0) will raise a warning ("Array was modified by the user comparison function").

As Raven always registers with E_ALL and then checks whether it needs to run in the handler itself, even if Raven decides not to do anything, it still instantiates the exception and thus will still cause the warning.

For example, if you run with E_NOTICE off and thus register Raven to not run on E_NOTICE, but then the user raises an E_NOTICE in a usort() callback, php bug 50688 will cause a warning to be thrown (which then likely *will* activate Raven on the second pass)