### PR TITLE
Allow reset the Breadcrumb storage

### DIFF
--- a/lib/Raven/Breadcrumbs.php
+++ b/lib/Raven/Breadcrumbs.php
@@ -26,9 +26,14 @@ class Raven_Breadcrumbs
 
     public function __construct($size = 100)
     {
+        $this->size = $size;
+        $this->reset();
+    }
+
+    public function reset()
+    {
         $this->count = 0;
         $this->pos = 0;
-        $this->size = $size;
         $this->buffer = array();
     }
 


### PR DESCRIPTION
This is particularly useful when a PHP script is consuming message from a queue. I want to be able to reset the breadcrumb between each messages