### PR TITLE
Added missing dollar sign to 'key' variable in Client::buildCurlCommand()

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -886,7 +886,7 @@ class Raven_Client
         // TODO(dcramer): support ca_cert
         $cmd = $this->curl_path.' -X POST ';
         foreach ($headers as $key => $value) {
-            $cmd .= '-H ' . escapeshellarg(key) . ': '. escapeshellarg($value). ' ';
+            $cmd .= '-H ' . escapeshellarg($key) . ': '. escapeshellarg($value). ' ';
         }
         $cmd .= '-d ' . escapeshellarg($data) . ' ';
         $cmd .= escapeshellarg($url) . ' ';


### PR DESCRIPTION
Broke here: https://github.com/getsentry/sentry-php/commit/09de00d2fb3b7f664eb140b23b5ddcbf941b085b