### PR TITLE
PHPDoc, properties of classes, warnings, code coverage, code style

### DIFF
--- a/lib/Raven/Breadcrumbs.php
+++ b/lib/Raven/Breadcrumbs.php
@@ -16,13 +16,13 @@
 
 class Raven_Breadcrumbs
 {
-    var $count;
-    var $pos;
-    var $size;
+    public $count;
+    public $pos;
+    public $size;
     /**
      * @var array[]
      */
-    var $buffer;
+    public $buffer;
 
     public function __construct($size = 100)
     {

--- a/lib/Raven/Breadcrumbs.php
+++ b/lib/Raven/Breadcrumbs.php
@@ -16,6 +16,14 @@
 
 class Raven_Breadcrumbs
 {
+    var $count;
+    var $pos;
+    var $size;
+    /**
+     * @var array[]
+     */
+    var $buffer;
+
     public function __construct($size = 100)
     {
         $this->count = 0;
@@ -34,6 +42,9 @@ class Raven_Breadcrumbs
         $this->count++;
     }
 
+    /**
+     * @return array[]
+     */
     public function fetch()
     {
         $results = array();

--- a/lib/Raven/Breadcrumbs/ErrorHandler.php
+++ b/lib/Raven/Breadcrumbs/ErrorHandler.php
@@ -11,15 +11,13 @@ class Raven_Breadcrumbs_ErrorHandler
 
     /**
      * @param Raven_Client $ravenClient
-     * @param int          $level       The minimum logging level at which this handler will be triggered
-     * @param Boolean      $bubble      Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(Raven_Client $ravenClient)
     {
         $this->ravenClient = $ravenClient;
     }
 
-    public function handleError($code, $message, $file = '', $line = 0, $context=array())
+    public function handleError($code, $message, $file = '', $line = 0, $context = array())
     {
         $this->ravenClient->breadcrumbs->record(array(
             'category' => 'error_reporting',

--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -29,7 +29,7 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
     /**
      * @param Raven_Client $ravenClient
      * @param int          $level       The minimum logging level at which this handler will be triggered
-     * @param Boolean      $bubble      Whether the messages that are handled can bubble up the stack or not
+     * @param bool         $bubble      Whether the messages that are handled can bubble up the stack or not
      */
     public function __construct(Raven_Client $ravenClient, $level = Logger::DEBUG, $bubble = true)
     {
@@ -38,13 +38,17 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
         $this->ravenClient = $ravenClient;
     }
 
+    /**
+     * @param string $message
+     * @return array|null
+     */
     protected function parseException($message)
     {
-        if (!preg_match($this->excMatch, $message, $matches)) {
-            return;
+        if (preg_match($this->excMatch, $message, $matches)) {
+            return array($matches[1], $matches[2]);
         }
 
-        return array($matches[1], $matches[2]);
+        return null;
     }
 
     /**
@@ -58,6 +62,9 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
         }
 
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
+            /**
+             * @var Exception $exc
+             */
             $exc = $record['context']['exception'];
             $crumb = array(
                 'type' => 'error',

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -128,7 +128,7 @@ class Raven_Client
         $this->project = Raven_Util::get($options, 'project', 1);
         $this->auto_log_stacks = (bool) Raven_Util::get($options, 'auto_log_stacks', false);
         $this->name = Raven_Util::get($options, 'name', Raven_Compat::gethostname());
-        $this->site = Raven_Util::get($options, 'site', $this->_server_variable('SERVER_NAME'));
+        $this->site = Raven_Util::get($options, 'site', self::_server_variable('SERVER_NAME'));
         $this->tags = Raven_Util::get($options, 'tags', array());
         $this->release = Raven_Util::get($options, 'release', null);
         $this->environment = Raven_Util::get($options, 'environment', null);
@@ -155,7 +155,7 @@ class Raven_Client
         $this->setAppPath(Raven_Util::get($options, 'app_path', null));
         $this->setExcludedAppPaths(Raven_Util::get($options, 'excluded_app_paths', null));
         // a list of prefixes used to coerce absolute paths into relative
-        $this->setPrefixes(Raven_Util::get($options, 'prefixes', $this->getDefaultPrefixes()));
+        $this->setPrefixes(Raven_Util::get($options, 'prefixes', static::getDefaultPrefixes()));
         $this->processors = $this->setProcessorsFromOptions($options);
 
         $this->_lasterror = null;
@@ -225,13 +225,13 @@ class Raven_Client
         return $this;
     }
 
-    private function getDefaultPrefixes()
+    private static function getDefaultPrefixes()
     {
         $value = get_include_path();
         return explode(PATH_SEPARATOR, $value);
     }
 
-    private function _convertPath($value)
+    private static function _convertPath($value)
     {
         $path = @realpath($value);
         if ($path === false) {
@@ -254,7 +254,7 @@ class Raven_Client
     public function setAppPath($value)
     {
         if ($value) {
-            $this->app_path = $this->_convertPath($value);
+            $this->app_path = static::_convertPath($value);
         } else {
             $this->app_path = null;
         }
@@ -312,7 +312,7 @@ class Raven_Client
         return $this->server;
     }
 
-    public function getUserAgent()
+    public static function getUserAgent()
     {
         return 'sentry-php/' . self::VERSION;
     }
@@ -353,7 +353,7 @@ class Raven_Client
     public function setProcessorsFromOptions($options)
     {
         $processors = array();
-        foreach (Raven_util::get($options, 'processors', self::getDefaultProcessors()) as $processor) {
+        foreach (Raven_util::get($options, 'processors', static::getDefaultProcessors()) as $processor) {
             /**
              * @var Raven_Processor        $new_processor
              * @var Raven_Processor|string $processor
@@ -642,9 +642,9 @@ class Raven_Client
         }
 
         $result = array(
-            'method' => $this->_server_variable('REQUEST_METHOD'),
+            'method' => self::_server_variable('REQUEST_METHOD'),
             'url' => $this->get_current_url(),
-            'query_string' => $this->_server_variable('QUERY_STRING'),
+            'query_string' => self::_server_variable('QUERY_STRING'),
         );
 
         // dont set this as an empty array as PHP will treat it as a numeric array
@@ -717,7 +717,7 @@ class Raven_Client
             $data['extra'] = array();
         }
         if (!isset($data['event_id'])) {
-            $data['event_id'] = $this->uuid4();
+            $data['event_id'] = static::uuid4();
         }
 
         if (isset($data['message'])) {
@@ -899,7 +899,7 @@ class Raven_Client
         $message = $this->encode($data);
 
         $headers = array(
-            'User-Agent' => $this->getUserAgent(),
+            'User-Agent' => static::getUserAgent(),
             'X-Sentry-Auth' => $this->getAuthHeader(),
             'Content-Type' => 'application/octet-stream'
         );
@@ -1074,7 +1074,7 @@ class Raven_Client
      * @param string $secret_key Sentry API key
      * @return string
      */
-    protected function get_auth_header($timestamp, $client, $api_key, $secret_key)
+    protected static function get_auth_header($timestamp, $client, $api_key, $secret_key)
     {
         $header = array(
             sprintf('sentry_timestamp=%F', $timestamp),
@@ -1097,7 +1097,7 @@ class Raven_Client
     public function getAuthHeader()
     {
         $timestamp = microtime(true);
-        return $this->get_auth_header($timestamp, $this->getUserAgent(), $this->public_key, $this->secret_key);
+        return $this->get_auth_header($timestamp, static::getUserAgent(), $this->public_key, $this->secret_key);
     }
 
     /**
@@ -1105,7 +1105,7 @@ class Raven_Client
      *
      * @return string
      */
-    private function uuid4()
+    private static function uuid4()
     {
         $uuid = sprintf('%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
             // 32 bits for "time_low"
@@ -1181,7 +1181,7 @@ class Raven_Client
      * @param string $key Key whose value you wish to obtain
      * @return string     Key's value
      */
-    private function _server_variable($key)
+    private static function _server_variable($key)
     {
         if (isset($_SERVER[$key])) {
             return $_SERVER[$key];

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -93,7 +93,7 @@ class Raven_Client
      */
     var $processors;
     /**
-     * @var string|integer|null
+     * @var string|int|null
      */
     var $_lasterror;
     var $_last_event_id;
@@ -101,7 +101,7 @@ class Raven_Client
     var $_pending_events;
     var $sdk;
 
-    public function __construct($options_or_dsn=null, $options=array())
+    public function __construct($options_or_dsn = null, $options = array())
     {
         if (is_array($options_or_dsn)) {
             $options = array_merge($options_or_dsn, $options);
@@ -283,7 +283,7 @@ class Raven_Client
 
     /**
      * @param array $value
-     * @return $this
+     * @return Raven_Client
      */
     public function setPrefixes($value)
     {
@@ -373,8 +373,8 @@ class Raven_Client
     /**
      * Parses a Raven-compatible DSN and returns an array of its values.
      *
-     * @param string    $dsn    Raven compatible DSN: http://raven.readthedocs.org/en/latest/config/#the-sentry-dsn
-     * @return array            parsed DSN
+     * @param string $dsn Raven compatible DSN: http://raven.readthedocs.org/en/latest/config/#the-sentry-dsn
+     * @return array      parsed DSN
      */
     public static function parseDSN($dsn)
     {
@@ -384,7 +384,7 @@ class Raven_Client
             throw new InvalidArgumentException('Unsupported Sentry DSN scheme: ' . (!empty($scheme) ? $scheme : '<not set>'));
         }
         $netloc = (isset($url['host']) ? $url['host'] : null);
-        $netloc.= (isset($url['port']) ? ':'.$url['port'] : null);
+        $netloc .= (isset($url['port']) ? ':'.$url['port'] : null);
         $rawpath = (isset($url['path']) ? $url['path'] : null);
         if ($rawpath) {
             $pos = strrpos($rawpath, '/', 1);
@@ -431,16 +431,16 @@ class Raven_Client
     }
 
     /**
-     * @param string $message The message (primary description) for the event.
-     * @param array $params params to use when formatting the message.
-     * @param string $level Log level group
-     * @param boolean|array $stack
-     * @param mixed $vars
+     * @param string     $message The message (primary description) for the event.
+     * @param array      $params  params to use when formatting the message.
+     * @param string     $level   Log level group
+     * @param bool|array $stack
+     * @param mixed      $vars
      * @return string|null
      * @deprecated
      */
-    public function message($message, $params=array(), $level=self::INFO,
-                            $stack=false, $vars = null)
+    public function message($message, $params = array(), $level = self::INFO,
+                            $stack = false, $vars = null)
     {
         return $this->captureMessage($message, $params, $level, $stack, $vars);
     }
@@ -458,15 +458,15 @@ class Raven_Client
     /**
      * Log a message to sentry
      *
-     * @param string $message The message (primary description) for the event.
-     * @param array $params params to use when formatting the message.
-     * @param array $data Additional attributes to pass with this event (see Sentry docs).
-     * @param boolean|array $stack
-     * @param mixed $vars
+     * @param string     $message The message (primary description) for the event.
+     * @param array      $params  params to use when formatting the message.
+     * @param array      $data    Additional attributes to pass with this event (see Sentry docs).
+     * @param bool|array $stack
+     * @param mixed      $vars
      * @return string|null
      */
-    public function captureMessage($message, $params=array(), $data=array(),
-                            $stack=false, $vars = null)
+    public function captureMessage($message, $params = array(), $data = array(),
+                            $stack = false, $vars = null)
     {
         // Gracefully handle messages which contain formatting characters, but were not
         // intended to be used with formatting.
@@ -499,12 +499,12 @@ class Raven_Client
      * Log an exception to sentry
      *
      * @param Exception $exception The Exception object.
-     * @param array $data Additional attributes to pass with this event (see Sentry docs).
-     * @param mixed $logger
-     * @param mixed $vars
+     * @param array     $data      Additional attributes to pass with this event (see Sentry docs).
+     * @param mixed     $logger
+     * @param mixed     $vars
      * @return string|null
      */
-    public function captureException($exception, $data=null, $logger=null, $vars=null)
+    public function captureException($exception, $data = null, $logger = null, $vars = null)
     {
         $has_chained_exceptions = version_compare(PHP_VERSION, '5.3.0', '>=');
 
@@ -589,11 +589,12 @@ class Raven_Client
 
     /**
      * Log an query to sentry
+     *
      * @param string|null $query
-     * @param string $level
-     * @param string $engine
+     * @param string      $level
+     * @param string      $engine
      */
-    public function captureQuery($query, $level=self::INFO, $engine = '')
+    public function captureQuery($query, $level = self::INFO, $engine = '')
     {
         $data = array(
             'message' => $query,
@@ -827,7 +828,7 @@ class Raven_Client
     /**
      * Process data through all defined Raven_Processor sub-classes
      *
-     * @param array     $data       Associative array of data to log
+     * @param array $data Associative array of data to log
      */
     public function process(&$data)
     {
@@ -850,7 +851,7 @@ class Raven_Client
 
     /**
      * @param string $data
-     * @return string|boolean
+     * @return string|bool
      */
     public function encode(&$data)
     {
@@ -909,11 +910,11 @@ class Raven_Client
     /**
      * Send data to Sentry
      *
-     * @param string    $url        Full URL to Sentry
+     * @param string       $url     Full URL to Sentry
      * @param array|string $data    Associative array of data to log
-     * @param array     $headers    Associative array of headers
+     * @param array        $headers Associative array of headers
      */
-    private function send_remote($url, $data, $headers=array())
+    private function send_remote($url, $data, $headers = array())
     {
         $parts = parse_url($url);
         $parts['netloc'] = $parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : null);
@@ -967,11 +968,11 @@ class Raven_Client
     /**
      * Send the message over http to the sentry url given
      *
-     * @param string $url       URL of the Sentry instance to log to
-     * @param array|string $data Associative array of data to log
-     * @param array $headers    Associative array of headers
+     * @param string       $url     URL of the Sentry instance to log to
+     * @param array|string $data    Associative array of data to log
+     * @param array        $headers Associative array of headers
      */
-    private function send_http($url, $data, $headers=array())
+    private function send_http($url, $data, $headers = array())
     {
         if ($this->curl_method == 'async') {
             $this->_curl_handler->enqueue($url, $data, $headers);
@@ -1003,9 +1004,9 @@ class Raven_Client
     /**
      * Send the cURL to Sentry asynchronously. No errors will be returned from cURL
      *
-     * @param string    $url        URL of the Sentry instance to log to
+     * @param string       $url     URL of the Sentry instance to log to
      * @param array|string $data    Associative array of data to log
-     * @param array     $headers    Associative array of headers
+     * @param array        $headers Associative array of headers
      * @return bool
      */
     private function send_http_asynchronous_curl_exec($url, $data, $headers)
@@ -1017,9 +1018,9 @@ class Raven_Client
     /**
      * Send a blocking cURL to Sentry and check for errors from cURL
      *
-     * @param string    $url        URL of the Sentry instance to log to
-     * @param array|string $data   Associative array of data to log
-     * @param array     $headers    Associative array of headers
+     * @param string       $url     URL of the Sentry instance to log to
+     * @param array|string $data    Associative array of data to log
+     * @param array        $headers Associative array of headers
      * @return bool
      */
     private function send_http_synchronous($url, $data, $headers)
@@ -1067,10 +1068,10 @@ class Raven_Client
     /**
      * Generate a Sentry authorization header string
      *
-     * @param string    $timestamp      Timestamp when the event occurred
-     * @param string    $client         HTTP client name (not Raven_Client object)
-     * @param string    $api_key        Sentry API key
-     * @param string    $secret_key     Sentry API key
+     * @param string $timestamp  Timestamp when the event occurred
+     * @param string $client     HTTP client name (not Raven_Client object)
+     * @param string $api_key    Sentry API key
+     * @param string $secret_key Sentry API key
      * @return string
      */
     protected function get_auth_header($timestamp, $client, $api_key, $secret_key)
@@ -1177,8 +1178,8 @@ class Raven_Client
     /**
      * Get the value of a key from $_SERVER
      *
-     * @param string $key       Key whose value you wish to obtain
-     * @return string           Key's value
+     * @param string $key Key whose value you wish to obtain
+     * @return string     Key's value
      */
     private function _server_variable($key)
     {
@@ -1192,8 +1193,8 @@ class Raven_Client
     /**
      * Translate a PHP Error constant into a Sentry log level group
      *
-     * @param string $severity  PHP E_$x error constant
-     * @return string           Sentry log level group
+     * @param string $severity PHP E_$x error constant
+     * @return string          Sentry log level group
      */
     public function translateSeverity($severity)
     {
@@ -1239,11 +1240,11 @@ class Raven_Client
      * Convenience function for setting a user's ID and Email
      *
      * @deprecated
-     * @param string $id            User's ID
-     * @param string|null $email    User's email
-     * @param array $data           Additional user data
+     * @param string      $id    User's ID
+     * @param string|null $email User's email
+     * @param array       $data  Additional user data
      */
-    public function set_user_data($id, $email=null, $data=array())
+    public function set_user_data($id, $email = null, $data = array())
     {
         $user = array('id' => $id);
         if (isset($email)) {
@@ -1266,10 +1267,10 @@ class Raven_Client
     /**
      * Sets user context.
      *
-     * @param array $data   Associative array of user data
-     * @param bool $merge   Merge existing context with new context
+     * @param array $data  Associative array of user data
+     * @param bool  $merge Merge existing context with new context
      */
-    public function user_context($data, $merge=true)
+    public function user_context($data, $merge = true)
     {
         if ($merge && $this->context->user !== null) {
             // bail if data is null
@@ -1285,7 +1286,7 @@ class Raven_Client
     /**
      * Appends tags context.
      *
-     * @param array $data   Associative array of tags
+     * @param array $data Associative array of tags
      */
     public function tags_context($data)
     {
@@ -1295,7 +1296,7 @@ class Raven_Client
     /**
      * Appends additional context.
      *
-     * @param array $data   Associative array of extra data
+     * @param array $data Associative array of extra data
      */
     public function extra_context($data)
     {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -66,46 +66,46 @@ class Raven_Client
      */
     protected $transport;
 
-    var $logger;
+    public $logger;
     /**
      * @var string Full URL to Sentry
      */
-    var $server;
-    var $secret_key;
-    var $public_key;
-    var $project;
-    var $auto_log_stacks;
-    var $name;
-    var $site;
-    var $tags;
-    var $release;
-    var $environment;
-    var $trace;
-    var $timeout;
-    var $message_limit;
-    var $exclude;
-    var $http_proxy;
+    public $server;
+    public $secret_key;
+    public $public_key;
+    public $project;
+    public $auto_log_stacks;
+    public $name;
+    public $site;
+    public $tags;
+    public $release;
+    public $environment;
+    public $trace;
+    public $timeout;
+    public $message_limit;
+    public $exclude;
+    public $http_proxy;
     protected $send_callback;
-    var $curl_method;
-    var $curl_path;
-    var $curl_ipv4;
-    var $ca_cert;
-    var $verify_ssl;
-    var $curl_ssl_version;
-    var $trust_x_forwarded_proto;
-    var $mb_detect_order;
+    public $curl_method;
+    public $curl_path;
+    public $curl_ipv4;
+    public $ca_cert;
+    public $verify_ssl;
+    public $curl_ssl_version;
+    public $trust_x_forwarded_proto;
+    public $mb_detect_order;
     /**
      * @var Raven_Processor[]
      */
-    var $processors;
+    public $processors;
     /**
      * @var string|int|null
      */
-    var $_lasterror;
-    var $_last_event_id;
-    var $_user;
-    var $_pending_events;
-    var $sdk;
+    public $_lasterror;
+    public $_last_event_id;
+    public $_user;
+    public $_pending_events;
+    public $sdk;
     /**
      * @var Raven_CurlHandler
      */

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -177,8 +177,10 @@ class Raven_Client
         }
 
         $this->transaction = new Raven_TransactionStack();
-        if ($this->is_http_request() && isset($_SERVER['PATH_INFO'])) {
+        if (static::is_http_request() && isset($_SERVER['PATH_INFO'])) {
+            // @codeCoverageIgnoreStart
             $this->transaction->push($_SERVER['PATH_INFO']);
+            // @codeCoverageIgnoreEnd
         }
 
         if (Raven_Util::get($options, 'install_default_breadcrumb_handlers', true)) {
@@ -726,7 +728,7 @@ class Raven_Client
 
         $data = array_merge($this->get_default_data(), $data);
 
-        if ($this->is_http_request()) {
+        if (static::is_http_request()) {
             $data = array_merge($this->get_http_data(), $data);
         }
 
@@ -776,7 +778,9 @@ class Raven_Client
         if (!empty($stack)) {
             // manually trigger autoloading, as it's not done in some edge cases due to PHP bugs (see #60149)
             if (!class_exists('Raven_Stacktrace')) {
+                // @codeCoverageIgnoreStart
                 spl_autoload_call('Raven_Stacktrace');
+                // @codeCoverageIgnoreEnd
             }
 
             if (!isset($data['stacktrace']) && !isset($data['exception'])) {

--- a/lib/Raven/Compat.php
+++ b/lib/Raven/Compat.php
@@ -77,7 +77,9 @@ class Raven_Compat
             return json_encode($value);
         }
 
+        // @codeCoverageIgnoreStart
         return self::_json_encode($value);
+        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/lib/Raven/Compat.php
+++ b/lib/Raven/Compat.php
@@ -36,6 +36,12 @@ class Raven_Compat
 
     /**
      * Implementation from 'KC Cloyd'.
+     *
+     * @param string $algo       Name of selected hashing algorithm
+     * @param string $data       Message to be hashed
+     * @param string $key        Shared secret key used for generating the HMAC variant of the message digest
+     * @param bool   $raw_output Must be binary
+     * @return string
      * @doc http://php.net/manual/en/function.hash-hmac.php
      */
     public static function _hash_hmac($algo, $data, $key, $raw_output = false)

--- a/lib/Raven/Compat.php
+++ b/lib/Raven/Compat.php
@@ -36,7 +36,7 @@ class Raven_Compat
 
     /**
      * Implementation from 'KC Cloyd'.
-     * See http://nl2.php.net/manual/en/function.hash-hmac.php
+     * See http://php.net/manual/en/function.hash-hmac.php
      */
     public static function _hash_hmac($algo, $data, $key, $raw_output=false)
     {
@@ -66,6 +66,9 @@ class Raven_Compat
     /**
      * Note that we discard the options given to be compatible
      * with PHP < 5.3
+     * @param mixed $value
+     * @param integer $options
+     * @return string
      */
     public static function json_encode($value, $options=0)
     {
@@ -79,12 +82,14 @@ class Raven_Compat
     /**
      * Implementation taken from
      * http://www.mike-griffiths.co.uk/php-json_encode-alternative/
+     * @param mixed $value
+     * @return string
      */
     public static function _json_encode($value)
     {
         static $jsonReplaces = array(
-            array('\\', '/', "\n", "\t", "\r", "\b", "\f", '"'),
-            array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\b', '\\f', '\"'));
+            array('\\', '/', "\n", "\t", "\r", "\f", '"'),
+            array('\\\\', '\\/', '\\n', '\\t', '\\r', '\\f', '\"'));
 
         if (is_null($value)) {
             return 'null';

--- a/lib/Raven/Compat.php
+++ b/lib/Raven/Compat.php
@@ -25,7 +25,7 @@ class Raven_Compat
         return php_uname('n');
     }
 
-    public static function hash_hmac($algo, $data, $key, $raw_output=false)
+    public static function hash_hmac($algo, $data, $key, $raw_output = false)
     {
         if (function_exists('hash_hmac')) {
             return hash_hmac($algo, $data, $key, $raw_output);
@@ -36,9 +36,9 @@ class Raven_Compat
 
     /**
      * Implementation from 'KC Cloyd'.
-     * See http://php.net/manual/en/function.hash-hmac.php
+     * @doc http://php.net/manual/en/function.hash-hmac.php
      */
-    public static function _hash_hmac($algo, $data, $key, $raw_output=false)
+    public static function _hash_hmac($algo, $data, $key, $raw_output = false)
     {
         $algo = strtolower($algo);
         $pack = 'H'.strlen($algo('test'));
@@ -66,11 +66,12 @@ class Raven_Compat
     /**
      * Note that we discard the options given to be compatible
      * with PHP < 5.3
+     *
      * @param mixed $value
-     * @param integer $options
+     * @param int   $options
      * @return string
      */
-    public static function json_encode($value, $options=0)
+    public static function json_encode($value, $options = 0)
     {
         if (function_exists('json_encode')) {
             return json_encode($value);
@@ -82,6 +83,7 @@ class Raven_Compat
     /**
      * Implementation taken from
      * http://www.mike-griffiths.co.uk/php-json_encode-alternative/
+     *
      * @param mixed $value
      * @return string
      */

--- a/lib/Raven/Context.php
+++ b/lib/Raven/Context.php
@@ -6,6 +6,19 @@
  */
 class Raven_Context
 {
+    /**
+     * @var array
+     */
+    var $tags;
+    /**
+     * @var array
+     */
+    var $extra;
+    /**
+     * @var array|null
+     */
+    var $user;
+
     public function __construct()
     {
         $this->clear();

--- a/lib/Raven/Context.php
+++ b/lib/Raven/Context.php
@@ -9,15 +9,15 @@ class Raven_Context
     /**
      * @var array
      */
-    var $tags;
+    public $tags;
     /**
      * @var array
      */
-    var $extra;
+    public $extra;
     /**
      * @var array|null
      */
-    var $user;
+    public $user;
 
     public function __construct()
     {

--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -84,7 +84,9 @@ class Raven_CurlHandler
         } while ($timeout !== 0 && time() - $start < $timeout);
     }
 
-    // http://se2.php.net/manual/en/function.curl-multi-exec.php
+    /**
+     * @doc http://php.net/manual/en/function.curl-multi-exec.php
+     */
     private function select()
     {
         do {

--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -22,7 +22,7 @@ class Raven_CurlHandler
     private $options;
     private $requests;
 
-    public function __construct($options, $join_timeout=5)
+    public function __construct($options, $join_timeout = 5)
     {
         $this->options = $options;
         $this->multi_handle = curl_multi_init();
@@ -37,7 +37,7 @@ class Raven_CurlHandler
         $this->join();
     }
 
-    public function enqueue($url, $data=null, $headers=array())
+    public function enqueue($url, $data = null, $headers = array())
     {
         $ch = curl_init();
 
@@ -69,7 +69,7 @@ class Raven_CurlHandler
         return $fd;
     }
 
-    public function join($timeout=null)
+    public function join($timeout = null)
     {
         if (!isset($timeout)) {
             $timeout = $this->join_timeout;

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -145,7 +145,7 @@ class Raven_ErrorHandler
      *
      * @param bool $call_existing Call any existing exception handlers after processing
      *                            this instance.
-     * @return $this
+     * @return Raven_ErrorHandler
      */
     public function registerExceptionHandler($call_existing = true)
     {
@@ -158,10 +158,10 @@ class Raven_ErrorHandler
      * Register a handler which will intercept standard PHP errors and report them to the
      * associated Sentry client.
      *
-     * @param bool $call_existing Call any existing errors handlers after processing
-     *                            this instance.
-     * @param array $error_types All error types that should be sent.
-     * @return $this
+     * @param bool  $call_existing Call any existing errors handlers after processing
+     *                             this instance.
+     * @param array $error_types   All error types that should be sent.
+     * @return Raven_ErrorHandler
      */
     public function registerErrorHandler($call_existing = true, $error_types = null)
     {
@@ -179,7 +179,7 @@ class Raven_ErrorHandler
      *
      * @param int $reservedMemorySize Number of kilobytes memory space to reserve,
      *                                which is utilized when handling fatal errors.
-     * @return $this
+     * @return Raven_ErrorHandler
      */
     public function registerShutdownFunction($reservedMemorySize = 10)
     {

--- a/lib/Raven/Processor.php
+++ b/lib/Raven/Processor.php
@@ -21,7 +21,7 @@ abstract class Raven_Processor
     /**
      * Process and sanitize data, modifying the existing value if necessary.
      *
-     * @param array $data   Array of log data
+     * @param array $data Array of log data
      */
     abstract public function process(&$data);
 

--- a/lib/Raven/Processor.php
+++ b/lib/Raven/Processor.php
@@ -6,6 +6,13 @@
  */
 abstract class Raven_Processor
 {
+    protected $client;
+    /**
+     * Raven_Processor constructor.
+     *
+     * @param Raven_Client $client
+     * @codeCoverageIgnore
+     */
     public function __construct(Raven_Client $client)
     {
         $this->client = $client;
@@ -17,4 +24,11 @@ abstract class Raven_Processor
      * @param array $data   Array of log data
      */
     abstract public function process(&$data);
+
+    /**
+     * Override the default processor options
+     *
+     * @param array $options Associative array of processor options
+     */
+    abstract public function setProcessorOptions(array $options);
 }

--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -26,7 +26,7 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
     /**
      * Override the default processor options
      *
-     * @param array $options    Associative array of processor options
+     * @param array $options Associative array of processor options
      */
     public function setProcessorOptions(array $options)
     {
@@ -42,8 +42,8 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
     /**
      * Replace any array values with our mask if the field name or the value matches a respective regex
      *
-     * @param mixed $item       Associative array value
-     * @param string $key       Associative array key
+     * @param mixed  $item Associative array value
+     * @param string $key  Associative array key
      */
     public function sanitize(&$item, $key)
     {

--- a/lib/Raven/SanitizeDataProcessor.php
+++ b/lib/Raven/SanitizeDataProcessor.php
@@ -11,13 +11,13 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
     const FIELDS_RE = '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i';
     const VALUES_RE = '/^(?:\d[ -]*?){13,16}$/';
 
-    private $client;
     private $fields_re;
     private $values_re;
+    protected $session_cookie_name;
 
     public function __construct(Raven_Client $client)
     {
-        $this->client       = $client;
+        parent::__construct($client);
         $this->fields_re    = self::FIELDS_RE;
         $this->values_re    = self::VALUES_RE;
         $this->session_cookie_name = ini_get('session.name');
@@ -64,6 +64,9 @@ class Raven_SanitizeDataProcessor extends Raven_Processor
         }
     }
 
+    /** @noinspection PhpInconsistentReturnPointsInspection
+     * @param array $data
+     */
     public function sanitizeException(&$data)
     {
         foreach ($data['exception']['values'] as &$value) {

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -54,9 +54,15 @@ class Raven_Serializer
             $this->mb_detect_order = $mb_detect_order;
         }
     }
+
     /**
      * Serialize an object (recursively) into something safe for data
      * sanitization and encoding.
+     *
+     * @param mixed $value
+     * @param integer $max_depth
+     * @param integer $_depth
+     * @return string|boolean|double|integer|null|object|array
      */
     public function serialize($value, $max_depth=3, $_depth=0)
     {
@@ -94,6 +100,10 @@ class Raven_Serializer
         return $value;
     }
 
+    /**
+     * @param mixed $value
+     * @return string|boolean|double|integer|null
+     */
     protected function serializeValue($value)
     {
         if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -122,6 +122,7 @@ class Raven_Serializer
 
     /**
      * @return string
+     * @codeCoverageIgnore
      */
     public function getMbDetectOrder()
     {
@@ -132,6 +133,7 @@ class Raven_Serializer
      * @param string $mb_detect_order
      *
      * @return Raven_Serializer
+     * @codeCoverageIgnore
      */
     public function setMbDetectOrder($mb_detect_order)
     {

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -43,7 +43,7 @@ class Raven_Serializer
      *
      * @var string
      */
-    private $mb_detect_order= self::DEFAULT_MB_DETECT_ORDER;
+    private $mb_detect_order = self::DEFAULT_MB_DETECT_ORDER;
 
     /**
      * @param null|string $mb_detect_order
@@ -60,11 +60,11 @@ class Raven_Serializer
      * sanitization and encoding.
      *
      * @param mixed $value
-     * @param integer $max_depth
-     * @param integer $_depth
-     * @return string|boolean|double|integer|null|object|array
+     * @param int   $max_depth
+     * @param int   $_depth
+     * @return string|bool|double|int|null|object|array
      */
-    public function serialize($value, $max_depth=3, $_depth=0)
+    public function serialize($value, $max_depth = 3, $_depth = 0)
     {
         $className = is_object($value) ? get_class($value) : null;
         $toArray = is_array($value) || $className === 'stdClass';
@@ -102,7 +102,7 @@ class Raven_Serializer
 
     /**
      * @param mixed $value
-     * @return string|boolean|double|integer|null
+     * @return string|bool|double|int|null
      */
     protected function serializeValue($value)
     {

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -240,7 +240,7 @@ class Raven_Stacktrace
         // Code which is eval'ed have a modified filename.. Extract the
         // correct filename + linenumber from the string.
         $matches = array();
-        $matched = preg_match("/^(.*?)\((\d+)\) : eval\(\)'d code$/",
+        $matched = preg_match("/^(.*?)\\((\\d+)\\) : eval\\(\\)'d code$/",
             $filename, $matches);
         if ($matched) {
             $frame['filename'] = $filename = $matches[1];
@@ -251,7 +251,7 @@ class Raven_Stacktrace
         // "</path/to/filename>(<lineno>) : runtime-created function"
         // Extract the correct filename + linenumber from the string.
         $matches = array();
-        $matched = preg_match("/^(.*?)\((\d+)\) : runtime-created function$/",
+        $matched = preg_match("/^(.*?)\\((\\d+)\\) : runtime-created function$/",
             $filename, $matches);
         if ($matched) {
             $frame['filename'] = $filename = $matches[1];

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -38,7 +38,7 @@ class Raven_TransactionStack
      * @param string|null $context
      * @return mixed
      */
-    public function pop($context=null)
+    public function pop($context = null)
     {
         if (!$context) {
             return array_pop($this->stack);

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -34,6 +34,10 @@ class Raven_TransactionStack
         $this->stack[] = $context;
     }
 
+    /** @noinspection PhpInconsistentReturnPointsInspection
+     * @param string|null $context
+     * @return mixed
+     */
     public function pop($context=null)
     {
         if (!$context) {

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -48,5 +48,7 @@ class Raven_TransactionStack
                 return $context;
             }
         }
+        // @codeCoverageIgnoreStart
     }
+    // @codeCoverageIgnoreEnd
 }

--- a/lib/Raven/Util.php
+++ b/lib/Raven/Util.php
@@ -21,6 +21,11 @@ class Raven_Util
      * Because we love Python, this works much like dict.get() in Python.
      *
      * Returns $var from $array if set, otherwise returns $default.
+     *
+     * @param array  $array
+     * @param string $var
+     * @param mixed  $default
+     * @return mixed
      */
     public static function get($array, $var, $default=null)
     {

--- a/lib/Raven/Util.php
+++ b/lib/Raven/Util.php
@@ -27,7 +27,7 @@ class Raven_Util
      * @param mixed  $default
      * @return mixed
      */
-    public static function get($array, $var, $default=null)
+    public static function get($array, $var, $default = null)
     {
         if (isset($array[$var])) {
             return $array[$var];

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -76,13 +76,13 @@ class Dummy_Raven_Client extends Raven_Client
 
 class Dummy_Raven_Client_With_Overrided_Direct_Send extends Raven_Client
 {
-    var $_send_http_asynchronous_curl_exec_called = false;
-    var $_send_http_synchronous = false;
-    var $_set_url;
-    var $_set_data;
-    var $_set_headers;
+    public $_send_http_asynchronous_curl_exec_called = false;
+    public $_send_http_synchronous = false;
+    public $_set_url;
+    public $_set_data;
+    public $_set_headers;
 
-    function send_http_asynchronous_curl_exec($url, $data, $headers)
+    public function send_http_asynchronous_curl_exec($url, $data, $headers)
     {
         $this->_send_http_asynchronous_curl_exec_called = true;
         $this->_set_url = $url;
@@ -90,7 +90,7 @@ class Dummy_Raven_Client_With_Overrided_Direct_Send extends Raven_Client
         $this->_set_headers = $headers;
     }
 
-    function send_http_synchronous($url, $data, $headers)
+    public function send_http_synchronous($url, $data, $headers)
     {
         $this->_send_http_synchronous = true;
         $this->_set_url = $url;
@@ -98,19 +98,19 @@ class Dummy_Raven_Client_With_Overrided_Direct_Send extends Raven_Client
         $this->_set_headers = $headers;
     }
 
-    function get_curl_options()
+    public function get_curl_options()
     {
         $options = parent::get_curl_options();
 
         return $options;
     }
 
-    function get_curl_handler()
+    public function get_curl_handler()
     {
         return $this->_curl_handler;
     }
 
-    function set_curl_handler(Raven_CurlHandler $value)
+    public function set_curl_handler(Raven_CurlHandler $value)
     {
         $this->_curl_handler = $value;
     }
@@ -131,7 +131,7 @@ class Dummy_Raven_Client_With_Sync_Override extends Raven_Client
 {
     private static $_test_data = null;
 
-    static function get_test_data()
+    public static function get_test_data()
     {
         if (is_null(self::$_test_data)) {
             self::$_test_data = '';
@@ -143,7 +143,7 @@ class Dummy_Raven_Client_With_Sync_Override extends Raven_Client
         return self::$_test_data;
     }
 
-    static function test_filename()
+    public static function test_filename()
     {
         return sys_get_temp_dir().'/clientraven.tmp';
     }
@@ -156,18 +156,18 @@ class Dummy_Raven_Client_With_Sync_Override extends Raven_Client
 
 class Dummy_Raven_CurlHandler extends Raven_CurlHandler
 {
-    var $_set_url;
-    var $_set_data;
-    var $_set_headers;
-    var $_enqueue_called = false;
-    var $_join_called = false;
+    public $_set_url;
+    public $_set_data;
+    public $_set_headers;
+    public $_enqueue_called = false;
+    public $_join_called = false;
 
-    function __construct($options = array(), $join_timeout = 5)
+    public function __construct($options = array(), $join_timeout = 5)
     {
         parent::__construct($options, $join_timeout);
     }
 
-    function enqueue($url, $data = null, $headers = array())
+    public function enqueue($url, $data = null, $headers = array())
     {
         $this->_enqueue_called = true;
         $this->_set_url = $url;
@@ -177,7 +177,7 @@ class Dummy_Raven_CurlHandler extends Raven_CurlHandler
         return 0;
     }
 
-    function join($timeout = null)
+    public function join($timeout = null)
     {
         $this->_join_called = true;
     }
@@ -185,7 +185,7 @@ class Dummy_Raven_CurlHandler extends Raven_CurlHandler
 
 class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 {
-    function tearDown()
+    public function tearDown()
     {
         parent::tearDown();
         if (file_exists(Dummy_Raven_Client_With_Sync_Override::test_filename())) {
@@ -1433,13 +1433,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $callable = array($this, 'stabClosureVoid');
 
         $data = array(
-            array('environment', null, 'value',),
-            array('environment', null, null,),
-            array('release', null, 'value',),
-            array('release', null, null,),
+            array('environment', null, 'value', ),
+            array('environment', null, null, ),
+            array('release', null, 'value', ),
+            array('release', null, null, ),
             array('app_path', null, 'value', $property_method__convert_path->invoke($client, 'value')),
-            array('app_path', null, null,),
-            array('app_path', null, false, null,),
+            array('app_path', null, null, ),
+            array('app_path', null, false, null, ),
             array('excluded_app_paths', null, array('value'),
                   array($property_method__convert_path->invoke($client, 'value'))),
             array('excluded_app_paths', null, array(), null),
@@ -1452,14 +1452,14 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             array('transport', null, null),
             array('server', 'ServerEndpoint', 'http://example.com/'),
             array('server', 'ServerEndpoint', 'http://example.org/'),
-            array('_lasterror', null, null,),
-            array('_lasterror', null, 'value',),
-            array('_lasterror', null, mt_rand(100, 999),),
-            array('_last_event_id', null, mt_rand(100, 999),),
-            array('_last_event_id', null, 'value',),
-            array('extra_data', '_extra_data', array('key' => 'value'),),
-            array('processors', 'processors', array(),),
-            array('processors', 'processors', array('key' => 'value'),),
+            array('_lasterror', null, null, ),
+            array('_lasterror', null, 'value', ),
+            array('_lasterror', null, mt_rand(100, 999), ),
+            array('_last_event_id', null, mt_rand(100, 999), ),
+            array('_last_event_id', null, 'value', ),
+            array('extra_data', '_extra_data', array('key' => 'value'), ),
+            array('processors', 'processors', array(), ),
+            array('processors', 'processors', array('key' => 'value'), ),
         );
         foreach ($data as &$datum) {
             $this->subTestGettersAndSettersDatum($client, $datum);
@@ -1532,7 +1532,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::_convertPath
      */
-    function test_convertPath()
+    public function test_convertPath()
     {
         $property = new ReflectionMethod('Raven_Client', '_convertPath');
         $property->setAccessible(true);
@@ -1542,7 +1542,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::getDefaultProcessors
      */
-    function testGetDefaultProcessors()
+    public function testGetDefaultProcessors()
     {
         foreach (Raven_Client::getDefaultProcessors() as $class_name) {
             $this->assertInternalType('string', $class_name);
@@ -1556,7 +1556,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::get_default_ca_cert
      */
-    function testGet_default_ca_cert()
+    public function testGet_default_ca_cert()
     {
         $reflection = new ReflectionMethod('Raven_Client', 'get_default_ca_cert');
         $reflection->setAccessible(true);
@@ -1567,7 +1567,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @covers Raven_Client::translateSeverity
      * @covers Raven_Client::registerSeverityMap
      */
-    function testTranslateSeverity()
+    public function testTranslateSeverity()
     {
         $reflection = new ReflectionProperty('Raven_Client', 'severity_map');
         $reflection->setAccessible(true);
@@ -1575,12 +1575,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $predefined = array(E_ERROR, E_WARNING, E_PARSE, E_NOTICE, E_CORE_ERROR, E_CORE_WARNING,
                        E_COMPILE_ERROR, E_COMPILE_WARNING, E_USER_ERROR, E_USER_WARNING,
-                       E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR,);
+                       E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR, );
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
             $predefined[] = E_DEPRECATED;
             $predefined[] = E_USER_DEPRECATED;
         }
-        $predefined_values = array('debug', 'info', 'warning', 'warning', 'error', 'fatal',);
+        $predefined_values = array('debug', 'info', 'warning', 'warning', 'error', 'fatal', );
 
         // step 1
         foreach ($predefined as &$key) {
@@ -1596,7 +1596,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('error', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123456));
         // step 3
-        $client->registerSeverityMap(array(123456 => 'foo',));
+        $client->registerSeverityMap(array(123456 => 'foo', ));
         $this->assertMixedValueAndArray(array(123456 => 'foo'), $reflection->getValue($client));
         foreach ($predefined as &$key) {
             $this->assertContains($client->translateSeverity($key), $predefined_values);
@@ -1604,12 +1604,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123457));
         // step 4
-        $client->registerSeverityMap(array(E_USER_ERROR => 'bar',));
+        $client->registerSeverityMap(array(E_USER_ERROR => 'bar', ));
         $this->assertEquals('bar', $client->translateSeverity(E_USER_ERROR));
         $this->assertEquals('error', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123457));
         // step 5
-        $client->registerSeverityMap(array(E_USER_ERROR => 'bar', 123456 => 'foo',));
+        $client->registerSeverityMap(array(E_USER_ERROR => 'bar', 123456 => 'foo', ));
         $this->assertEquals('bar', $client->translateSeverity(E_USER_ERROR));
         $this->assertEquals('foo', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123457));
@@ -1618,12 +1618,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::getUserAgent
      */
-    function testGetUserAgent()
+    public function testGetUserAgent()
     {
         $this->assertRegExp('|^[0-9a-z./_-]+$|i', Raven_Client::getUserAgent());
     }
 
-    function testCaptureExceptionWithLogger()
+    public function testCaptureExceptionWithLogger()
     {
         $client = new Dummy_Raven_Client();
         $client->captureException(new Exception(), null, 'foobar');
@@ -1640,7 +1640,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @covers Raven_Client::send_remote
      * @covers Raven_Client::send_http
      */
-    function testCurl_method()
+    public function testCurl_method()
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
@@ -1671,7 +1671,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @covers Raven_Client::send_remote
      * @covers Raven_Client::send_http
      */
-    function testCurl_method_async()
+    public function testCurl_method_async()
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
@@ -1701,7 +1701,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @backupGlobals
      * @covers Raven_Client::__construct
      */
-    function testConstructWithServerDSN()
+    public function testConstructWithServerDSN()
     {
         $_SERVER['SENTRY_DSN'] = 'http://public:secret@example.com/1';
         $client = new Dummy_Raven_Client();
@@ -1715,7 +1715,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @backupGlobals
      * @covers Raven_Client::_server_variable
      */
-    function test_server_variable()
+    public function test_server_variable()
     {
         $method = new ReflectionMethod('Raven_Client', '_server_variable');
         $method->setAccessible(true);
@@ -1737,7 +1737,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    function testEncode()
+    public function testEncode()
     {
         $client = new Dummy_Raven_Client();
         $data_broken = array();
@@ -1764,7 +1764,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @covers Raven_Client::__construct
      * @covers Raven_Client::registerDefaultBreadcrumbHandlers
      */
-    function testRegisterDefaultBreadcrumbHandlers()
+    public function testRegisterDefaultBreadcrumbHandlers()
     {
         $previous = set_error_handler(array($this, 'stabClosureErrorHandler'), E_USER_NOTICE);
         new Raven_Client(null, array());
@@ -1779,19 +1779,19 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
     private $_closure_called = false;
 
-    function stabClosureVoid()
+    public function stabClosureVoid()
     {
         $this->_closure_called = true;
     }
 
-    function stabClosureNull()
+    public function stabClosureNull()
     {
         $this->_closure_called = true;
 
         return null;
     }
 
-    function stabClosureFalse()
+    public function stabClosureFalse()
     {
         $this->_closure_called = true;
 
@@ -1800,7 +1800,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
     private $_debug_backtrace = array();
 
-    function stabClosureErrorHandler($code, $message, $file = '', $line = 0, $context = array())
+    public function stabClosureErrorHandler($code, $message, $file = '', $line = 0, $context = array())
     {
         $this->_closure_called = true;
         $this->_debug_backtrace = debug_backtrace();
@@ -1813,7 +1813,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @covers Raven_Client::sendUnsentErrors
      * @covers Raven_Client::capture
      */
-    function testOnShutdown()
+    public function testOnShutdown()
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
@@ -1865,7 +1865,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::send
      */
-    function testNonWorkingSendSendCallback()
+    public function testNonWorkingSendSendCallback()
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
@@ -1896,7 +1896,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::send
      */
-    function testNonWorkingSendDSNEmpty()
+    public function testNonWorkingSendDSNEmpty()
     {
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
             'http://public:secret@example.com/1', array(
@@ -1913,7 +1913,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::send
      */
-    function testNonWorkingSendSetTransport()
+    public function testNonWorkingSendSetTransport()
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
@@ -1942,7 +1942,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::get_user_data
      */
-    function testGet_user_data()
+    public function testGet_user_data()
     {
         // step 1
         $client = new Dummy_Raven_Client();
@@ -1962,7 +1962,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         // step 3
         session_id($session_id);
-        @session_start(array('use_cookies' => false,));
+        @session_start(array('use_cookies' => false, ));
         $_SESSION = array('foo' => 'bar');
         $output = $client->get_user_data();
         $this->assertInternalType('array', $output);
@@ -1981,13 +1981,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      */
     public function testCaptureLevel()
     {
-        foreach ([Raven_Client::MESSAGE_LIMIT * 3, 100] as $length) {
+        foreach (array(Raven_Client::MESSAGE_LIMIT * 3, 100) as $length) {
             $message = '';
             for ($i = 0; $i < $length; $i++) {
                 $message .= chr($i % 256);
             }
             $client = new Dummy_Raven_Client();
-            $client->capture(array('message' => $message,));
+            $client->capture(array('message' => $message, ));
             $events = $client->getSentEvents();
             $this->assertEquals(1, count($events));
             $event = array_pop($events);
@@ -1999,7 +1999,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         }
 
         $client = new Dummy_Raven_Client();
-        $client->capture(array('message' => 'foobar',));
+        $client->capture(array('message' => 'foobar', ));
         $events = $client->getSentEvents();
         $event = array_pop($events);
         $input = $client->get_http_data();
@@ -2008,15 +2008,15 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('environment', $event);
 
         $client = new Dummy_Raven_Client();
-        $client->capture(array('message' => 'foobar', 'request' => array('foo' => 'bar'),));
+        $client->capture(array('message' => 'foobar', 'request' => array('foo' => 'bar'), ));
         $events = $client->getSentEvents();
         $event = array_pop($events);
         $this->assertEquals(array('foo' => 'bar'), $event['request']);
         $this->assertArrayNotHasKey('release', $event);
         $this->assertArrayNotHasKey('environment', $event);
 
-        foreach ([false, true] as $u1) {
-            foreach ([false, true] as $u2) {
+        foreach (array(false, true) as $u1) {
+            foreach (array(false, true) as $u2) {
                 $client = new Dummy_Raven_Client();
                 if ($u1) {
                     $client->setRelease('foo');
@@ -2024,7 +2024,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
                 if ($u2) {
                     $client->setEnvironment('bar');
                 }
-                $client->capture(array('message' => 'foobar',));
+                $client->capture(array('message' => 'foobar', ));
                 $events = $client->getSentEvents();
                 $event = array_pop($events);
                 if ($u1) {
@@ -2060,7 +2060,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         // step 3
         session_id($session_id);
-        @session_start(array('use_cookies' => false,));
+        @session_start(array('use_cookies' => false, ));
     }
 
     /**
@@ -2102,7 +2102,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     /**
      * @covers Raven_Client::send_http_asynchronous_curl_exec
      */
-    public function testSend_http_asynchronous_curl_exec(){
+    public function testSend_http_asynchronous_curl_exec()
+    {
         $client = new Dummy_Raven_Client_With_Sync_Override(
             'http://public:secret@example.com/1', array(
                 'curl_method' => 'exec',
@@ -2116,5 +2117,4 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $test_data = Dummy_Raven_Client_With_Sync_Override::get_test_data();
         $this->assertStringEqualsFile(Dummy_Raven_Client_With_Sync_Override::test_filename(), $test_data."\n");
     }
-
 }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -38,7 +38,7 @@ class Dummy_Raven_Client extends Raven_Client
         }
         $this->__sent_events[] = $data;
     }
-    public function is_http_request()
+    public static function is_http_request()
     {
         return true;
     }
@@ -74,8 +74,125 @@ class Dummy_Raven_Client extends Raven_Client
     }
 }
 
+class Dummy_Raven_Client_With_Overrided_Direct_Send extends Raven_Client
+{
+    var $_send_http_asynchronous_curl_exec_called = false;
+    var $_send_http_synchronous = false;
+    var $_set_url;
+    var $_set_data;
+    var $_set_headers;
+
+    function send_http_asynchronous_curl_exec($url, $data, $headers)
+    {
+        $this->_send_http_asynchronous_curl_exec_called = true;
+        $this->_set_url = $url;
+        $this->_set_data = $data;
+        $this->_set_headers = $headers;
+    }
+
+    function send_http_synchronous($url, $data, $headers)
+    {
+        $this->_send_http_synchronous = true;
+        $this->_set_url = $url;
+        $this->_set_data = $data;
+        $this->_set_headers = $headers;
+    }
+
+    function get_curl_options()
+    {
+        $options = parent::get_curl_options();
+
+        return $options;
+    }
+
+    function get_curl_handler()
+    {
+        return $this->_curl_handler;
+    }
+
+    function set_curl_handler(Raven_CurlHandler $value)
+    {
+        $this->_curl_handler = $value;
+    }
+}
+
+class Dummy_Raven_Client_No_Http extends Dummy_Raven_Client
+{
+    /**
+     * @return bool
+     */
+    public static function is_http_request()
+    {
+        return false;
+    }
+}
+
+class Dummy_Raven_Client_With_Sync_Override extends Raven_Client
+{
+    private static $_test_data = null;
+
+    static function get_test_data()
+    {
+        if (is_null(self::$_test_data)) {
+            self::$_test_data = '';
+            for ($i = 0; $i < 128; $i++) {
+                self::$_test_data .= chr(mt_rand(ord('a'), ord('z')));
+            }
+        }
+
+        return self::$_test_data;
+    }
+
+    static function test_filename()
+    {
+        return sys_get_temp_dir().'/clientraven.tmp';
+    }
+
+    protected function buildCurlCommand($url, $data, $headers)
+    {
+        return 'echo '.escapeshellarg(self::get_test_data()).' > '.self::test_filename();
+    }
+}
+
+class Dummy_Raven_CurlHandler extends Raven_CurlHandler
+{
+    var $_set_url;
+    var $_set_data;
+    var $_set_headers;
+    var $_enqueue_called = false;
+    var $_join_called = false;
+
+    function __construct($options = array(), $join_timeout = 5)
+    {
+        parent::__construct($options, $join_timeout);
+    }
+
+    function enqueue($url, $data = null, $headers = array())
+    {
+        $this->_enqueue_called = true;
+        $this->_set_url = $url;
+        $this->_set_data = $data;
+        $this->_set_headers = $headers;
+
+        return 0;
+    }
+
+    function join($timeout = null)
+    {
+        $this->_join_called = true;
+    }
+}
+
 class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 {
+    function tearDown()
+    {
+        parent::tearDown();
+        if (file_exists(Dummy_Raven_Client_With_Sync_Override::test_filename())) {
+            unlink(Dummy_Raven_Client_With_Sync_Override::test_filename());
+        }
+    }
+
     private function create_exception()
     {
         try {
@@ -183,6 +300,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         Raven_Client::ParseDSN('http://public@example.com/1');
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testDsnFirstArgument()
     {
         $client = new Dummy_Raven_Client('http://public:secret@example.com/1');
@@ -193,6 +313,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->secret_key, 'secret');
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testDsnFirstArgumentWithOptions()
     {
         $client = new Dummy_Raven_Client('http://public:secret@example.com/1', array(
@@ -206,6 +329,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->site, 'foo');
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testOptionsFirstArgument()
     {
         $client = new Dummy_Raven_Client(array(
@@ -217,6 +343,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     }
 
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testDsnInOptionsFirstArg()
     {
         $client = new Dummy_Raven_Client(array(
@@ -229,6 +358,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->secret_key, 'secret');
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testDsnInOptionsSecondArg()
     {
         $client = new Dummy_Raven_Client(null, array(
@@ -241,6 +373,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->secret_key, 'secret');
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testOptionsFirstArgumentWithOptions()
     {
         $client = new Dummy_Raven_Client(array(
@@ -254,6 +389,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->site, 'foo');
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testOptionsExtraData()
     {
         $client = new Dummy_Raven_Client(array('extra' => array('foo' => 'bar')));
@@ -265,6 +403,23 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['extra']['foo'], 'bar');
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
+    public function testOptionsExtraDataWithNull()
+    {
+        $client = new Dummy_Raven_Client(array('extra' => array('foo' => 'bar')));
+
+        $client->captureMessage('Test Message %s', array('foo'), null);
+        $events = $client->getSentEvents();
+        $this->assertEquals(count($events), 1);
+        $event = array_pop($events);
+        $this->assertEquals($event['extra']['foo'], 'bar');
+    }
+
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testEmptyExtraData()
     {
         $client = new Dummy_Raven_Client(array('extra' => array()));
@@ -276,6 +431,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array_key_exists('extra', $event), false);
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageDoesHandleUninterpolatedMessage()
     {
         $client = new Dummy_Raven_Client();
@@ -287,6 +445,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['message'], 'Test Message %s');
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageDoesHandleInterpolatedMessage()
     {
         $client = new Dummy_Raven_Client();
@@ -298,6 +459,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['message'], 'Test Message foo');
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageDoesHandleInterpolatedMessageWithRelease()
     {
         $client = new Dummy_Raven_Client();
@@ -313,6 +477,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['message'], 'Test Message foo');
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageSetsInterface()
     {
         $client = new Dummy_Raven_Client();
@@ -326,8 +493,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'params' => array('foo'),
             'formatted' => 'Test Message foo',
         ));
+        $this->assertEquals('Test Message foo', $event['message']);
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageHandlesOptionsAsThirdArg()
     {
         $client = new Dummy_Raven_Client();
@@ -341,8 +512,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $event = array_pop($events);
         $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
         $this->assertEquals($event['extra']['foo'], 'bar');
+        $this->assertEquals('Test Message foo', $event['message']);
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageHandlesLevelAsThirdArg()
     {
         $client = new Dummy_Raven_Client();
@@ -352,8 +527,12 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(count($events), 1);
         $event = array_pop($events);
         $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
+        $this->assertEquals('Test Message foo', $event['message']);
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionSetsInterfaces()
     {
         # TODO: it'd be nice if we could mock the stacktrace extraction function here
@@ -381,6 +560,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(empty($frame['post_context']));
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionChainedException()
     {
         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
@@ -402,6 +584,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exc['values'][1]['value'], 'Child exc');
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug()
     {
         if (version_compare(PHP_VERSION, '5.3.0', '<')) {
@@ -428,6 +613,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionHandlesOptionsAsSecondArg()
     {
         $client = new Dummy_Raven_Client();
@@ -439,6 +627,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['culprit'], 'test');
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionHandlesExcludeOption()
     {
         $client = new Dummy_Raven_Client(array(
@@ -450,6 +641,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(count($events), 0);
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionInvalidUTF8()
     {
         $client = new Dummy_Raven_Client();
@@ -466,6 +660,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertNotEquals($message, false, $client->getLastError());
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     */
     public function testDoesRegisterProcessors()
     {
         $client = new Dummy_Raven_Client(array(
@@ -491,6 +688,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client->process($data);
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     * @covers Raven_Client::getDefaultProcessors
+     */
     public function testDefaultProcessorsAreUsed()
     {
         $client = new Dummy_Raven_Client();
@@ -499,6 +700,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(count($client->processors), count($defaults));
     }
 
+    /**
+     * @covers Raven_Client::getDefaultProcessors
+     */
     public function testDefaultProcessorsContainSanitizeDataProcessor()
     {
         $defaults = Dummy_Raven_Client::getDefaultProcessors();
@@ -506,6 +710,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(in_array('Raven_SanitizeDataProcessor', $defaults));
     }
 
+    /**
+     * @covers Raven_Client::__construct
+     * @covers Raven_Client::get_default_data
+     */
     public function testGetDefaultData()
     {
         $client = new Dummy_Raven_Client();
@@ -528,6 +736,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
     /**
      * @backupGlobals
+     * @covers Raven_Client::get_http_data
      */
     public function testGetHttpData()
     {
@@ -579,6 +788,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_http_data());
     }
 
+    /**
+     * @covers Raven_Client::user_context
+     * @covers Raven_Client::get_user_data
+     */
     public function testGetUserDataWithSetUser()
     {
         $client = new Dummy_Raven_Client();
@@ -590,6 +803,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'username' => 'my_user',
         );
 
+        // @todo переписать
         $client->set_user_data($id, $email, $user);
 
         $expected = array(
@@ -603,6 +817,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_user_data());
     }
 
+    /**
+     * @covers Raven_Client::get_user_data
+     */
     public function testGetUserDataWithNoUser()
     {
         $client = new Dummy_Raven_Client();
@@ -615,7 +832,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_user_data());
     }
 
-    public function testGetAuthHeader()
+    /**
+     * @covers Raven_Client::get_auth_header
+     */
+    public function testGet_Auth_Header()
     {
         $client = new Dummy_Raven_Client();
 
@@ -629,6 +849,24 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $client->get_auth_header($timestamp, 'sentry-php/test', 'publickey', 'secretkey'));
     }
 
+    /**
+     * @covers Raven_Client::getAuthHeader
+     */
+    public function testGetAuthHeader()
+    {
+        $client = new Dummy_Raven_Client();
+        $ts1 = microtime(true);
+        $header = $client->getAuthHeader();
+        $ts2 = microtime(true);
+        $this->assertEquals(1, preg_match('/sentry_timestamp=([0-9.]+)/', $header, $a));
+        $this->assertRegExp('/^[0-9]+(\\.[0-9]+)?$/', $a[1]);
+        $this->assertGreaterThanOrEqual($ts1, (double)$a[1]);
+        $this->assertLessThanOrEqual($ts2, (double)$a[1]);
+    }
+
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageWithUserContext()
     {
         $client = new Dummy_Raven_Client();
@@ -644,6 +882,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ), $event['user']);
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     */
     public function testCaptureMessageWithUnserializableUserData()
     {
         $client = new Dummy_Raven_Client();
@@ -659,9 +900,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $events = $client->getSentEvents();
         // we're just asserting that this goes off without a hitch
         $this->assertEquals(1, count($events));
-        $event = array_pop($events);
+        array_pop($events);
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     * @covers Raven_Client::tags_context
+     */
     public function testCaptureMessageWithTagsContext()
     {
         $client = new Dummy_Raven_Client();
@@ -680,6 +925,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ), $event['tags']);
     }
 
+    /**
+     * @covers Raven_Client::captureMessage
+     * @covers Raven_Client::extra_context
+     */
     public function testCaptureMessageWithExtraContext()
     {
         $client = new Dummy_Raven_Client();
@@ -698,6 +947,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ), $event['extra']);
     }
 
+    /**
+     * @covers Raven_Client::captureException
+     */
     public function testCaptureExceptionContainingLatin1()
     {
         // If somebody has a non-utf8 codebase, she/he should add the encoding to the detection order
@@ -753,9 +1005,14 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($found, true);
     }
 
+    /**
+     * @covers Raven_Client::captureLastError
+     */
     public function testCaptureLastError()
     {
         $client = new Dummy_Raven_Client();
+        $this->assertNull($client->captureLastError());
+        $this->assertEquals(0, count($client->getSentEvents()));
 
         @$undefined;
 
@@ -766,6 +1023,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($event['exception']['values'][0]['value'], 'Undefined variable: undefined');
     }
 
+    /**
+     * @covers Raven_Client::getLastEventID
+     */
     public function testGetLastEventID()
     {
         $client = new Dummy_Raven_Client();
@@ -773,6 +1033,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->getLastEventID(), 'abc');
     }
 
+    /**
+     * @covers Raven_Client::setTransport
+     */
     public function testCustomTransport()
     {
         $events = array();
@@ -788,6 +1051,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(count($events), 1);
     }
 
+    /**
+     * @covers Raven_Client::setAppPath
+     */
     public function testAppPathLinux()
     {
         $client = new Dummy_Raven_Client();
@@ -800,6 +1066,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->getAppPath(), '/foo/baz/');
     }
 
+    /**
+     * @covers Raven_Client::setAppPath
+     */
     public function testAppPathWindows()
     {
         $client = new Dummy_Raven_Client();
@@ -837,6 +1106,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         return true;
     }
 
+    /**
+     * @covers Raven_Client::send
+     */
     public function testSendCallback()
     {
         $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb1')));
@@ -856,6 +1128,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(empty($events[0]['message']), true);
     }
 
+    /**
+     * @covers Raven_Client::sanitize
+     */
     public function testSanitizeExtra()
     {
         $client = new Dummy_Raven_Client();
@@ -879,6 +1154,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         )));
     }
 
+    /**
+     * @covers Raven_Client::sanitize
+     */
     public function testSanitizeTags()
     {
         $client = new Dummy_Raven_Client();
@@ -894,6 +1172,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         )));
     }
 
+    /**
+     * @covers Raven_Client::sanitize
+     */
     public function testSanitizeUser()
     {
         $client = new Dummy_Raven_Client();
@@ -907,14 +1188,88 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         )));
     }
 
+    /**
+     * @covers Raven_Client::sanitize
+     */
+    public function testSanitizeRequest()
+    {
+        $client = new Dummy_Raven_Client();
+        $data = array('request' => array(
+            'context' => array(
+                'line' => 1216,
+                'stack' => array(
+                    1, array(2), 3
+                ),
+            ),
+        ));
+        $client->sanitize($data);
+
+        $this->assertEquals($data, array('request' => array(
+            'context' => array(
+                'line' => 1216,
+                'stack' => array(
+                    1, 'Array of length 1', 3
+                ),
+            ),
+        )));
+    }
+
+    /**
+     * @covers Raven_Client::sanitize
+     */
+    public function testSanitizeContexts()
+    {
+        $client = new Dummy_Raven_Client();
+        $data = array('contexts' => array(
+            'context' => array(
+                'line' => 1216,
+                'stack' => array(
+                    1, array(
+                        'foo' => 'bar',
+                        'level4' => array(array('level5', 'level5 a'), 2),
+                    ), 3
+                ),
+            ),
+        ));
+        $client->sanitize($data);
+
+        $this->assertEquals($data, array('contexts' => array(
+            'context' => array(
+                'line' => 1216,
+                'stack' => array(
+                    1, array(
+                        'foo' => 'bar',
+                        'level4' => array('Array of length 2', 2),
+                    ), 3
+                ),
+            ),
+        )));
+    }
+
+    /**
+     * @covers Raven_Client::buildCurlCommand
+     */
     public function testBuildCurlCommandEscapesInput()
     {
         $data = '{"foo": "\'; ls;"}';
         $client = new Dummy_Raven_Client();
         $result = $client->buildCurlCommand('http://foo.com', $data, array());
         $this->assertEquals($result, 'curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &');
+
+        $result = $client->buildCurlCommand('http://foo.com', $data, array('key' => 'value'));
+        $this->assertEquals($result, 'curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &');
+
+        $client->verify_ssl = false;
+        $result = $client->buildCurlCommand('http://foo.com', $data, array());
+        $this->assertEquals($result, 'curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &');
+
+        $result = $client->buildCurlCommand('http://foo.com', $data, array('key' => 'value'));
+        $this->assertEquals($result, 'curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &');
     }
 
+    /**
+     * @covers Raven_Client::user_context
+     */
     public function testUserContextWithoutMerge()
     {
         $client = new Dummy_Raven_Client();
@@ -923,6 +1278,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->context->user, array('baz' => 'bar'));
     }
 
+    /**
+     * @covers Raven_Client::user_context
+     */
     public function testUserContextWithMerge()
     {
         $client = new Dummy_Raven_Client();
@@ -931,6 +1289,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($client->context->user, array('foo' => 'bar', 'baz' => 'bar'));
     }
 
+    /**
+     * @covers Raven_Client::user_context
+     */
     public function testUserContextWithMergeAndNull()
     {
         $client = new Dummy_Raven_Client();
@@ -947,6 +1308,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * @param array $options
      * @param string $expected - the url expected
      * @param string $message - fail message
+     * @covers Raven_Client::get_current_url
+     * @covers Raven_Client::isHttps
      */
     public function testCurrentUrl($serverVars, $options, $expected, $message)
     {
@@ -1027,4 +1390,731 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             )
         );
     }
+
+    /**
+     * @covers Raven_Client::uuid4()
+     */
+    public function testUuid4()
+    {
+        $method = new ReflectionMethod('Raven_Client', 'uuid4');
+        $method->setAccessible(true);
+        for ($i = 0; $i < 1000; $i++) {
+            $this->assertRegExp('/^[0-9a-z-]+$/', $method->invoke(null));
+        }
+    }
+
+    /**
+     * @covers Raven_Client::getEnvironment
+     * @covers Raven_Client::setEnvironment
+     * @covers Raven_Client::getRelease
+     * @covers Raven_Client::setRelease
+     * @covers Raven_Client::getAppPath
+     * @covers Raven_Client::setAppPath
+     * @covers Raven_Client::getExcludedAppPaths
+     * @covers Raven_Client::setExcludedAppPaths
+     * @covers Raven_Client::getPrefixes
+     * @covers Raven_Client::setPrefixes
+     * @covers Raven_Client::getSendCallback
+     * @covers Raven_Client::setSendCallback
+     * @covers Raven_Client::getTransport
+     * @covers Raven_Client::setTransport
+     * @covers Raven_Client::getServerEndpoint
+     * @covers Raven_Client::getLastError
+     * @covers Raven_Client::getLastEventID
+     * @covers Raven_Client::get_extra_data
+     * @covers Raven_Client::setProcessors
+     */
+    public function testGettersAndSetters()
+    {
+        $client = new Dummy_Raven_Client();
+        $property_method__convert_path = new ReflectionMethod('Raven_Client', '_convertPath');
+        $property_method__convert_path->setAccessible(true);
+        // @todo зависит от версии php. Вставить сюда closure
+        $callable = array($this, 'stabClosureVoid');
+
+        $data = array(
+            array('environment', null, 'value',),
+            array('environment', null, null,),
+            array('release', null, 'value',),
+            array('release', null, null,),
+            array('app_path', null, 'value', $property_method__convert_path->invoke($client, 'value')),
+            array('app_path', null, null,),
+            array('app_path', null, false, null,),
+            array('excluded_app_paths', null, array('value'),
+                  array($property_method__convert_path->invoke($client, 'value'))),
+            array('excluded_app_paths', null, array(), null),
+            array('excluded_app_paths', null, null),
+            array('prefixes', null, array('value'), array($property_method__convert_path->invoke($client, 'value'))),
+            array('prefixes', null, array()),
+            array('send_callback', null, $callable),
+            array('send_callback', null, null),
+            array('transport', null, $callable),
+            array('transport', null, null),
+            array('server', 'ServerEndpoint', 'http://example.com/'),
+            array('server', 'ServerEndpoint', 'http://example.org/'),
+            array('_lasterror', null, null,),
+            array('_lasterror', null, 'value',),
+            array('_lasterror', null, mt_rand(100, 999),),
+            array('_last_event_id', null, mt_rand(100, 999),),
+            array('_last_event_id', null, 'value',),
+            array('extra_data', '_extra_data', array('key' => 'value'),),
+            array('processors', 'processors', array(),),
+            array('processors', 'processors', array('key' => 'value'),),
+        );
+        foreach ($data as &$datum) {
+            $this->subTestGettersAndSettersDatum($client, $datum);
+        }
+        foreach ($data as &$datum) {
+            $client = new Dummy_Raven_Client();
+            $this->subTestGettersAndSettersDatum($client, $datum);
+        }
+    }
+
+    private function subTestGettersAndSettersDatum(Raven_Client $client, $datum)
+    {
+        if (count($datum) == 3) {
+            list($property_name, $function_name, $value_in) = $datum;
+            $value_out = $value_in;
+        } else {
+            list($property_name, $function_name, $value_in, $value_out) = $datum;
+        }
+        if (is_null($function_name)) {
+            $function_name = str_replace('_', '', $property_name);
+        }
+
+        $method_get_name = 'get'.$function_name;
+        $method_set_name = 'set'.$function_name;
+        $property = new ReflectionProperty('Raven_Client', $property_name);
+        $property->setAccessible(true);
+
+        if (method_exists($client, $method_set_name)) {
+            $setter_output = $client->$method_set_name($value_in);
+            if (!is_null($setter_output) and is_object($setter_output)) {
+                // chaining call test
+                $this->assertEquals(spl_object_hash($client), spl_object_hash($setter_output));
+            }
+            $actual_value = $property->getValue($client);
+            $this->assertMixedValueAndArray($value_out, $actual_value);
+        }
+
+        if (method_exists($client, $method_get_name)) {
+            $property->setValue($client, $value_out);
+            $reflection = new ReflectionMethod('Raven_Client', $method_get_name);
+            if ($reflection->isPublic()) {
+                $actual_value = $client->$method_get_name();
+                $this->assertMixedValueAndArray($value_out, $actual_value);
+            }
+        }
+    }
+
+    private function assertMixedValueAndArray($expected_value, $actual_value)
+    {
+        if (is_null($expected_value)) {
+            $this->assertNull($actual_value);
+        } elseif ($expected_value === true) {
+            $this->assertTrue($actual_value);
+        } elseif ($expected_value === false) {
+            $this->assertFalse($actual_value);
+        } elseif (is_string($expected_value) or is_integer($expected_value) or is_double($expected_value)) {
+            $this->assertEquals($expected_value, $actual_value);
+        } elseif (is_array($expected_value)) {
+            $this->assertInternalType('array', $actual_value);
+            $this->assertEquals(count($expected_value), count($actual_value));
+            foreach ($expected_value as $key => $value) {
+                $this->assertArrayHasKey($key, $actual_value);
+                $this->assertMixedValueAndArray($value, $actual_value[$key]);
+            }
+        } elseif (is_callable($expected_value) or is_object($expected_value)) {
+            $this->assertEquals(spl_object_hash($expected_value), spl_object_hash($actual_value));
+        }
+    }
+
+    /**
+     * @covers Raven_Client::_convertPath
+     */
+    function test_convertPath()
+    {
+        $property = new ReflectionMethod('Raven_Client', '_convertPath');
+        $property->setAccessible(true);
+        // @todo
+    }
+
+    /**
+     * @covers Raven_Client::getDefaultProcessors
+     */
+    function testGetDefaultProcessors()
+    {
+        foreach (Raven_Client::getDefaultProcessors() as $class_name) {
+            $this->assertInternalType('string', $class_name);
+            $this->assertTrue(class_exists($class_name));
+            $reflection = new ReflectionClass($class_name);
+            $this->assertTrue($reflection->isSubclassOf('Raven_Processor'));
+            $this->assertFalse($reflection->isAbstract());
+        }
+    }
+
+    /**
+     * @covers Raven_Client::get_default_ca_cert
+     */
+    function testGet_default_ca_cert()
+    {
+        $reflection = new ReflectionMethod('Raven_Client', 'get_default_ca_cert');
+        $reflection->setAccessible(true);
+        $this->assertFileExists($reflection->invoke(null));
+    }
+
+    /**
+     * @covers Raven_Client::translateSeverity
+     * @covers Raven_Client::registerSeverityMap
+     */
+    function testTranslateSeverity()
+    {
+        $reflection = new ReflectionProperty('Raven_Client', 'severity_map');
+        $reflection->setAccessible(true);
+        $client = new Dummy_Raven_Client();
+
+        $predefined = array(E_ERROR, E_WARNING, E_PARSE, E_NOTICE, E_CORE_ERROR, E_CORE_WARNING,
+                       E_COMPILE_ERROR, E_COMPILE_WARNING, E_USER_ERROR, E_USER_WARNING,
+                       E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR,);
+        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+            $predefined[] = E_DEPRECATED;
+            $predefined[] = E_USER_DEPRECATED;
+        }
+        $predefined_values = array('debug', 'info', 'warning', 'warning', 'error', 'fatal',);
+
+        // step 1
+        foreach ($predefined as &$key) {
+            $this->assertContains($client->translateSeverity($key), $predefined_values);
+        }
+        $this->assertEquals('error', $client->translateSeverity(123456));
+        // step 2
+        $client->registerSeverityMap(array());
+        $this->assertMixedValueAndArray(array(), $reflection->getValue($client));
+        foreach ($predefined as &$key) {
+            $this->assertContains($client->translateSeverity($key), $predefined_values);
+        }
+        $this->assertEquals('error', $client->translateSeverity(123456));
+        $this->assertEquals('error', $client->translateSeverity(123456));
+        // step 3
+        $client->registerSeverityMap(array(123456 => 'foo',));
+        $this->assertMixedValueAndArray(array(123456 => 'foo'), $reflection->getValue($client));
+        foreach ($predefined as &$key) {
+            $this->assertContains($client->translateSeverity($key), $predefined_values);
+        }
+        $this->assertEquals('foo', $client->translateSeverity(123456));
+        $this->assertEquals('error', $client->translateSeverity(123457));
+        // step 4
+        $client->registerSeverityMap(array(E_USER_ERROR => 'bar',));
+        $this->assertEquals('bar', $client->translateSeverity(E_USER_ERROR));
+        $this->assertEquals('error', $client->translateSeverity(123456));
+        $this->assertEquals('error', $client->translateSeverity(123457));
+        // step 5
+        $client->registerSeverityMap(array(E_USER_ERROR => 'bar', 123456 => 'foo',));
+        $this->assertEquals('bar', $client->translateSeverity(E_USER_ERROR));
+        $this->assertEquals('foo', $client->translateSeverity(123456));
+        $this->assertEquals('error', $client->translateSeverity(123457));
+    }
+
+    /**
+     * @covers Raven_Client::getUserAgent
+     */
+    function testGetUserAgent()
+    {
+        $this->assertRegExp('|^[0-9a-z./_-]+$|i', Raven_Client::getUserAgent());
+    }
+
+    function testCaptureExceptionWithLogger()
+    {
+        $client = new Dummy_Raven_Client();
+        $client->captureException(new Exception(), null, 'foobar');
+
+        $events = $client->getSentEvents();
+        $this->assertEquals(count($events), 1);
+        $event = array_pop($events);
+        $this->assertEquals('foobar', $event['logger']);
+    }
+
+    /**
+     * @covers Raven_Client::__construct
+     * @covers Raven_Client::send
+     * @covers Raven_Client::send_remote
+     * @covers Raven_Client::send_http
+     */
+    function testCurl_method()
+    {
+        // step 1
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'foobar',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $client->captureMessage('foobar');
+        $this->assertTrue($client->_send_http_synchronous);
+        $this->assertFalse($client->_send_http_asynchronous_curl_exec_called);
+
+        // step 2
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'exec',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $client->captureMessage('foobar');
+        $this->assertFalse($client->_send_http_synchronous);
+        $this->assertTrue($client->_send_http_asynchronous_curl_exec_called);
+    }
+
+    /**
+     * @covers Raven_Client::__construct
+     * @covers Raven_Client::send
+     * @covers Raven_Client::send_remote
+     * @covers Raven_Client::send_http
+     */
+    function testCurl_method_async()
+    {
+        // step 1
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'async',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $object = $client->get_curl_handler();
+        $this->assertInternalType('object', $object);
+        $this->assertEquals('Raven_CurlHandler', get_class($object));
+
+        $reflection = new ReflectionProperty('Raven_CurlHandler', 'options');
+        $reflection->setAccessible(true);
+        $this->assertEquals($client->get_curl_options(), $reflection->getValue($object));
+
+        // step 2
+        $ch = new Dummy_Raven_CurlHandler();
+        $client->set_curl_handler($ch);
+        $client->captureMessage('foobar');
+        $this->assertFalse($client->_send_http_synchronous);
+        $this->assertFalse($client->_send_http_asynchronous_curl_exec_called);
+        $this->assertTrue($ch->_enqueue_called);
+    }
+
+    /**
+     * @backupGlobals
+     * @covers Raven_Client::__construct
+     */
+    function testConstructWithServerDSN()
+    {
+        $_SERVER['SENTRY_DSN'] = 'http://public:secret@example.com/1';
+        $client = new Dummy_Raven_Client();
+        $this->assertEquals($client->project, 1);
+        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
+        $this->assertEquals($client->public_key, 'public');
+        $this->assertEquals($client->secret_key, 'secret');
+    }
+
+    /**
+     * @backupGlobals
+     * @covers Raven_Client::_server_variable
+     */
+    function test_server_variable()
+    {
+        $method = new ReflectionMethod('Raven_Client', '_server_variable');
+        $method->setAccessible(true);
+        foreach ($_SERVER as $key => $value) {
+            $actual = $method->invoke(null, $key);
+            $this->assertNotNull($actual);
+            $this->assertEquals($value, $actual);
+        }
+        foreach (array('foo', 'bar', 'foobar', '123456', 'SomeLongNonExistedKey') as $key => $value) {
+            if (!isset($_SERVER[$key])) {
+                $actual = $method->invoke(null, $key);
+                $this->assertNotNull($actual);
+                $this->assertEquals('', $actual);
+            }
+            unset($_SERVER[$key]);
+            $actual = $method->invoke(null, $key);
+            $this->assertNotNull($actual);
+            $this->assertEquals('', $actual);
+        }
+    }
+
+    function testEncode()
+    {
+        $client = new Dummy_Raven_Client();
+        $data_broken = array();
+        for ($i = 0; $i < 1024; $i++) {
+            $data_broken = array($data_broken);
+        }
+        $value = $client->encode($data_broken);
+        $this->assertFalse($value);
+        unset($data_broken);
+
+        $data = array('some' => (object)array('value' => 'data'), 'foo' => array('bar', null, 123), false);
+        $json_stringify = Raven_Compat::json_encode($data);
+        $value = $client->encode($data);
+        $this->assertRegExp('_^[a-zA-Z0-9/=]+$_', $value);
+        $decoded = base64_decode($value);
+        if (function_exists("gzcompress")) {
+            $decoded = gzuncompress($decoded);
+        }
+
+        $this->assertEquals($json_stringify, $decoded);
+    }
+
+    /**
+     * @covers Raven_Client::__construct
+     * @covers Raven_Client::registerDefaultBreadcrumbHandlers
+     */
+    function testRegisterDefaultBreadcrumbHandlers()
+    {
+        $previous = set_error_handler(array($this, 'stabClosureErrorHandler'), E_USER_NOTICE);
+        new Raven_Client(null, array());
+        $this->_closure_called = false;
+        trigger_error('foobar', E_USER_NOTICE);
+        $u = $this->_closure_called;
+        $debug_backtrace = $this->_debug_backtrace;
+        set_error_handler($previous, E_ALL);
+        $this->assertTrue($u);
+        $this->assertEquals('Raven_Breadcrumbs_ErrorHandler', $debug_backtrace[2]['class']);
+    }
+
+    private $_closure_called = false;
+
+    function stabClosureVoid()
+    {
+        $this->_closure_called = true;
+    }
+
+    function stabClosureNull()
+    {
+        $this->_closure_called = true;
+
+        return null;
+    }
+
+    function stabClosureFalse()
+    {
+        $this->_closure_called = true;
+
+        return false;
+    }
+
+    private $_debug_backtrace = array();
+
+    function stabClosureErrorHandler($code, $message, $file = '', $line = 0, $context = array())
+    {
+        $this->_closure_called = true;
+        $this->_debug_backtrace = debug_backtrace();
+
+        return true;
+    }
+
+    /**
+     * @covers Raven_Client::onShutdown
+     * @covers Raven_Client::sendUnsentErrors
+     * @covers Raven_Client::capture
+     */
+    function testOnShutdown()
+    {
+        // step 1
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'foobar',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $this->assertEquals(0, count($client->_pending_events));
+        $client->_pending_events[] = array('foo' => 'bar');
+        $client->sendUnsentErrors();
+        $this->assertTrue($client->_send_http_synchronous);
+        $this->assertFalse($client->_send_http_asynchronous_curl_exec_called);
+        $this->assertEquals(0, count($client->_pending_events));
+
+        // step 2
+        $client->_send_http_synchronous = false;
+        $client->_send_http_asynchronous_curl_exec_called = false;
+
+        $client->store_errors_for_bulk_send = true;
+        $client->captureMessage('foobar');
+        $this->assertEquals(1, count($client->_pending_events));
+        $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
+        $client->_send_http_synchronous = false;
+        $client->_send_http_asynchronous_curl_exec_called = false;
+
+        // step 3
+        $client->onShutdown();
+        $this->assertTrue($client->_send_http_synchronous);
+        $this->assertFalse($client->_send_http_asynchronous_curl_exec_called);
+        $this->assertEquals(0, count($client->_pending_events));
+
+        // step 1
+        $client = null;
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'async',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $ch = new Dummy_Raven_CurlHandler();
+        $client->set_curl_handler($ch);
+        $client->captureMessage('foobar');
+        $client->onShutdown();
+        $client = null;
+        $this->assertTrue($ch->_join_called);
+    }
+
+    /**
+     * @covers Raven_Client::send
+     */
+    function testNonWorkingSendSendCallback()
+    {
+        // step 1
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'foobar',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $this->_closure_called = false;
+        $client->setSendCallback(array($this, 'stabClosureNull'));
+        $this->assertFalse($this->_closure_called);
+        $data = array('foo' => 'bar');
+        $client->send($data);
+        $this->assertTrue($this->_closure_called);
+        $this->assertTrue($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
+        // step 2
+        $this->_closure_called = false;
+        $client->_send_http_synchronous = false;
+        $client->_send_http_asynchronous_curl_exec_called = false;
+        $client->setSendCallback(array($this, 'stabClosureFalse'));
+        $this->assertFalse($this->_closure_called);
+        $data = array('foo' => 'bar');
+        $client->send($data);
+        $this->assertTrue($this->_closure_called);
+        $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
+    }
+
+    /**
+     * @covers Raven_Client::send
+     */
+    function testNonWorkingSendDSNEmpty()
+    {
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'foobar',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $client->server = null;
+        $data = array('foo' => 'bar');
+        $client->send($data);
+        $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
+    }
+
+    /**
+     * @covers Raven_Client::send
+     */
+    function testNonWorkingSendSetTransport()
+    {
+        // step 1
+        $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'foobar',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        $this->_closure_called = false;
+        $client->setTransport(array($this, 'stabClosureNull'));
+        $this->assertFalse($this->_closure_called);
+        $data = array('foo' => 'bar');
+        $client->send($data);
+        $this->assertTrue($this->_closure_called);
+        $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
+        // step 2
+        $this->_closure_called = false;
+        $client->setSendCallback(array($this, 'stabClosureFalse'));
+        $this->assertFalse($this->_closure_called);
+        $data = array('foo' => 'bar');
+        $client->send($data);
+        $this->assertTrue($this->_closure_called);
+        $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
+    }
+
+    /**
+     * @covers Raven_Client::get_user_data
+     */
+    function testGet_user_data()
+    {
+        // step 1
+        $client = new Dummy_Raven_Client();
+        $output = $client->get_user_data();
+        $this->assertInternalType('array', $output);
+        $this->assertArrayHasKey('user', $output);
+        $this->assertArrayHasKey('id', $output['user']);
+        $session_old = $_SESSION;
+
+        // step 2
+        $session_id = session_id();
+        session_write_close();
+        session_id('');
+        $output = $client->get_user_data();
+        $this->assertInternalType('array', $output);
+        $this->assertEquals(0, count($output));
+
+        // step 3
+        session_id($session_id);
+        @session_start(array('use_cookies' => false,));
+        $_SESSION = array('foo' => 'bar');
+        $output = $client->get_user_data();
+        $this->assertInternalType('array', $output);
+        $this->assertArrayHasKey('user', $output);
+        $this->assertArrayHasKey('id', $output['user']);
+        $this->assertArrayHasKey('data', $output['user']);
+        $this->assertArrayHasKey('foo', $output['user']['data']);
+        $this->assertEquals('bar', $output['user']['data']['foo']);
+        $_SESSION = $session_old;
+    }
+
+    /**
+     * @covers Raven_Client::capture
+     * @covers Raven_Client::setRelease
+     * @covers Raven_Client::setEnvironment
+     */
+    public function testCaptureLevel()
+    {
+        foreach ([Raven_Client::MESSAGE_LIMIT * 3, 100] as $length) {
+            $message = '';
+            for ($i = 0; $i < $length; $i++) {
+                $message .= chr($i % 256);
+            }
+            $client = new Dummy_Raven_Client();
+            $client->capture(array('message' => $message,));
+            $events = $client->getSentEvents();
+            $this->assertEquals(count($events), 1);
+            $event = array_pop($events);
+
+            $this->assertEquals('error', $event['level']);
+            $this->assertEquals(substr($message, 0, min(Raven_Client::MESSAGE_LIMIT, $length)), $event['message']);
+            $this->assertArrayNotHasKey('release', $event);
+            $this->assertArrayNotHasKey('environment', $event);
+        }
+
+        $client = new Dummy_Raven_Client();
+        $client->capture(array('message' => 'foobar',));
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        $input = $client->get_http_data();
+        $this->assertEquals($input['request'], $event['request']);
+        $this->assertArrayNotHasKey('release', $event);
+        $this->assertArrayNotHasKey('environment', $event);
+
+        $client = new Dummy_Raven_Client();
+        $client->capture(array('message' => 'foobar', 'request' => array('foo' => 'bar'),));
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        $this->assertEquals(array('foo' => 'bar'), $event['request']);
+        $this->assertArrayNotHasKey('release', $event);
+        $this->assertArrayNotHasKey('environment', $event);
+
+        foreach ([false, true] as $u1) {
+            foreach ([false, true] as $u2) {
+                $client = new Dummy_Raven_Client();
+                if ($u1) {
+                    $client->setRelease('foo');
+                }
+                if ($u2) {
+                    $client->setEnvironment('bar');
+                }
+                $client->capture(array('message' => 'foobar',));
+                $events = $client->getSentEvents();
+                $event = array_pop($events);
+                if ($u1) {
+                    $this->assertEquals('foo', $event['release']);
+                } else {
+                    $this->assertArrayNotHasKey('release', $event);
+                }
+                if ($u2) {
+                    $this->assertEquals('bar', $event['environment']);
+                } else {
+                    $this->assertArrayNotHasKey('environment', $event);
+                }
+            }
+        }
+    }
+
+    /**
+     * @covers Raven_Client::capture
+     */
+    public function testCaptureNoUserAndRequest()
+    {
+        $client = new Dummy_Raven_Client_No_Http(null, array(
+            'install_default_breadcrumb_handlers' => false,
+        ));
+        $session_id = session_id();
+        session_write_close();
+        session_id('');
+        $client->capture(array('user' => '', 'request' => ''));
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        $this->assertArrayNotHasKey('user', $event);
+        $this->assertArrayNotHasKey('request', $event);
+
+        // step 3
+        session_id($session_id);
+        @session_start(array('use_cookies' => false,));
+    }
+
+    /**
+     * @covers Raven_Client::capture
+     */
+    public function testCaptureNonEmptyBreadcrumb()
+    {
+        $client = new Dummy_Raven_Client();
+        $ts1 = microtime(true);
+        $client->breadcrumbs->record(array('foo' => 'bar'));
+        $client->breadcrumbs->record(array('honey' => 'clover'));
+        $client->capture(array());
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        foreach ($event['breadcrumbs'] as &$crumb) {
+            $this->assertGreaterThanOrEqual($ts1, $crumb['timestamp']);
+            unset($crumb['timestamp']);
+        }
+        $this->assertEquals(array(
+            array('foo' => 'bar'),
+            array('honey' => 'clover'),
+        ), $event['breadcrumbs']);
+    }
+
+
+    /**
+     * @covers Raven_Client::capture
+     */
+    public function testCaptureAutoLogStacks()
+    {
+        $client = new Dummy_Raven_Client();
+        $client->capture(array('auto_log_stacks' => true), true);
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        $this->assertArrayHasKey('stacktrace', $event);
+        $this->assertInternalType('array', $event['stacktrace']['frames']);
+    }
+
+    /**
+     * @covers Raven_Client::send_http_asynchronous_curl_exec
+     */
+    public function testSend_http_asynchronous_curl_exec(){
+        $client = new Dummy_Raven_Client_With_Sync_Override(
+            'http://public:secret@example.com/1', array(
+                'curl_method' => 'exec',
+                'install_default_breadcrumb_handlers' => false,
+            )
+        );
+        if (file_exists(Dummy_Raven_Client_With_Sync_Override::test_filename())) {
+            unlink(Dummy_Raven_Client_With_Sync_Override::test_filename());
+        }
+        $client->captureMessage('foobar');
+        $test_data = Dummy_Raven_Client_With_Sync_Override::get_test_data();
+        $this->assertStringEqualsFile(Dummy_Raven_Client_With_Sync_Override::test_filename(), $test_data."\n");
+    }
+
 }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -641,11 +641,14 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($events));
     }
 
-    /**
-     * @covers Raven_Client::captureException
-     */
     public function testCaptureExceptionInvalidUTF8()
     {
+        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+            if (ini_get('zend.assertions') != 1) {
+                $this->markTestSkipped('Production environment does not execute asserts');
+                return;
+            }
+        }
         $client = new Dummy_Raven_Client();
         try {
             invalid_encoding();
@@ -657,7 +660,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         // if this fails to encode it returns false
         $message = $client->encode($events[0]);
-        $this->assertNotEquals($message, false, $client->getLastError());
+        $this->assertNotFalse($message, $client->getLastError());
     }
 
     /**

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -42,7 +42,7 @@ class Dummy_Raven_Client extends Raven_Client
     {
         return true;
     }
-    public function get_auth_header($timestamp, $client, $api_key, $secret_key)
+    public static function get_auth_header($timestamp, $client, $api_key, $secret_key)
     {
         return parent::get_auth_header($timestamp, $client, $api_key, $secret_key);
     }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1753,11 +1753,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $value = $client->encode($data);
         $this->assertRegExp('_^[a-zA-Z0-9/=]+$_', $value);
         $decoded = base64_decode($value);
+        $this->assertInternalType('string', $decoded, 'Can not use base64 decode on the encoded blob');
         if (function_exists("gzcompress")) {
             $decoded = gzuncompress($decoded);
+            $this->assertEquals($json_stringify, $decoded, 'Can not decompress compressed blob');
+        } else {
+            $this->assertEquals($json_stringify, $decoded);
         }
-
-        $this->assertEquals($json_stringify, $decoded);
     }
 
     /**

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1013,6 +1013,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      */
     public function testCaptureLastError()
     {
+        if (function_exists('error_clear_last')) {
+            error_clear_last();
+        }
         $client = new Dummy_Raven_Client();
         $this->assertNull($client->captureLastError());
         $this->assertEquals(0, count($client->getSentEvents()));

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -219,40 +219,40 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     {
         $result = Raven_Client::ParseDSN('http://public:secret@example.com/1');
 
-        $this->assertEquals($result['project'], 1);
-        $this->assertEquals($result['server'], 'http://example.com/api/1/store/');
-        $this->assertEquals($result['public_key'], 'public');
-        $this->assertEquals($result['secret_key'], 'secret');
+        $this->assertEquals(1, $result['project']);
+        $this->assertEquals('http://example.com/api/1/store/', $result['server']);
+        $this->assertEquals('public', $result['public_key']);
+        $this->assertEquals('secret', $result['secret_key']);
     }
 
     public function testParseDSNHttps()
     {
         $result = Raven_Client::ParseDSN('https://public:secret@example.com/1');
 
-        $this->assertEquals($result['project'], 1);
-        $this->assertEquals($result['server'], 'https://example.com/api/1/store/');
-        $this->assertEquals($result['public_key'], 'public');
-        $this->assertEquals($result['secret_key'], 'secret');
+        $this->assertEquals(1, $result['project']);
+        $this->assertEquals('https://example.com/api/1/store/', $result['server']);
+        $this->assertEquals('public', $result['public_key']);
+        $this->assertEquals('secret', $result['secret_key']);
     }
 
     public function testParseDSNPath()
     {
         $result = Raven_Client::ParseDSN('http://public:secret@example.com/app/1');
 
-        $this->assertEquals($result['project'], 1);
-        $this->assertEquals($result['server'], 'http://example.com/app/api/1/store/');
-        $this->assertEquals($result['public_key'], 'public');
-        $this->assertEquals($result['secret_key'], 'secret');
+        $this->assertEquals(1, $result['project']);
+        $this->assertEquals('http://example.com/app/api/1/store/', $result['server']);
+        $this->assertEquals('public', $result['public_key']);
+        $this->assertEquals('secret', $result['secret_key']);
     }
 
     public function testParseDSNPort()
     {
         $result = Raven_Client::ParseDSN('http://public:secret@example.com:9000/app/1');
 
-        $this->assertEquals($result['project'], 1);
-        $this->assertEquals($result['server'], 'http://example.com:9000/app/api/1/store/');
-        $this->assertEquals($result['public_key'], 'public');
-        $this->assertEquals($result['secret_key'], 'secret');
+        $this->assertEquals(1, $result['project']);
+        $this->assertEquals('http://example.com:9000/app/api/1/store/', $result['server']);
+        $this->assertEquals('public', $result['public_key']);
+        $this->assertEquals('secret', $result['secret_key']);
     }
 
     public function testParseDSNInvalidScheme()
@@ -307,10 +307,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client('http://public:secret@example.com/1');
 
-        $this->assertEquals($client->project, 1);
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
-        $this->assertEquals($client->public_key, 'public');
-        $this->assertEquals($client->secret_key, 'secret');
+        $this->assertEquals(1, $client->project);
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
+        $this->assertEquals('public', $client->public_key);
+        $this->assertEquals('secret', $client->secret_key);
     }
 
     /**
@@ -322,11 +322,11 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'site' => 'foo',
         ));
 
-        $this->assertEquals($client->project, 1);
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
-        $this->assertEquals($client->public_key, 'public');
-        $this->assertEquals($client->secret_key, 'secret');
-        $this->assertEquals($client->site, 'foo');
+        $this->assertEquals(1, $client->project);
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
+        $this->assertEquals('public', $client->public_key);
+        $this->assertEquals('secret', $client->secret_key);
+        $this->assertEquals('foo', $client->site);
     }
 
     /**
@@ -339,7 +339,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'project' => 1,
         ));
 
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
     }
 
 
@@ -352,10 +352,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'dsn' => 'http://public:secret@example.com/1',
         ));
 
-        $this->assertEquals($client->project, 1);
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
-        $this->assertEquals($client->public_key, 'public');
-        $this->assertEquals($client->secret_key, 'secret');
+        $this->assertEquals(1, $client->project);
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
+        $this->assertEquals('public', $client->public_key);
+        $this->assertEquals('secret', $client->secret_key);
     }
 
     /**
@@ -367,10 +367,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'dsn' => 'http://public:secret@example.com/1',
         ));
 
-        $this->assertEquals($client->project, 1);
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
-        $this->assertEquals($client->public_key, 'public');
-        $this->assertEquals($client->secret_key, 'secret');
+        $this->assertEquals(1, $client->project);
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
+        $this->assertEquals('public', $client->public_key);
+        $this->assertEquals('secret', $client->secret_key);
     }
 
     /**
@@ -385,8 +385,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'site' => 'foo',
         ));
 
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
-        $this->assertEquals($client->site, 'foo');
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
+        $this->assertEquals('foo', $client->site);
     }
 
     /**
@@ -398,9 +398,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['extra']['foo'], 'bar');
+        $this->assertEquals('bar', $event['extra']['foo']);
     }
 
     /**
@@ -412,9 +412,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'), null);
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['extra']['foo'], 'bar');
+        $this->assertEquals('bar', $event['extra']['foo']);
     }
 
     /**
@@ -426,7 +426,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
         $this->assertEquals(array_key_exists('extra', $event), false);
     }
@@ -440,9 +440,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['message'], 'Test Message %s');
+        $this->assertEquals('Test Message %s', $event['message']);
     }
 
     /**
@@ -454,9 +454,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['message'], 'Test Message foo');
+        $this->assertEquals('Test Message foo', $event['message']);
     }
 
     /**
@@ -471,10 +471,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['release'], 20160909144742);
-        $this->assertEquals($event['message'], 'Test Message foo');
+        $this->assertEquals(20160909144742, $event['release']);
+        $this->assertEquals('Test Message foo', $event['message']);
     }
 
     /**
@@ -486,13 +486,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['sentry.interfaces.Message'], array(
+        $this->assertEquals(array(
             'message' => 'Test Message %s',
             'params' => array('foo'),
             'formatted' => 'Test Message foo',
-        ));
+        ), $event['sentry.interfaces.Message']);
         $this->assertEquals('Test Message foo', $event['message']);
     }
 
@@ -508,10 +508,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             'extra' => array('foo' => 'bar')
         ));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
-        $this->assertEquals($event['extra']['foo'], 'bar');
+        $this->assertEquals(Dummy_Raven_Client::WARNING, $event['level']);
+        $this->assertEquals('bar', $event['extra']['foo']);
         $this->assertEquals('Test Message foo', $event['message']);
     }
 
@@ -524,9 +524,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $client->captureMessage('Test Message %s', array('foo'), Dummy_Raven_Client::WARNING);
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
+        $this->assertEquals(Dummy_Raven_Client::WARNING, $event['level']);
         $this->assertEquals('Test Message foo', $event['message']);
     }
 
@@ -541,21 +541,21 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client->captureException($ex);
 
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
 
         $exc = $event['exception'];
-        $this->assertEquals(count($exc['values']), 1);
-        $this->assertEquals($exc['values'][0]['value'], 'Foo bar');
-        $this->assertEquals($exc['values'][0]['type'], 'Exception');
+        $this->assertEquals(1, count($exc['values']));
+        $this->assertEquals('Foo bar', $exc['values'][0]['value']);
+        $this->assertEquals('Exception', $exc['values'][0]['type']);
 
         $this->assertFalse(empty($exc['values'][0]['stacktrace']['frames']));
         $frames = $exc['values'][0]['stacktrace']['frames'];
         $frame = $frames[count($frames) - 1];
         $this->assertTrue($frame['lineno'] > 0);
-        $this->assertEquals($frame['function'], 'create_exception');
+        $this->assertEquals('create_exception', $frame['function']);
         $this->assertFalse(isset($frame['vars']));
-        $this->assertEquals($frame['context_line'], '            throw new Exception(\'Foo bar\');');
+        $this->assertEquals('            throw new Exception(\'Foo bar\');', $frame['context_line']);
         $this->assertFalse(empty($frame['pre_context']));
         $this->assertFalse(empty($frame['post_context']));
     }
@@ -575,13 +575,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client->captureException($ex);
 
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
 
         $exc = $event['exception'];
-        $this->assertEquals(count($exc['values']), 2);
-        $this->assertEquals($exc['values'][0]['value'], 'Foo bar');
-        $this->assertEquals($exc['values'][1]['value'], 'Child exc');
+        $this->assertEquals(2, count($exc['values']));
+        $this->assertEquals('Foo bar', $exc['values'][0]['value']);
+        $this->assertEquals('Child exc', $exc['values'][1]['value']);
     }
 
     /**
@@ -604,13 +604,13 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $events = $client->getSentEvents();
 
         $event = array_pop($events);
-        $this->assertEquals($event['level'], Dummy_Raven_Client::ERROR);
+        $this->assertEquals(Dummy_Raven_Client::ERROR, $event['level']);
 
         $event = array_pop($events);
-        $this->assertEquals($event['level'], Dummy_Raven_Client::INFO);
+        $this->assertEquals(Dummy_Raven_Client::INFO, $event['level']);
 
         $event = array_pop($events);
-        $this->assertEquals($event['level'], Dummy_Raven_Client::WARNING);
+        $this->assertEquals(Dummy_Raven_Client::WARNING, $event['level']);
     }
 
     /**
@@ -622,9 +622,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $ex = $this->create_exception();
         $client->captureException($ex, array('culprit' => 'test'));
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['culprit'], 'test');
+        $this->assertEquals('test', $event['culprit']);
     }
 
     /**
@@ -638,7 +638,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $ex = $this->create_exception();
         $client->captureException($ex, 'test');
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 0);
+        $this->assertEquals(0, count($events));
     }
 
     /**
@@ -653,7 +653,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             $client->captureException($ex);
         }
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
 
         // if this fails to encode it returns false
         $message = $client->encode($events[0]);
@@ -668,8 +668,8 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client(array(
             'processors' => array('Raven_SanitizeDataProcessor'),
         ));
-        $this->assertEquals(count($client->processors), 1);
-        $this->assertTrue($client->processors[0] instanceof Raven_SanitizeDataProcessor);
+        $this->assertEquals(1, count($client->processors));
+        $this->assertInstanceOf('Raven_SanitizeDataProcessor', $client->processors[0]);
     }
 
     public function testProcessDoesCallProcessors()
@@ -697,7 +697,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $defaults = Dummy_Raven_Client::getDefaultProcessors();
 
-        $this->assertEquals(count($client->processors), count($defaults));
+        $this->assertEquals(count($defaults), count($client->processors));
     }
 
     /**
@@ -971,7 +971,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $events = $client->getSentEvents();
         $event = array_pop($events);
 
-        $this->assertEquals($event['exception']['values'][0]['value'], $utf8String);
+        $this->assertEquals($utf8String, $event['exception']['values'][0]['value']);
     }
 
 
@@ -1002,7 +1002,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertEquals($found, true);
+        $this->assertTrue($found);
     }
 
     /**
@@ -1020,7 +1020,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals($event['exception']['values'][0]['value'], 'Undefined variable: undefined');
+        $this->assertEquals('Undefined variable: undefined', $event['exception']['values'][0]['value']);
     }
 
     /**
@@ -1030,7 +1030,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
         $client->capture(array('message' => 'test', 'event_id' => 'abc'));
-        $this->assertEquals($client->getLastEventID(), 'abc');
+        $this->assertEquals('abc', $client->getLastEventID());
     }
 
     /**
@@ -1048,7 +1048,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             $events[] = $data;
         });
         $client->capture(array('message' => 'test', 'event_id' => 'abc'));
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
     }
 
     /**
@@ -1059,11 +1059,11 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $client->setAppPath('/foo/bar');
 
-        $this->assertEquals($client->getAppPath(), '/foo/bar/');
+        $this->assertEquals('/foo/bar/', $client->getAppPath());
 
         $client->setAppPath('/foo/baz/');
 
-        $this->assertEquals($client->getAppPath(), '/foo/baz/');
+        $this->assertEquals('/foo/baz/', $client->getAppPath());
     }
 
     /**
@@ -1074,7 +1074,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $client->setAppPath('C:\\foo\\bar\\');
 
-        $this->assertEquals($client->getAppPath(), 'C:\\foo\\bar\\');
+        $this->assertEquals('C:\\foo\\bar\\', $client->getAppPath());
     }
 
     /**
@@ -1125,7 +1125,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
-        $this->assertEquals(empty($events[0]['message']), true);
+        $this->assertTrue(empty($events[0]['message']));
     }
 
     /**
@@ -1144,14 +1144,14 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ));
         $client->sanitize($data);
 
-        $this->assertEquals($data, array('extra' => array(
+        $this->assertEquals(array('extra' => array(
             'context' => array(
                 'line' => 1216,
                 'stack' => array(
                     1, 'Array of length 1', 3
                 ),
             ),
-        )));
+        )), $data);
     }
 
     /**
@@ -1166,10 +1166,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ));
         $client->sanitize($data);
 
-        $this->assertEquals($data, array('tags' => array(
+        $this->assertEquals(array('tags' => array(
             'foo' => 'bar',
             'baz' => 'Array',
-        )));
+        )), $data);
     }
 
     /**
@@ -1183,9 +1183,9 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ));
         $client->sanitize($data);
 
-        $this->assertEquals($data, array('user' => array(
+        $this->assertEquals(array('user' => array(
             'email' => 'foo@example.com',
-        )));
+        )), $data);
     }
 
     /**
@@ -1204,14 +1204,14 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ));
         $client->sanitize($data);
 
-        $this->assertEquals($data, array('request' => array(
+        $this->assertEquals(array('request' => array(
             'context' => array(
                 'line' => 1216,
                 'stack' => array(
                     1, 'Array of length 1', 3
                 ),
             ),
-        )));
+        )), $data);
     }
 
     /**
@@ -1233,7 +1233,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         ));
         $client->sanitize($data);
 
-        $this->assertEquals($data, array('contexts' => array(
+        $this->assertEquals(array('contexts' => array(
             'context' => array(
                 'line' => 1216,
                 'stack' => array(
@@ -1243,7 +1243,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
                     ), 3
                 ),
             ),
-        )));
+        )), $data);
     }
 
     /**
@@ -1254,17 +1254,17 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $data = '{"foo": "\'; ls;"}';
         $client = new Dummy_Raven_Client();
         $result = $client->buildCurlCommand('http://foo.com', $data, array());
-        $this->assertEquals($result, 'curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &');
+        $this->assertEquals('curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &', $result);
 
         $result = $client->buildCurlCommand('http://foo.com', $data, array('key' => 'value'));
-        $this->assertEquals($result, 'curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &');
+        $this->assertEquals('curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &', $result);
 
         $client->verify_ssl = false;
         $result = $client->buildCurlCommand('http://foo.com', $data, array());
-        $this->assertEquals($result, 'curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &');
+        $this->assertEquals('curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &', $result);
 
         $result = $client->buildCurlCommand('http://foo.com', $data, array('key' => 'value'));
-        $this->assertEquals($result, 'curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &');
+        $this->assertEquals('curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &', $result);
     }
 
     /**
@@ -1275,7 +1275,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $client->user_context(array('foo' => 'bar'), false);
         $client->user_context(array('baz' => 'bar'), false);
-        $this->assertEquals($client->context->user, array('baz' => 'bar'));
+        $this->assertEquals(array('baz' => 'bar'), $client->context->user);
     }
 
     /**
@@ -1286,7 +1286,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $client->user_context(array('foo' => 'bar'), true);
         $client->user_context(array('baz' => 'bar'), true);
-        $this->assertEquals($client->context->user, array('foo' => 'bar', 'baz' => 'bar'));
+        $this->assertEquals(array('foo' => 'bar', 'baz' => 'bar'), $client->context->user);
     }
 
     /**
@@ -1297,7 +1297,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $client->user_context(array('foo' => 'bar'), true);
         $client->user_context(null, true);
-        $this->assertEquals($client->context->user, array('foo' => 'bar'));
+        $this->assertEquals(array('foo' => 'bar'), $client->context->user);
     }
 
     /**
@@ -1629,7 +1629,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $client->captureException(new Exception(), null, 'foobar');
 
         $events = $client->getSentEvents();
-        $this->assertEquals(count($events), 1);
+        $this->assertEquals(1, count($events));
         $event = array_pop($events);
         $this->assertEquals('foobar', $event['logger']);
     }
@@ -1686,7 +1686,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
         $reflection = new ReflectionProperty('Raven_CurlHandler', 'options');
         $reflection->setAccessible(true);
-        $this->assertEquals($client->get_curl_options(), $reflection->getValue($object));
+        $this->assertEquals($reflection->getValue($object), $client->get_curl_options());
 
         // step 2
         $ch = new Dummy_Raven_CurlHandler();
@@ -1705,10 +1705,10 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
     {
         $_SERVER['SENTRY_DSN'] = 'http://public:secret@example.com/1';
         $client = new Dummy_Raven_Client();
-        $this->assertEquals($client->project, 1);
-        $this->assertEquals($client->server, 'http://example.com/api/1/store/');
-        $this->assertEquals($client->public_key, 'public');
-        $this->assertEquals($client->secret_key, 'secret');
+        $this->assertEquals(1, $client->project);
+        $this->assertEquals('http://example.com/api/1/store/', $client->server);
+        $this->assertEquals('public', $client->public_key);
+        $this->assertEquals('secret', $client->secret_key);
     }
 
     /**
@@ -1989,7 +1989,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
             $client = new Dummy_Raven_Client();
             $client->capture(array('message' => $message,));
             $events = $client->getSentEvents();
-            $this->assertEquals(count($events), 1);
+            $this->assertEquals(1, count($events));
             $event = array_pop($events);
 
             $this->assertEquals('error', $event['level']);

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -643,7 +643,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
 
     public function testCaptureExceptionInvalidUTF8()
     {
-        if (version_compare(PHP_VERSION, '7.0.0', '>=')) {
+        if (version_compare(PHP_VERSION, '7.0', '>=')) {
             if (ini_get('zend.assertions') != 1) {
                 $this->markTestSkipped('Production environment does not execute asserts');
                 return;
@@ -1792,7 +1792,16 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
         $debug_backtrace = $this->_debug_backtrace;
         set_error_handler($previous, E_ALL);
         $this->assertTrue($u);
-        $this->assertEquals('Raven_Breadcrumbs_ErrorHandler', $debug_backtrace[2]['class']);
+        if (isset($debug_backtrace[1]['function']) and ($debug_backtrace[1]['function'] == 'call_user_func')
+            and version_compare(PHP_VERSION, '7.0', '>=')
+        ) {
+            $offset = 2;
+        } elseif (version_compare(PHP_VERSION, '7.0', '>=')) {
+            $offset = 1;
+        } else {
+            $offset = 2;
+        }
+        $this->assertEquals('Raven_Breadcrumbs_ErrorHandler', $debug_backtrace[$offset]['class']);
     }
 
     private $_closure_called = false;

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -943,7 +943,7 @@ class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
      * Set the server array to the test values, check the current url
      *
      * @dataProvider currentUrlProvider
-     * @param array $serverData
+     * @param array $serverVars
      * @param array $options
      * @param string $expected - the url expected
      * @param string $message - fail message

--- a/test/Raven/Tests/CompatTest.php
+++ b/test/Raven/Tests/CompatTest.php
@@ -66,4 +66,48 @@ class Raven_Tests_CompatTest extends PHPUnit_Framework_TestCase
         $result = Raven_Compat::_json_encode(array(null, false, true, 1.5));
         $this->assertEquals('[null,false,true,1.5]', $result);
     }
+
+    /**
+     * @covers Raven_Compat::_json_encode
+     * @covers Raven_Compat::_json_encode_lowlevel
+     *
+     * I show you how deep the rabbit hole goes
+     */
+    public function test_json_encode_with_broken_data()
+    {
+        $data_broken_named = array();
+        $data_broken_named_510 = null;
+        $data_broken_named_511 = null;
+
+        $data_broken = array();
+        $data_broken_510 = null;
+        $data_broken_511 = null;
+        for ($i = 0; $i < 1024; $i++) {
+            $data_broken = array($data_broken);
+            $data_broken_named = array('a' => $data_broken_named);
+            switch ($i) {
+                case 510:
+                    $data_broken_510 = $data_broken;
+                    $data_broken_named_510 = $data_broken_named;
+                    break;
+                case 511:
+                    $data_broken_511 = $data_broken;
+                    $data_broken_named_511 = $data_broken_named;
+                    break;
+            }
+        }
+        $value_1024 = Raven_Compat::_json_encode($data_broken);
+        $value_510 = Raven_Compat::_json_encode($data_broken_510);
+        $value_511 = Raven_Compat::_json_encode($data_broken_511);
+        $this->assertFalse($value_1024, 'Broken data encoded successfully with Raven_Compat::_json_encode');
+        $this->assertNotFalse($value_510);
+        $this->assertFalse($value_511);
+
+        $value_1024 = Raven_Compat::_json_encode($data_broken_named);
+        $value_510 = Raven_Compat::_json_encode($data_broken_named_510);
+        $value_511 = Raven_Compat::_json_encode($data_broken_named_511);
+        $this->assertFalse($value_1024, 'Broken data encoded successfully with Raven_Compat::_json_encode');
+        $this->assertNotFalse($value_510);
+        $this->assertFalse($value_511);
+    }
 }

--- a/test/Raven/Tests/CompatTest.php
+++ b/test/Raven/Tests/CompatTest.php
@@ -24,6 +24,26 @@ class Raven_Tests_CompatTest extends PHPUnit_Framework_TestCase
 
         $result = Raven_Compat::_hash_hmac('sha1', 'foo', 'bar');
         $this->assertEquals('85d155c55ed286a300bd1cf124de08d87e914f3a', $result);
+
+        $long_key = '0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF';
+        $result = Raven_Compat::_hash_hmac('md5', 'data', $long_key);
+        $this->assertEquals('951038f9ab8a10c929ab6dbc5f927207', $result);
+
+        $result = Raven_Compat::_hash_hmac('sha1', 'data', $long_key);
+        $this->assertEquals('cbf0d1ca10d211da2bc15cb3b579ecfebf3056d2', $result);
+
+        $result = Raven_Compat::_hash_hmac('md5', 'foobar', $long_key);
+        $this->assertEquals('5490f3cddeb9665bce3239cbc4c15e2c', $result);
+
+        $result = Raven_Compat::_hash_hmac('sha1', 'foobar', $long_key);
+        $this->assertEquals('5729f50ff2fbb8f8bf81d7a86f69a89f7574697c', $result);
+
+
+        $result = Raven_Compat::_hash_hmac('md5', 'foo', $long_key);
+        $this->assertEquals('ab193328035cbd3a48dea9d64ba92736', $result);
+
+        $result = Raven_Compat::_hash_hmac('sha1', 'foo', $long_key);
+        $this->assertEquals('8f883d0755115314930968496573f27735eb0c41', $result);
     }
 
     public function test_json_encode()
@@ -42,5 +62,8 @@ class Raven_Tests_CompatTest extends PHPUnit_Framework_TestCase
 
         $result = Raven_Compat::_json_encode(array(array()));
         $this->assertEquals('[[]]', $result);
+
+        $result = Raven_Compat::_json_encode(array(null, false, true, 1.5));
+        $this->assertEquals('[null,false,true,1.5]', $result);
     }
 }

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -12,6 +12,8 @@
 class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
 {
     private $errorLevel;
+    private $errorHandlerCalled;
+    private $existingErrorHandler;
 
     public function setUp()
     {

--- a/test/Raven/Tests/IntegrationTest.php
+++ b/test/Raven/Tests/IntegrationTest.php
@@ -24,7 +24,7 @@ class DummyIntegration_Raven_Client extends Raven_Client
         }
         $this->__sent_events[] = $data;
     }
-    public function is_http_request()
+    public static function is_http_request()
     {
         return true;
     }

--- a/test/Raven/Tests/ReprSerializerTest.php
+++ b/test/Raven/Tests/ReprSerializerTest.php
@@ -32,7 +32,7 @@ class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
         $serializer = new Raven_ReprSerializer();
         $input = 1;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_string($result));
+        $this->assertInternalType('string', $result);
         $this->assertEquals(1, $result);
     }
 
@@ -41,7 +41,7 @@ class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
         $serializer = new Raven_ReprSerializer();
         $input = 1.5;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_string($result));
+        $this->assertInternalType('string', $result);
         $this->assertEquals('1.5', $result);
     }
 
@@ -50,12 +50,11 @@ class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
         $serializer = new Raven_ReprSerializer();
         $input = true;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_string($result));
         $this->assertEquals('true', $result);
 
         $input = false;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_string($result));
+        $this->assertInternalType('string', $result);
         $this->assertEquals('false', $result);
     }
 
@@ -64,7 +63,7 @@ class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
         $serializer = new Raven_ReprSerializer();
         $input = null;
         $result = $serializer->serialize($input);
-        $this->assertTrue(is_string($result));
+        $this->assertInternalType('string', $result);
         $this->assertEquals('null', $result);
     }
 
@@ -75,5 +74,39 @@ class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);
         $this->assertEquals(array(array(array('Array of length 1'))), $result);
+    }
+
+    /**
+     * @covers Raven_ReprSerializer::serializeValue
+     */
+    public function testSerializeValueResource()
+    {
+        $serializer = new Raven_ReprSerializer();
+        $filename = tempnam(sys_get_temp_dir(), 'sentry_test_');
+        $fo = fopen($filename, 'wb');
+
+        $result = $serializer->serialize($fo);
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('Resource stream', $result);
+    }
+
+    /**
+     * @covers Raven_ReprSerializer::serializeValue
+     */
+    public function testSerializeRoundedFloat()
+    {
+        $serializer = new Raven_ReprSerializer();
+
+        $result = $serializer->serialize((double)1);
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('1.0', $result);
+
+        $result = $serializer->serialize((double)floor(5 / 2));
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('2.0', $result);
+
+        $result = $serializer->serialize((double)floor(12345.678901234));
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('12345.0', $result);
     }
 }

--- a/test/Raven/Tests/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/SanitizeDataProcessorTest.php
@@ -83,7 +83,7 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers setProcessorOptions
+     * @covers Raven_SanitizeDataProcessor::setProcessorOptions
      *
      */
     public function testSettingProcessorOptions()
@@ -115,6 +115,9 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
     public function testOverrideOptions($processorOptions, $client_options, $dsn)
     {
         $client = new Dummy_Raven_Client($dsn, $client_options);
+        /**
+         * @var Raven_SanitizeDataProcessor $processor
+         */
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);
@@ -151,6 +154,9 @@ class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
         );
 
         $client = new Dummy_Raven_Client($dsn, $client_options);
+        /**
+         * @var Raven_SanitizeDataProcessor $processor
+         */
         $processor = $client->processors[0];
 
         $this->assertInstanceOf('Raven_SanitizeDataProcessor', $processor);

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -102,12 +102,12 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
     public function testBrokenEncoding()
     {
         $serializer = new Raven_Serializer();
-        foreach (['7efbce4384', 'b782b5d8e5', '9dde8d1427', '8fd4c373ca', '9b8e84cb90'] as $key) {
+        foreach (array('7efbce4384', 'b782b5d8e5', '9dde8d1427', '8fd4c373ca', '9b8e84cb90') as $key) {
             $input = pack('H*', $key);
             $result = $serializer->serialize($input);
             $this->assertInternalType('string', $result);
             if (function_exists('mb_detect_encoding')) {
-                $this->assertContains(mb_detect_encoding($result), ['ASCII', 'UTF-8']);
+                $this->assertContains(mb_detect_encoding($result), array('ASCII', 'UTF-8'));
             }
         }
     }
@@ -119,7 +119,7 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
     {
         $serializer = new Raven_Serializer();
         for ($i = 0; $i < 100; $i++) {
-            foreach ([100, 1000, 1010, 1024, 1050, 1100, 10000] as $length) {
+            foreach (array(100, 1000, 1010, 1024, 1050, 1100, 10000) as $length) {
                 $input = '';
                 for ($i = 0; $i < $length; $i++) {
                     $input .= chr(mt_rand(0, 255));

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -209,6 +209,9 @@ class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
             $trace = $ex->getTrace();
             $frames = Raven_Stacktrace::get_stack_info($trace);
         }
+        /**
+         * @var array $frames
+         */
         $this->assertEquals($frames[count($frames) -1]['filename'], __FILE__);
     }
 }

--- a/test/Raven/Tests/TransactionStackTest.php
+++ b/test/Raven/Tests/TransactionStackTest.php
@@ -16,6 +16,8 @@ class Raven_Tests_TransactionStackTest extends PHPUnit_Framework_TestCase
     {
         $stack = new Raven_TransactionStack();
         $stack->push('hello');
+        /** @noinspection PhpVoidFunctionResultUsedInspection */
+        /** @noinspection PhpUnusedLocalVariableInspection */
         $foo = $stack->push('foo');
         $stack->push('bar');
         $stack->push('world');
@@ -25,5 +27,9 @@ class Raven_Tests_TransactionStackTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($stack->peek(), 'hello');
         $this->assertEquals($stack->pop(), 'hello');
         $this->assertEquals($stack->peek(), null);
+
+        $stack->clear();
+        $this->assertInternalType('array', $stack->stack);
+        $this->assertEquals(0, count($stack->stack));
     }
 }


### PR DESCRIPTION
Sorry guys. I just can not see that anymore. I open my Idea and then I want to pull my eyes out.
![warnings_in_main_class](https://cloud.githubusercontent.com/assets/9131758/22930052/8d73a342-f2cf-11e6-9723-456423364cf9.PNG)
![actual_expected_swap](https://cloud.githubusercontent.com/assets/9131758/22930053/8d74169c-f2cf-11e6-9753-038bcc682757.PNG)
![equals_wrap_codestyle](https://cloud.githubusercontent.com/assets/9131758/22930050/8d72a6fe-f2cf-11e6-9ae0-caa7eb164495.PNG)

I added and fixed many phpdoc-comments of class methods.
I added properties in classes.

And impove code coverage.
![code_coverage_improve](https://cloud.githubusercontent.com/assets/9131758/22930051/8d733560-f2cf-11e6-8c64-78d183c57df2.PNG)