### PR TITLE
Add processors to remove POST data and cookies - fixes #405

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@
 - The default exception handler will now re-raise exceptions when
   ``call_existing`` is true and no exception handler is registered (#421).
 - Collect User.ip_address automatically (#419).
+- Added a processor to remove web cookies and another to remove HTTP body data for POST, PUT, PATCH and DELETE requests. They will be enabled by default in ``2.0`` (#405).
 
 1.6.2
 -----

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -380,7 +380,7 @@ class Raven_Client
     public static function getDefaultProcessors()
     {
         return array(
-            'Raven_SanitizeDataProcessor',
+            'Raven_Processor_SanitizeDataProcessor',
         );
     }
 

--- a/lib/Raven/Processor.php
+++ b/lib/Raven/Processor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Base class for data processing.
  *
@@ -6,16 +7,33 @@
  */
 abstract class Raven_Processor
 {
-    protected $client;
     /**
-     * Raven_Processor constructor.
+     * This constant defines the mask string used to strip sensitive informations.
+     */
+    const STRING_MASK = '********';
+
+    /**
+     * @var Raven_Client The Raven client
+     */
+    protected $client;
+
+    /**
+     * Class constructor.
      *
-     * @param Raven_Client $client
-     * @codeCoverageIgnore
+     * @param Raven_Client $client The Raven client
      */
     public function __construct(Raven_Client $client)
     {
         $this->client = $client;
+    }
+
+    /**
+     * Override the default processor options
+     *
+     * @param array $options Associative array of processor options
+     */
+    public function setProcessorOptions(array $options)
+    {
     }
 
     /**
@@ -24,11 +42,4 @@ abstract class Raven_Processor
      * @param array $data Array of log data
      */
     abstract public function process(&$data);
-
-    /**
-     * Override the default processor options
-     *
-     * @param array $options Associative array of processor options
-     */
-    abstract public function setProcessorOptions(array $options);
 }

--- a/lib/Raven/Processor/RemoveCookiesProcessor.php
+++ b/lib/Raven/Processor/RemoveCookiesProcessor.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This processor removes all the cookies from the request to ensure no sensitive
+ * informations are sent to the server.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class Raven_Processor_RemoveCookiesProcessor extends Raven_Processor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(&$data)
+    {
+        if (isset($data['request'])) {
+            if (isset($data['request']['cookies'])) {
+                $data['request']['cookies'] = self::STRING_MASK;
+            }
+
+            if (isset($data['request']['headers']) && isset($data['request']['headers']['Cookie'])) {
+                $data['request']['headers']['Cookie'] = self::STRING_MASK;
+            }
+        }
+    }
+}

--- a/lib/Raven/Processor/RemoveHttpBodyProcessor.php
+++ b/lib/Raven/Processor/RemoveHttpBodyProcessor.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This processor removes all the data of the HTTP body to ensure no sensitive
+ * informations are sent to the server in case the request method is POST, PUT,
+ * PATCH or DELETE.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class Raven_Processor_RemoveHttpBodyProcessor extends Raven_Processor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(&$data)
+    {
+        if (isset($data['request'], $data['request']['method']) && in_array(strtoupper($data['request']['method']), array('POST', 'PUT', 'PATCH', 'DELETE'))) {
+            $data['request']['data'] = self::STRING_MASK;
+        }
+    }
+}

--- a/lib/Raven/Processor/SanitizeDataProcessor.php
+++ b/lib/Raven/Processor/SanitizeDataProcessor.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * Asterisk out passwords from password fields in frames, http,
+ * and basic extra data.
+ *
+ * @package raven
+ */
+class Raven_Processor_SanitizeDataProcessor extends Raven_Processor
+{
+    const MASK = self::STRING_MASK;
+    const FIELDS_RE = '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i';
+    const VALUES_RE = '/^(?:\d[ -]*?){13,16}$/';
+
+    protected $fields_re;
+    protected $values_re;
+    protected $session_cookie_name;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Raven_Client $client)
+    {
+        parent::__construct($client);
+
+        $this->fields_re = self::FIELDS_RE;
+        $this->values_re = self::VALUES_RE;
+        $this->session_cookie_name = ini_get('session.name');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProcessorOptions(array $options)
+    {
+        if (isset($options['fields_re'])) {
+            $this->fields_re = $options['fields_re'];
+        }
+
+        if (isset($options['values_re'])) {
+            $this->values_re = $options['values_re'];
+        }
+    }
+
+    /**
+     * Replace any array values with our mask if the field name or the value matches a respective regex
+     *
+     * @param mixed $item       Associative array value
+     * @param string $key       Associative array key
+     */
+    public function sanitize(&$item, $key)
+    {
+        if (empty($item)) {
+            return;
+        }
+
+        if (preg_match($this->values_re, $item)) {
+            $item = self::STRING_MASK;
+        }
+
+        if (empty($key)) {
+            return;
+        }
+
+        if (preg_match($this->fields_re, $key)) {
+            $item = self::STRING_MASK;
+        }
+    }
+
+    public function sanitizeException(&$data)
+    {
+        foreach ($data['exception']['values'] as &$value) {
+            return $this->sanitizeStacktrace($value['stacktrace']);
+        }
+    }
+
+    public function sanitizeHttp(&$data)
+    {
+        $http = &$data['request'];
+        if (!empty($http['cookies']) && is_array($http['cookies'])) {
+            $cookies = &$http['cookies'];
+            if (!empty($cookies[$this->session_cookie_name])) {
+                $cookies[$this->session_cookie_name] = self::STRING_MASK;
+            }
+        }
+        if (!empty($http['data']) && is_array($http['data'])) {
+            array_walk_recursive($http['data'], array($this, 'sanitize'));
+        }
+    }
+
+    public function sanitizeStacktrace(&$data)
+    {
+        foreach ($data['frames'] as &$frame) {
+            if (empty($frame['vars'])) {
+                continue;
+            }
+            array_walk_recursive($frame['vars'], array($this, 'sanitize'));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(&$data)
+    {
+        if (!empty($data['exception'])) {
+            $this->sanitizeException($data);
+        }
+        if (!empty($data['stacktrace'])) {
+            $this->sanitizeStacktrace($data['stacktrace']);
+        }
+        if (!empty($data['request'])) {
+            $this->sanitizeHttp($data);
+        }
+        if (!empty($data['extra'])) {
+            array_walk_recursive($data['extra'], array($this, 'sanitize'));
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getFieldsRe()
+    {
+        return $this->fields_re;
+    }
+
+    /**
+     * @param string $fields_re
+     */
+    public function setFieldsRe($fields_re)
+    {
+        $this->fields_re = $fields_re;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValuesRe()
+    {
+        return $this->values_re;
+    }
+
+    /**
+     * @param string $values_re
+     */
+    public function setValuesRe($values_re)
+    {
+        $this->values_re = $values_re;
+    }
+}

--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -1,148 +1,19 @@
 <?php
-/**
- * Asterisk out passwords from password fields in frames, http,
- * and basic extra data.
+
+/*
+ * This file is part of Raven.
  *
- * @package raven
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
  */
-class Raven_SanitizeDataProcessor extends Raven_Processor
+
+@trigger_error('The '.__NAMESPACE__.'\Raven_SanitizeDataProcessor class is deprecated since version 1.7 and will be removed in 2.0. Use the Raven_Processor_SanitizeDataProcessor class in the same namespace instead.', E_USER_DEPRECATED);
+
+/**
+ * {@inheritdoc}
+ */
+class Raven_SanitizeDataProcessor extends Raven_Processor_SanitizeDataProcessor
 {
-    const MASK = '********';
-    const FIELDS_RE = '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i';
-    const VALUES_RE = '/^(?:\d[ -]*?){13,16}$/';
-
-    protected $fields_re;
-    protected $values_re;
-    protected $session_cookie_name;
-
-    public function __construct(Raven_Client $client)
-    {
-        parent::__construct($client);
-        $this->fields_re    = self::FIELDS_RE;
-        $this->values_re    = self::VALUES_RE;
-        $this->session_cookie_name = ini_get('session.name');
-    }
-
-    /**
-     * Override the default processor options
-     *
-     * @param array $options Associative array of processor options
-     */
-    public function setProcessorOptions(array $options)
-    {
-        if (isset($options['fields_re'])) {
-            $this->fields_re = $options['fields_re'];
-        }
-
-        if (isset($options['values_re'])) {
-            $this->values_re = $options['values_re'];
-        }
-    }
-
-    /**
-     * Replace any array values with our mask if the field name or the value matches a respective regex
-     *
-     * @param mixed  $item Associative array value
-     * @param string $key  Associative array key
-     */
-    public function sanitize(&$item, $key)
-    {
-        if (empty($item)) {
-            return;
-        }
-
-        if (preg_match($this->values_re, $item)) {
-            $item = self::MASK;
-        }
-
-        if (empty($key)) {
-            return;
-        }
-
-        if (preg_match($this->fields_re, $key)) {
-            $item = self::MASK;
-        }
-    }
-
-    /** @noinspection PhpInconsistentReturnPointsInspection
-     * @param array $data
-     */
-    public function sanitizeException(&$data)
-    {
-        foreach ($data['exception']['values'] as &$value) {
-            return $this->sanitizeStacktrace($value['stacktrace']);
-        }
-    }
-
-    public function sanitizeHttp(&$data)
-    {
-        $http = &$data['request'];
-        if (!empty($http['cookies'])) {
-            $cookies = &$http['cookies'];
-            if (!empty($cookies[$this->session_cookie_name])) {
-                $cookies[$this->session_cookie_name] = self::MASK;
-            }
-        }
-        if (!empty($http['data']) && is_array($http['data'])) {
-            array_walk_recursive($http['data'], array($this, 'sanitize'));
-        }
-    }
-
-    public function sanitizeStacktrace(&$data)
-    {
-        foreach ($data['frames'] as &$frame) {
-            if (empty($frame['vars'])) {
-                continue;
-            }
-            array_walk_recursive($frame['vars'], array($this, 'sanitize'));
-        }
-    }
-
-    public function process(&$data)
-    {
-        if (!empty($data['exception'])) {
-            $this->sanitizeException($data);
-        }
-        if (!empty($data['stacktrace'])) {
-            $this->sanitizeStacktrace($data['stacktrace']);
-        }
-        if (!empty($data['request'])) {
-            $this->sanitizeHttp($data);
-        }
-        if (!empty($data['extra'])) {
-            array_walk_recursive($data['extra'], array($this, 'sanitize'));
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function getFieldsRe()
-    {
-        return $this->fields_re;
-    }
-
-    /**
-     * @param string $fields_re
-     */
-    public function setFieldsRe($fields_re)
-    {
-        $this->fields_re = $fields_re;
-    }
-
-    /**
-     * @return string
-     */
-    public function getValuesRe()
-    {
-        return $this->values_re;
-    }
-
-    /**
-     * @param string $values_re
-     */
-    public function setValuesRe($values_re)
-    {
-        $this->values_re = $values_re;
-    }
 }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -690,10 +690,11 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     public function testDoesRegisterProcessors()
     {
         $client = new Dummy_Raven_Client(array(
-            'processors' => array('Raven_SanitizeDataProcessor'),
+            'processors' => array('Raven_Processor_SanitizeDataProcessor'),
         ));
+
         $this->assertEquals(1, count($client->processors));
-        $this->assertInstanceOf('Raven_SanitizeDataProcessor', $client->processors[0]);
+        $this->assertInstanceOf('Raven_Processor_SanitizeDataProcessor', $client->processors[0]);
     }
 
     public function testProcessDoesCallProcessors()
@@ -729,9 +730,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      */
     public function testDefaultProcessorsContainSanitizeDataProcessor()
     {
-        $defaults = Dummy_Raven_Client::getDefaultProcessors();
-
-        $this->assertTrue(in_array('Raven_SanitizeDataProcessor', $defaults));
+        $this->assertContains('Raven_Processor_SanitizeDataProcessor', Dummy_Raven_Client::getDefaultProcessors());
     }
 
     /**
@@ -2095,7 +2094,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         }
 
         $client = new Dummy_Raven_Client();
-        $client->capture(array('message' => 'foobar', ));
+        $client->capture(array('message' => 'foobar'));
         $events = $client->getSentEvents();
         $event = array_pop($events);
         $input = $client->get_http_data();

--- a/test/Raven/Tests/Processor/RemoveCookiesProcessorTest.php
+++ b/test/Raven/Tests/Processor/RemoveCookiesProcessorTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_Tests_RemoveCookiesProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Raven_Processor_RemoveCookiesProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $processor;
+
+    protected function setUp()
+    {
+        /** @var \Raven_Client|\PHPUnit_Framework_MockObject_MockObject $client */
+        $client = $this->getMockBuilder('\Raven_Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->processor = new Raven_Processor_RemoveCookiesProcessor($client);
+    }
+
+    /**
+     * @dataProvider processDataProvider
+     */
+    public function testProcess($inputData, $expectedData)
+    {
+        $this->processor->process($inputData);
+
+        $this->assertArraySubset($expectedData, $inputData);
+    }
+
+    public function processDataProvider()
+    {
+        return array(
+            array(
+                array(
+                    'request' => array(
+                        'foo' => 'bar',
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'foo' => 'bar',
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'request' => array(
+                        'foo' => 'bar',
+                        'cookies' => 'baz',
+                        'headers' => array(
+                            'Cookie' => 'bar',
+                            'AnotherHeader' => 'foo',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'foo' => 'bar',
+                        'cookies' => Raven_Processor::STRING_MASK,
+                        'headers' => array(
+                            'Cookie' => Raven_Processor::STRING_MASK,
+                            'AnotherHeader' => 'foo',
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+}

--- a/test/Raven/Tests/Processor/RemoveHttpBodyProcessorTest.php
+++ b/test/Raven/Tests/Processor/RemoveHttpBodyProcessorTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_Tests_RemoveHttpBodyProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Raven_Processor_RemoveHttpBodyProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $processor;
+
+    protected function setUp()
+    {
+        /** @var \Raven_Client|\PHPUnit_Framework_MockObject_MockObject $client */
+        $client = $this->getMockBuilder('\Raven_Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->processor = new Raven_Processor_RemoveHttpBodyProcessor($client);
+    }
+
+    /**
+     * @dataProvider processDataProvider
+     */
+    public function testProcess($inputData, $expectedData)
+    {
+        $this->processor->process($inputData);
+
+        $this->assertArraySubset($expectedData, $inputData);
+    }
+
+    public function processDataProvider()
+    {
+        return array(
+            array(
+                array(
+                    'request' => array(
+                        'method' => 'POST',
+                        'data' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'data' => Raven_Processor::STRING_MASK,
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'request' => array(
+                        'method' => 'PUT',
+                        'data' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'data' => Raven_Processor::STRING_MASK,
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'request' => array(
+                        'method' => 'PATCH',
+                        'data' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'data' => Raven_Processor::STRING_MASK,
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'request' => array(
+                        'method' => 'DELETE',
+                        'data' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'data' => Raven_Processor::STRING_MASK,
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'request' => array(
+                        'method' => 'GET',
+                        'data' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'data' => array(
+                            'foo' => 'bar',
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+}

--- a/test/Raven/Tests/Processor/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/Processor/SanitizeDataProcessorTest.php
@@ -33,20 +33,20 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         );
 
         $client = new Dummy_Raven_Client();
-        $processor = new Raven_SanitizeDataProcessor($client);
+        $processor = new Raven_Processor_SanitizeDataProcessor($client);
         $processor->process($data);
 
         $vars = $data['request']['data'];
         $this->assertEquals($vars['foo'], 'bar');
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['password']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['the_secret']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['a_password_here']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['mypasswd']);
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['authorization']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['password']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['the_secret']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['a_password_here']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['mypasswd']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['authorization']);
 
         $this->markTestIncomplete('Array scrubbing has not been implemented yet.');
 
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['card_number']['0']);
     }
 
     public function testDoesFilterSessionId()
@@ -60,11 +60,11 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         );
 
         $client = new Dummy_Raven_Client();
-        $processor = new Raven_SanitizeDataProcessor($client);
+        $processor = new Raven_Processor_SanitizeDataProcessor($client);
         $processor->process($data);
 
         $cookies = $data['request']['cookies'];
-        $this->assertEquals($cookies[ini_get('session.name')], Raven_SanitizeDataProcessor::MASK);
+        $this->assertEquals($cookies[ini_get('session.name')], Raven_Processor_SanitizeDataProcessor::STRING_MASK);
     }
 
     public function testDoesFilterCreditCard()
@@ -76,20 +76,16 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         );
 
         $client = new Dummy_Raven_Client();
-        $processor = new Raven_SanitizeDataProcessor($client);
+        $processor = new Raven_Processor_SanitizeDataProcessor($client);
         $processor->process($data);
 
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $data['extra']['ccnumba']);
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $data['extra']['ccnumba']);
     }
 
-    /**
-     * @covers Raven_SanitizeDataProcessor::setProcessorOptions
-     *
-     */
     public function testSettingProcessorOptions()
     {
         $client     = new Dummy_Raven_Client();
-        $processor  = new Raven_SanitizeDataProcessor($client);
+        $processor  = new Raven_Processor_SanitizeDataProcessor($client);
 
         $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i', 'got default fields');
         $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){13,16}$/', 'got default values');
@@ -116,13 +112,13 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client($dsn, $client_options);
         /**
-         * @var Raven_SanitizeDataProcessor $processor
+         * @var Raven_Processor_SanitizeDataProcessor $processor
          */
         $processor = $client->processors[0];
 
-        $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
-        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'], 'overwrote values');
+        $this->assertInstanceOf('Raven_Processor_SanitizeDataProcessor', $processor);
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_Processor_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_Processor_SanitizeDataProcessor']['values_re'], 'overwrote values');
     }
 
     /**
@@ -155,13 +151,13 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
 
         $client = new Dummy_Raven_Client($dsn, $client_options);
         /**
-         * @var Raven_SanitizeDataProcessor $processor
+         * @var Raven_Processor_SanitizeDataProcessor $processor
          */
         $processor = $client->processors[0];
 
-        $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
-        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
-        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_SanitizeDataProcessor']['values_re'], 'overwrote values');
+        $this->assertInstanceOf('Raven_Processor_SanitizeDataProcessor', $processor);
+        $this->assertEquals($processor->getFieldsRe(), $processorOptions['Raven_Processor_SanitizeDataProcessor']['fields_re'], 'overwrote fields');
+        $this->assertEquals($processor->getValuesRe(), $processorOptions['Raven_Processor_SanitizeDataProcessor']['values_re'], 'overwrote values');
 
         $processor->process($data);
 
@@ -172,9 +168,9 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($vars['a_password_here'], 'hello', 'did not alter a_password_here');
         $this->assertEquals($vars['mypasswd'], 'hello', 'did not alter mypasswd');
         $this->assertEquals($vars['authorization'], 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=', 'did not alter authorization');
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['api_token'], 'masked api_token');
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['api_token'], 'masked api_token');
 
-        $this->assertEquals(Raven_SanitizeDataProcessor::MASK, $vars['card_number']['0'], 'masked card_number[0]');
+        $this->assertEquals(Raven_Processor_SanitizeDataProcessor::STRING_MASK, $vars['card_number']['0'], 'masked card_number[0]');
         $this->assertEquals($vars['card_number']['1'], $vars['card_number']['1'], 'did not alter card_number[1]');
     }
 
@@ -186,14 +182,14 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
     public static function overrideDataProvider()
     {
         $processorOptions = array(
-            'Raven_SanitizeDataProcessor' => array(
+            'Raven_Processor_SanitizeDataProcessor' => array(
                 'fields_re' => '/(api_token)/i',
                 'values_re' => '/^(?:\d[ -]*?){15,16}$/'
             )
         );
 
         $client_options = array(
-            'processors' => array('Raven_SanitizeDataProcessor'),
+            'processors' => array('Raven_Processor_SanitizeDataProcessor'),
             'processorOptions' => $processorOptions
         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| Fixed tickets | #405 

The POST data and the cookies could leak sensitive informations, so they are both cleared before submitting the data to the server.