### PR TITLE
Fixed CURL header escaping

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -886,7 +886,7 @@ class Raven_Client
         // TODO(dcramer): support ca_cert
         $cmd = $this->curl_path.' -X POST ';
         foreach ($headers as $key => $value) {
-            $cmd .= '-H ' . escapeshellarg($key) . ': '. escapeshellarg($value). ' ';
+            $cmd .= '-H ' . escapeshellarg($key.': '.$value). ' ';
         }
         $cmd .= '-d ' . escapeshellarg($data) . ' ';
         $cmd .= escapeshellarg($url) . ' ';


### PR DESCRIPTION
There's another problem with the shell escaping (Also see #372) inside buildCurlCommand().

Curl headers are being escaped as [-H 'key:' 'value'] instead of [-H 'key: value'].