### PR TITLE
Add a processor to sanitize the HTTP headers

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
   ``call_existing`` is true and no exception handler is registered (#421).
 - Collect User.ip_address automatically (#419).
 - Added a processor to remove web cookies and another to remove HTTP body data for POST, PUT, PATCH and DELETE requests. They will be enabled by default in ``2.0`` (#405).
+- Added a processor to sanitize HTTP headers (e.g. the Authorization header) (#428).
 
 1.6.2
 -----

--- a/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
+++ b/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This processor sanitizes the configured HTTP headers to ensure no sensitive
+ * informations are sent to the server.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class Raven_Processor_SanitizeHttpHeadersProcessor extends Raven_Processor
+{
+    /**
+     * @var string[] $httpHeadersToSanitize The list of HTTP headers to sanitize
+     */
+    private $httpHeadersToSanitize = array();
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Raven_Client $client)
+    {
+        parent::__construct($client);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setProcessorOptions(array $options)
+    {
+        $this->httpHeadersToSanitize = array_merge($this->getDefaultHeaders(), isset($options['sanitize_http_headers']) ? $options['sanitize_http_headers'] : array());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(&$data)
+    {
+        if (isset($data['request']) && isset($data['request']['headers'])) {
+            foreach ($data['request']['headers'] as $header => &$value) {
+                if (in_array($header, $this->httpHeadersToSanitize)) {
+                    $value = self::STRING_MASK;
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets the list of default headers that must be sanitized.
+     *
+     * @return string[]
+     */
+    private function getDefaultHeaders()
+    {
+        return array('Authorization', 'Proxy-Authorization', 'X-Csrf-Token', 'X-CSRFToken', 'X-XSRF-TOKEN');
+    }
+}

--- a/test/Raven/Tests/Processor/SanitizeHttpHeadersProcessorTest.php
+++ b/test/Raven/Tests/Processor/SanitizeHttpHeadersProcessorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_SanitizeHttpHeadersProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Raven_Processor_SanitizeHttpHeadersProcessor|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $processor;
+
+    protected function setUp()
+    {
+        /** @var \Raven_Client|\PHPUnit_Framework_MockObject_MockObject $client */
+        $client = $this->getMockBuilder('\Raven_Client')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->processor = new Raven_Processor_SanitizeHttpHeadersProcessor($client);
+        $this->processor->setProcessorOptions(array(
+            'sanitize_http_headers' => array('User-Defined-Header'),
+        ));
+    }
+
+    /**
+     * @dataProvider processDataProvider
+     */
+    public function testProcess($inputData, $expectedData)
+    {
+        $this->processor->process($inputData);
+
+        $this->assertArraySubset($expectedData, $inputData);
+    }
+
+    public function processDataProvider()
+    {
+        return array(
+            array(
+                array(
+                    'request' => array(
+                        'headers' => array(
+                            'Authorization' => 'foo',
+                            'AnotherHeader' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'headers' => array(
+                            'Authorization' => Raven_Processor::STRING_MASK,
+                            'AnotherHeader' => 'bar',
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'request' => array(
+                        'headers' => array(
+                            'User-Defined-Header' => 'foo',
+                            'AnotherHeader' => 'bar',
+                        ),
+                    ),
+                ),
+                array(
+                    'request' => array(
+                        'headers' => array(
+                            'User-Defined-Header' => Raven_Processor::STRING_MASK,
+                            'AnotherHeader' => 'bar',
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

Some HTTP headers like the `Authorization` header could contain sensitive informations. The processor added with this PR is a porting of the one added for the Ruby client in getsentry/raven-ruby#537