### PR TITLE
Allow raven to function without session extension

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -573,7 +573,7 @@ class Raven_Client
     {
         $user = $this->context->user;
         if ($user === null) {
-            if (!session_id()) {
+            if (!function_exists('session_id') || !session_id()) {
                 return array();
             }
             $user = array(


### PR DESCRIPTION
Turns out, you can disable the session module. Then raven errors badly