### PR TITLE
Add json string data to default context

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -559,9 +559,21 @@ class Raven_Client
         if (!empty($_POST)) {
             $result['data'] = $_POST;
         }
+        
+        // if the $_POST super global is empty, try to retrieve a json string 
+        if(empty($_POST)){
+            try {
+                $data = file_get_contents( 'php://input' );
+                $result['data'] = json_decode( $data, true );
+            } catch ( Exception $exception ) {
+                // do nothing
+            }
+        }
+        
         if (!empty($_COOKIE)) {
             $result['cookies'] = $_COOKIE;
         }
+        
         if (!empty($headers)) {
             $result['headers'] = $headers;
         }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -561,11 +561,11 @@ class Raven_Client
         }
         
         // if the $_POST super global is empty, try to retrieve a json string
-        if(empty($_POST)) {
+        if (empty($_POST)) {
             try {
                 $data = file_get_contents('php://input');
                 $result['data'] = json_decode($data, true);
-            } catch(\Exception $exception) {
+            } catch (\Exception $exception) {
                 // do nothing
             }
         }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -565,7 +565,7 @@ class Raven_Client
             try {
                 $data = file_get_contents('php://input');
                 $result['data'] = json_decode($data, true);
-            } catch (\Exception $exception) {
+            } catch(\Exception $exception) {
                 // do nothing
             }
         }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -563,9 +563,9 @@ class Raven_Client
         // if the $_POST super global is empty, try to retrieve a json string 
         if(empty($_POST)){
             try {
-                $data = file_get_contents( 'php://input' );
-                $result['data'] = json_decode( $data, true );
-            } catch ( Exception $exception ) {
+                $data = file_get_contents('php://input');
+                $result['data'] = json_decode($data, true);
+            } catch (\Exception $exception) {
                 // do nothing
             }
         }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -561,7 +561,8 @@ class Raven_Client
         }
         
         // if the $_POST super global is empty, try to retrieve a json string
-        if (empty($_POST)) {
+        // prior to PHP 5.6, a stream opened with php://input could only be read once, so only do this with 5.6 or up
+        if (version_compare(PHP_VERSION, '5.6', '>=') && empty($_POST)) {
             try {
                 $data = file_get_contents('php://input');
                 $result['data'] = json_decode($data, true);

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -560,8 +560,8 @@ class Raven_Client
             $result['data'] = $_POST;
         }
         
-        // if the $_POST super global is empty, try to retrieve a json string 
-        if(empty($_POST)){
+        // if the $_POST super global is empty, try to retrieve a json string
+        if(empty($_POST)) {
             try {
                 $data = file_get_contents('php://input');
                 $result['data'] = json_decode($data, true);


### PR DESCRIPTION
As it becomes more common for the php apps to be backend/api only, it becomes more common for communication to be done via json data.  When you POST a json string to the php backend, there is no $_POST data, therefore this context is lost.  This PR suggests a solution which tries to retrieve the json string data if no $_POST data is set. 