### PR TITLE
Re-throw exception to invoke the native handler when a custom handler…

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -77,8 +77,12 @@ class Raven_ErrorHandler
     {
         $e->event_id = $this->client->captureException($e, null, null, $vars);
 
-        if (!$isError && $this->call_existing_exception_handler && $this->old_exception_handler) {
-            call_user_func($this->old_exception_handler, $e);
+        if (!$isError && $this->call_existing_exception_handler) {
+            if ($this->old_exception_handler !== null) {
+                call_user_func($this->old_exception_handler, $e);
+            } else {
+                throw $e;
+            }
         }
     }
 


### PR DESCRIPTION
This change causes captured exceptions to be propagated up to the native exception handler (re-thrown).

This behaviour is on by default and is controlled by a boolean variable passed to the `registerExceptionHandler` on the `ErrorHandler`.

Right now exceptions are propagated to the existing exception handler if one exists (other than the native handler, meaning a custom function has been set using `set_exception_handler`).

However if no custom exception handler is set exceptions will not propagate further than Sentry's handler. In other words exceptions are captured by Sentry but not re-thrown.

Because of this change in behaviour some may consider this a breaking change so we should consider the effects of it before release.

Because right now exceptions are not re-thrown the application is allowed to continue to execute and some applications may have unfortunately become dependent on this behaviour.

Those applications will face `Uncaught Exception` fatal errors if this change is activated for them.

Related issue: #407 

