### PR TITLE
Fixes #367 - array_walk_recursive being possibly called with a string in case http['data'] is a raw string.

### DIFF
--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -80,7 +80,7 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
                 $cookies[$this->session_cookie_name] = self::MASK;
             }
         }
-        if (!empty($http['data'])) {
+        if (!empty($http['data']) && is_array($http['data'])) {
             array_walk_recursive($http['data'], array($this, 'sanitize'));
         }
     }


### PR DESCRIPTION
fixes #367 