### PR TITLE
Add badges from shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,23 @@ sentry-php
 
 .. image:: https://secure.travis-ci.org/getsentry/sentry-php.png?branch=master
    :target: http://travis-ci.org/getsentry/sentry-php
+   :alt: Build Status
+
+.. image:: https://img.shields.io/packagist/dt/sentry/sentry.svg?style=flat-square
+   :target: https://packagist.org/packages/sentry/sentry
+   :alt: Total Downloads
+
+.. image:: https://img.shields.io/packagist/dm/sentry/sentry.svg?style=flat-square
+   :target: https://packagist.org/packages/sentry/sentry
+   :alt: Downloads per month
+
+.. image:: https://img.shields.io/packagist/v/sentry/sentry.svg?style=flat-square
+   :target: https://packagist.org/packages/sentry/sentry
+   :alt: Latest stable version
+
+.. image:: http://img.shields.io/packagist/l/sentry/sentry.svg?style=flat-square
+   :target: https://packagist.org/packages/sentry/sentry
+   :alt: License
 
 
 The official PHP SDK for `Sentry <https://getsentry.com/>`_.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I added more badges to the README file and I chose [shields.io](https://shields.io) because they provide SVGs that scale well on all monitor sizes. Would be possible to convert the file to Markdown? GitHub does not render reStructuredText files, but it does well with Markdown