### PR TITLE
Add a processor to remove all stacktraces from reported exceptions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@
 - Collect User.ip_address automatically (#419).
 - Added a processor to remove web cookies and another to remove HTTP body data for POST, PUT, PATCH and DELETE requests. They will be enabled by default in ``2.0`` (#405).
 - Added a processor to sanitize HTTP headers (e.g. the Authorization header) (#428).
+- Added a processor to remove ``pre_context``, ``context_line`` and ``post_context`` informations from reported exceptions (#429).
 
 1.6.2
 -----

--- a/lib/Raven/Processor/SanitizeStacktraceProcessor.php
+++ b/lib/Raven/Processor/SanitizeStacktraceProcessor.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * This processor removes the `pre_context`, `context_line` and `post_context`
+ * informations from all exceptions captured by an event.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+class Raven_Processor_SanitizeStacktraceProcessor extends Raven_Processor
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(&$data)
+    {
+        if (!isset($data['exception'], $data['exception']['values'])) {
+            return;
+        }
+
+        foreach ($data['exception']['values'] as &$exception) {
+            if (!isset($exception['stacktrace'])) {
+                continue;
+            }
+
+            foreach ($exception['stacktrace']['frames'] as &$frame) {
+                unset($frame['pre_context'], $frame['context_line'], $frame['post_context']);
+            }
+        }
+    }
+}

--- a/test/Raven/Tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/test/Raven/Tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+class Raven_Tests_SanitizeStacktraceProcessorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Raven_Client|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $client;
+
+    /**
+     * @var Raven_Processor_SanitizeStacktraceProcessor
+     */
+    protected $processor;
+
+    protected function setUp()
+    {
+        $this->client = $this->getMockBuilder('Raven_Client')
+            ->setMethods(array_diff($this->getClassMethods('Raven_Client'), array('captureException', 'capture', 'get_default_data', 'get_http_data', 'get_user_data', 'get_extra_data')))
+            ->getMock();
+
+        $this->client->store_errors_for_bulk_send = true;
+
+        $this->processor = new Raven_Processor_SanitizeStacktraceProcessor($this->client);
+    }
+
+    public function testProcess()
+    {
+        try {
+            throw new \Exception();
+        } catch (\Exception $exception) {
+            $this->client->captureException($exception);
+        }
+
+        foreach ($this->client->_pending_events[0]['exception']['values'] as $exceptionValue) {
+            foreach ($exceptionValue['stacktrace']['frames'] as $frame) {
+                $this->assertArrayHasKey('pre_context', $frame);
+                $this->assertArrayHasKey('context_line', $frame);
+                $this->assertArrayHasKey('post_context', $frame);
+            }
+        }
+
+        $this->processor->process($this->client->_pending_events[0]);
+
+        foreach ($this->client->_pending_events[0]['exception']['values'] as $exceptionValue) {
+            foreach ($exceptionValue['stacktrace']['frames'] as $frame) {
+                $this->assertArrayNotHasKey('pre_context', $frame);
+                $this->assertArrayNotHasKey('context_line', $frame);
+                $this->assertArrayNotHasKey('post_context', $frame);
+            }
+        }
+    }
+
+    public function testProcessWithPreviousException()
+    {
+        try {
+            try {
+                throw new \Exception('foo');
+            } catch (\Exception $exception) {
+                throw new \Exception('bar', 0, $exception);
+            }
+        } catch (\Exception $exception) {
+            $this->client->captureException($exception);
+        }
+
+        foreach ($this->client->_pending_events[0]['exception']['values'] as $exceptionValue) {
+            foreach ($exceptionValue['stacktrace']['frames'] as $frame) {
+                $this->assertArrayHasKey('pre_context', $frame);
+                $this->assertArrayHasKey('context_line', $frame);
+                $this->assertArrayHasKey('post_context', $frame);
+            }
+        }
+
+        $this->processor->process($this->client->_pending_events[0]);
+
+        foreach ($this->client->_pending_events[0]['exception']['values'] as $exceptionValue) {
+            foreach ($exceptionValue['stacktrace']['frames'] as $frame) {
+                $this->assertArrayNotHasKey('pre_context', $frame);
+                $this->assertArrayNotHasKey('context_line', $frame);
+                $this->assertArrayNotHasKey('post_context', $frame);
+            }
+        }
+    }
+
+    /**
+     * Gets all the public and abstracts methods of a given class.
+     *
+     * @param string $className The FCQN of the class
+     *
+     * @return array
+     */
+    private function getClassMethods($className)
+    {
+        $class = new ReflectionClass($className);
+        $methods = array();
+
+        foreach ($class->getMethods() as $method) {
+            if ($method->isPublic() || $method->isAbstract()) {
+                $methods[] = $method->getName();
+            }
+        }
+
+        return $methods;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes

This PR implements a processor that removes all stacktraces from reported exceptions. Its code is a direct porting of the processor added to the Ruby client with getsentry/raven-ruby#233