### PR TITLE
Added message name tracking for compatibility with Sentry server, version 8.3.0

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -460,6 +460,7 @@ class Raven_Client
             $exceptions[] = $exc_data;
         } while ($has_chained_exceptions && $exc = $exc->getPrevious());
 
+        $data['message'] = $exception->getMessage();
         $data['exception'] = array(
             'values' => array_reverse($exceptions),
         );

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -375,6 +375,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $frame = $frames[count($frames) - 1];
         $this->assertTrue($frame['lineno'] > 0);
         $this->assertEquals($frame['function'], 'create_exception');
+        $this->assertEquals($event['message'], 'Foo bar');
         $this->assertFalse(isset($frame['vars']));
         $this->assertEquals($frame['context_line'], '            throw new Exception(\'Foo bar\');');
         $this->assertFalse(empty($frame['pre_context']));


### PR DESCRIPTION
Sentry server 8.3.0 tracks all events generated by sentry-php as <no message value>.
To fix the incompatibility the exception's name has been added to the actual event.