### PR TITLE
fix autoload raven class failed

### DIFF
--- a/lib/Raven/Autoloader.php
+++ b/lib/Raven/Autoloader.php
@@ -32,7 +32,7 @@ class Raven_Autoloader
      */
     public static function autoload($class)
     {
-        if (substr($class, 0, 6) == 'Raven_') {
+        if (substr($class, 0, 6) !== 'Raven_') {
             return;
         }
 


### PR DESCRIPTION
I think this condition is on the contrary, and will result in unable to load any class prefixed by raven