### PR TITLE
Sentry 2.0 [pull request #2]

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,6 +3,7 @@
 return PhpCsFixer\Config::create()
     ->setRules([
         '@PSR2' => true,
+        'array_syntax' => ['syntax' => 'short'],
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.1
     - php: hhvm-3.12
     - php: nightly
   fast_finish: true

--- a/bin/sentry
+++ b/bin/sentry
@@ -55,7 +55,7 @@ function cmd_test($dsn)
 
     echo "Sending a test event:\n";
 
-    $ex = raven_cli_test("command name", array("foo" => "bar"));
+    $ex = raven_cli_test("command name", ["foo" => "bar"]);
     $event_id = $client->captureException($ex);
 
     echo "-> event ID: $event_id\n";

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
             "vendor/bin/phpunit --verbose"
         ],
         "tests-report": [
-            "vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-html tests/html-report"
+            "vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-html tests/html-report"
         ],
         "phpcs": [
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"

--- a/examples/vanilla/index.php
+++ b/examples/vanilla/index.php
@@ -12,7 +12,7 @@ function setupSentry()
     $object = new \Raven\Client(SENTRY_DSN);
     $object->setAppPath(__DIR__)
            ->setRelease(\Raven\Client::VERSION)
-           ->setPrefixes(array(__DIR__))
+           ->setPrefixes([__DIR__])
            ->install();
 }
 

--- a/lib/Raven/Breadcrumbs.php
+++ b/lib/Raven/Breadcrumbs.php
@@ -36,7 +36,7 @@ class Breadcrumbs
     {
         $this->count = 0;
         $this->pos = 0;
-        $this->buffer = array();
+        $this->buffer = [];
     }
 
     public function record($crumb)
@@ -54,7 +54,7 @@ class Breadcrumbs
      */
     public function fetch()
     {
-        $results = array();
+        $results = [];
         for ($i = 0; $i <= ($this->size - 1); $i++) {
             $idx = ($this->pos + $i) % $this->size;
             if (isset($this->buffer[$idx])) {
@@ -71,8 +71,8 @@ class Breadcrumbs
 
     public function to_json()
     {
-        return array(
+        return [
             'values' => $this->fetch(),
-        );
+        ];
     }
 }

--- a/lib/Raven/Breadcrumbs/ErrorHandler.php
+++ b/lib/Raven/Breadcrumbs/ErrorHandler.php
@@ -19,18 +19,18 @@ class ErrorHandler
         $this->ravenClient = $ravenClient;
     }
 
-    public function handleError($code, $message, $file = '', $line = 0, $context = array())
+    public function handleError($code, $message, $file = '', $line = 0, $context = [])
     {
-        $this->ravenClient->breadcrumbs->record(array(
+        $this->ravenClient->breadcrumbs->record([
             'category' => 'error_reporting',
             'message' => $message,
             'level' => $this->ravenClient->translateSeverity($code),
-            'data' => array(
+            'data' => [
                 'code' => $code,
                 'line' => $line,
                 'file' => $file,
-            ),
-        ));
+            ],
+        ]);
 
         if ($this->existingHandler !== null) {
             return call_user_func($this->existingHandler, $code, $message, $file, $line, $context);
@@ -41,7 +41,7 @@ class ErrorHandler
 
     public function install()
     {
-        $this->existingHandler = set_error_handler(array($this, 'handleError'), E_ALL);
+        $this->existingHandler = set_error_handler([$this, 'handleError'], E_ALL);
         return $this;
     }
 }

--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -9,7 +9,7 @@ class MonologHandler extends \Monolog\Handler\AbstractProcessingHandler
     /**
      * Translates Monolog log levels to Raven log levels.
      */
-    protected $logLevels = array(
+    protected $logLevels = [
         Logger::DEBUG     => \Raven\Client::DEBUG,
         Logger::INFO      => \Raven\Client::INFO,
         Logger::NOTICE    => \Raven\Client::INFO,
@@ -18,7 +18,7 @@ class MonologHandler extends \Monolog\Handler\AbstractProcessingHandler
         Logger::CRITICAL  => \Raven\Client::FATAL,
         Logger::ALERT     => \Raven\Client::FATAL,
         Logger::EMERGENCY => \Raven\Client::FATAL,
-    );
+    ];
 
     protected $excMatch = '/^exception \'([^\']+)\' with message \'(.+)\' in .+$/s';
 
@@ -46,7 +46,7 @@ class MonologHandler extends \Monolog\Handler\AbstractProcessingHandler
     protected function parseException($message)
     {
         if (preg_match($this->excMatch, $message, $matches)) {
-            return array($matches[1], $matches[2]);
+            return [$matches[1], $matches[2]];
         }
 
         return null;
@@ -67,33 +67,33 @@ class MonologHandler extends \Monolog\Handler\AbstractProcessingHandler
              * @var \Exception $exc
              */
             $exc = $record['context']['exception'];
-            $crumb = array(
+            $crumb = [
                 'type' => 'error',
                 'level' => $this->logLevels[$record['level']],
                 'category' => $record['channel'],
-                'data' => array(
+                'data' => [
                     'type' => get_class($exc),
                     'value' => $exc->getMessage(),
-                ),
-            );
+                ],
+            ];
         } else {
             // TODO(dcramer): parse exceptions out of messages and format as above
             if ($error = $this->parseException($record['message'])) {
-                $crumb = array(
+                $crumb = [
                     'type' => 'error',
                     'level' => $this->logLevels[$record['level']],
                     'category' => $record['channel'],
-                    'data' => array(
+                    'data' => [
                         'type' => $error[0],
                         'value' => $error[1],
-                    ),
-                );
+                    ],
+                ];
             } else {
-                $crumb = array(
+                $crumb = [
                     'level' => $this->logLevels[$record['level']],
                     'category' => $record['channel'],
                     'message' => $record['message'],
-                );
+                ];
             }
         }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -233,7 +233,7 @@ class Client
      */
     protected $_shutdown_function_has_been_set;
 
-    public function __construct($options_or_dsn = null, $options = array())
+    public function __construct($options_or_dsn = null, $options = [])
     {
         if (is_array($options_or_dsn)) {
             $options = array_merge($options_or_dsn, $options);
@@ -332,15 +332,15 @@ class Client
         $this->_curl_instance = null;
         $this->_last_event_id = null;
         $this->_user = null;
-        $this->_pending_events = array();
+        $this->_pending_events = [];
         $this->context = new \Raven\Context();
         $this->breadcrumbs = new \Raven\Breadcrumbs();
         $this->_shutdown_function_has_been_set = false;
 
-        $this->sdk = \Raven\Util::get($options, 'sdk', array(
+        $this->sdk = \Raven\Util::get($options, 'sdk', [
             'name' => 'sentry-php',
             'version' => self::VERSION,
-        ));
+        ]);
         $this->serializer = new \Raven\Serializer($this->mb_detect_order);
         $this->reprSerializer = new \Raven\ReprSerializer($this->mb_detect_order);
         if (\Raven\Util::get($options, 'serialize_all_object', false)) {
@@ -372,7 +372,7 @@ class Client
      */
     public function close_all_children_link()
     {
-        $this->processors = array();
+        $this->processors = [];
     }
 
     /**
@@ -475,7 +475,7 @@ class Client
 
     public function setExcludedAppPaths($value)
     {
-        $this->excluded_app_paths = $value ? array_map(array($this, '_convertPath'), $value) : null;
+        $this->excluded_app_paths = $value ? array_map([$this, '_convertPath'], $value) : null;
         return $this;
     }
 
@@ -490,7 +490,7 @@ class Client
      */
     public function setPrefixes($value)
     {
-        $this->prefixes = $value ? array_map(array($this, '_convertPath'), $value) : $value;
+        $this->prefixes = $value ? array_map([$this, '_convertPath'], $value) : $value;
         return $this;
     }
 
@@ -541,9 +541,9 @@ class Client
      */
     public static function getDefaultProcessors()
     {
-        return array(
+        return [
             '\\Raven\\Processor\\SanitizeDataProcessor',
-        );
+        ];
     }
 
     /**
@@ -555,7 +555,7 @@ class Client
      */
     public function setProcessorsFromOptions($options)
     {
-        $processors = array();
+        $processors = [];
         foreach (\Raven\util::get($options, 'processors', static::getDefaultProcessors()) as $processor) {
             /**
              * @var \Raven\Processor        $new_processor
@@ -587,10 +587,10 @@ class Client
     {
         $url = parse_url($dsn);
         $scheme = (isset($url['scheme']) ? $url['scheme'] : '');
-        if (!in_array($scheme, array('http', 'https'))) {
+        if (!in_array($scheme, ['http', 'https'])) {
             throw new \InvalidArgumentException(
                 'Unsupported Sentry DSN scheme: '.
-                (!empty($scheme) ? $scheme : '<not set>')
+                (!empty($scheme) ? $scheme : /** @lang text */'<not set>')
             );
         }
         $netloc = (isset($url['host']) ? $url['host'] : null);
@@ -615,12 +615,12 @@ class Client
             throw new \InvalidArgumentException('Invalid Sentry DSN: ' . $dsn);
         }
 
-        return array(
+        return [
             'server'     => sprintf('%s://%s%s/api/%s/store/', $scheme, $netloc, $path, $project),
             'project'    => $project,
             'public_key' => $username,
             'secret_key' => $password,
-        );
+        ];
     }
 
     public function getLastError()
@@ -651,7 +651,7 @@ class Client
      * @deprecated
      * @codeCoverageIgnore
      */
-    public function message($message, $params = array(), $level = self::INFO,
+    public function message($message, $params = [], $level = self::INFO,
                             $stack = false, $vars = null)
     {
         return $this->captureMessage($message, $params, $level, $stack, $vars);
@@ -678,7 +678,7 @@ class Client
      * @param mixed      $vars
      * @return string|null
      */
-    public function captureMessage($message, $params = array(), $data = array(),
+    public function captureMessage($message, $params = [], $data = [],
                             $stack = false, $vars = null)
     {
         // Gracefully handle messages which contain formatting characters, but were not
@@ -690,20 +690,20 @@ class Client
         }
 
         if ($data === null) {
-            $data = array();
+            $data = [];
         // support legacy method of passing in a level name as the third arg
         } elseif (!is_array($data)) {
-            $data = array(
+            $data = [
                 'level' => $data,
-            );
+            ];
         }
 
         $data['message'] = $formatted_message;
-        $data['sentry.interfaces.Message'] = array(
+        $data['sentry.interfaces.Message'] = [
             'message' => $message,
             'params' => $params,
             'formatted' => $formatted_message,
-        );
+        ];
 
         return $this->capture($data, $stack, $vars);
     }
@@ -726,25 +726,25 @@ class Client
         }
 
         if ($data === null) {
-            $data = array();
+            $data = [];
         }
 
         $exc = $exception;
         do {
-            $exc_data = array(
+            $exc_data = [
                 'value' => $this->serializer->serialize($exc->getMessage()),
                 'type' => get_class($exc),
-            );
+            ];
 
             /**'exception'
              * Exception::getTrace doesn't store the point at where the exception
              * was thrown, so we have to stuff it in ourselves. Ugh.
              */
             $trace = $exc->getTrace();
-            $frame_where_exception_thrown = array(
+            $frame_where_exception_thrown = [
                 'file' => $exc->getFile(),
                 'line' => $exc->getLine(),
-            );
+            ];
 
             array_unshift($trace, $frame_where_exception_thrown);
 
@@ -755,16 +755,18 @@ class Client
                 // @codeCoverageIgnoreEnd
             }
 
-            $exc_data['stacktrace'] = array(
-                'frames' => Stacktrace::fromBacktrace($this, $exception->getTrace(), $exception->getFile(), $exception->getLine())->getFrames(),
-            );
+            $exc_data['stacktrace'] = [
+                'frames' => Stacktrace::fromBacktrace(
+                    $this, $exception->getTrace(), $exception->getFile(), $exception->getLine()
+                )->getFrames(),
+            ];
 
             $exceptions[] = $exc_data;
         } while ($has_chained_exceptions && $exc = $exc->getPrevious());
 
-        $data['exception'] = array(
+        $data['exception'] = [
             'values' => array_reverse($exceptions),
-        );
+        ];
         if ($logger !== null) {
             $data['logger'] = $logger;
         }
@@ -810,13 +812,13 @@ class Client
      */
     public function captureQuery($query, $level = self::INFO, $engine = '')
     {
-        $data = array(
+        $data = [
             'message' => $query,
             'level' => $level,
-            'sentry.interfaces.Query' => array(
+            'sentry.interfaces.Query' => [
                 'query' => $query
-            )
-        );
+            ]
+        ];
 
         if ($engine !== '') {
             $data['sentry.interfaces.Query']['engine'] = $engine;
@@ -842,7 +844,7 @@ class Client
     {
         if (!$this->_shutdown_function_has_been_set) {
             $this->_shutdown_function_has_been_set = true;
-            register_shutdown_function(array($this, 'onShutdown'));
+            register_shutdown_function([$this, 'onShutdown']);
         }
     }
 
@@ -857,24 +859,24 @@ class Client
 
     protected function get_http_data()
     {
-        $headers = array();
+        $headers = [];
 
         foreach ($_SERVER as $key => $value) {
             if (0 === strpos($key, 'HTTP_')) {
                 $header_key =
                     str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
                 $headers[$header_key] = $value;
-            } elseif (in_array($key, array('CONTENT_TYPE', 'CONTENT_LENGTH')) && $value !== '') {
+            } elseif (in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH']) && $value !== '') {
                 $header_key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))));
                 $headers[$header_key] = $value;
             }
         }
 
-        $result = array(
+        $result = [
             'method' => self::_server_variable('REQUEST_METHOD'),
             'url' => $this->get_current_url(),
             'query_string' => self::_server_variable('QUERY_STRING'),
-        );
+        ];
 
         // dont set this as an empty array as PHP will treat it as a numeric array
         // instead of a mapping which goes against the defined Sentry spec
@@ -888,9 +890,9 @@ class Client
             $result['headers'] = $headers;
         }
 
-        return array(
+        return [
             'request' => $result,
-        );
+        ];
     }
 
     protected function get_user_data()
@@ -898,11 +900,11 @@ class Client
         $user = $this->context->user;
         if ($user === null) {
             if (!function_exists('session_id') || !session_id()) {
-                return array();
+                return [];
             }
-            $user = array(
+            $user = [
                 'id' => session_id(),
-            );
+            ];
             if (!empty($_SERVER['REMOTE_ADDR'])) {
                 $user['ip_address'] = $_SERVER['REMOTE_ADDR'];
             }
@@ -910,9 +912,9 @@ class Client
                 $user['data'] = $_SESSION;
             }
         }
-        return array(
+        return [
             'user' => $user,
-        );
+        ];
     }
 
     protected function get_extra_data()
@@ -922,7 +924,7 @@ class Client
 
     public function get_default_data()
     {
-        return array(
+        return [
             'server_name' => $this->name,
             'project' => $this->project,
             'site' => $this->site,
@@ -931,7 +933,7 @@ class Client
             'platform' => 'php',
             'sdk' => $this->sdk,
             'culprit' => $this->transaction->peek(),
-        );
+        ];
     }
 
     public function capture($data, $stack = null, $vars = null)
@@ -943,10 +945,10 @@ class Client
             $data['level'] = self::ERROR;
         }
         if (!isset($data['tags'])) {
-            $data['tags'] = array();
+            $data['tags'] = [];
         }
         if (!isset($data['extra'])) {
-            $data['extra'] = array();
+            $data['extra'] = [];
         }
         if (!isset($data['event_id'])) {
             $data['event_id'] = static::uuid4();
@@ -1014,9 +1016,12 @@ class Client
             }
 
             if (!isset($data['stacktrace']) && !isset($data['exception'])) {
-                $data['stacktrace'] = array(
-                    'frames' => Stacktrace::fromBacktrace($this, $stack, isset($stack['file']) ? $stack['file'] : __FILE__, isset($stack['line']) ? $stack['line'] : __LINE__)->getFrames(),
-                );
+                $data['stacktrace'] = [
+                    'frames' => Stacktrace::fromBacktrace(
+                        $this, $stack, isset($stack['file']) ? $stack['file'] : __FILE__,
+                        isset($stack['line']) ? $stack['line'] : __LINE__ - 2
+                    )->getFrames(),
+                ];
             }
         }
 
@@ -1073,7 +1078,7 @@ class Client
         foreach ($this->_pending_events as $data) {
             $this->send($data);
         }
-        $this->_pending_events = array();
+        $this->_pending_events = [];
         if ($this->store_errors_for_bulk_send) {
             //in case an error occurs after this is called, on shutdown, send any new errors.
             $this->store_errors_for_bulk_send = !defined('RAVEN_CLIENT_END_REACHED');
@@ -1116,7 +1121,7 @@ class Client
     public function send(&$data)
     {
         if (is_callable($this->send_callback)
-            && call_user_func_array($this->send_callback, array(&$data)) === false
+            && call_user_func_array($this->send_callback, [&$data]) === false
         ) {
             // if send_callback returns false, end native send
             return;
@@ -1138,11 +1143,11 @@ class Client
 
         $message = $this->encode($data);
 
-        $headers = array(
+        $headers = [
             'User-Agent' => static::getUserAgent(),
             'X-Sentry-Auth' => $this->getAuthHeader(),
             'Content-Type' => 'application/octet-stream'
-        );
+        ];
 
         $this->send_remote($this->server, $message, $headers);
     }
@@ -1154,7 +1159,7 @@ class Client
      * @param array|string $data    Associative array of data to log
      * @param array        $headers Associative array of headers
      */
-    protected function send_remote($url, $data, $headers = array())
+    protected function send_remote($url, $data, $headers = [])
     {
         $parts = parse_url($url);
         $parts['netloc'] = $parts['host'].(isset($parts['port']) ? ':'.$parts['port'] : null);
@@ -1169,16 +1174,17 @@ class Client
     /**
      * @return array
      * @doc http://stackoverflow.com/questions/9062798/php-curl-timeout-is-not-working/9063006#9063006
+     * @doc https://3v4l.org/4I7F5
      */
     protected function get_curl_options()
     {
-        $options = array(
+        $options = [
             CURLOPT_VERBOSE => false,
             CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_SSL_VERIFYPEER => $this->verify_ssl,
             CURLOPT_CAINFO => $this->ca_cert,
             CURLOPT_USERAGENT => 'sentry-php/' . self::VERSION,
-        );
+        ];
         if ($this->http_proxy) {
             $options[CURLOPT_PROXY] = $this->http_proxy;
         }
@@ -1192,7 +1198,7 @@ class Client
             // MS is available in curl >= 7.16.2
             $timeout = max(1, ceil(1000 * $this->timeout));
 
-            // some versions of PHP 5.3 don't have this defined correctly
+            // None of the versions of PHP contains this constant
             if (!defined('CURLOPT_CONNECTTIMEOUT_MS')) {
                 //see stackoverflow link in the phpdoc
                 define('CURLOPT_CONNECTTIMEOUT_MS', 156);
@@ -1216,7 +1222,7 @@ class Client
      * @param array|string $data    Associative array of data to log
      * @param array        $headers Associative array of headers
      */
-    protected function send_http($url, $data, $headers = array())
+    protected function send_http($url, $data, $headers = [])
     {
         if ($this->curl_method == 'async') {
             $this->_curl_handler->enqueue($url, $data, $headers);
@@ -1269,7 +1275,7 @@ class Client
      */
     protected function send_http_synchronous($url, $data, $headers)
     {
-        $new_headers = array();
+        $new_headers = [];
         foreach ($headers as $key => $value) {
             array_push($new_headers, $key .': '. $value);
         }
@@ -1332,11 +1338,11 @@ class Client
      */
     protected static function get_auth_header($timestamp, $client, $api_key, $secret_key)
     {
-        $header = array(
+        $header = [
             sprintf('sentry_timestamp=%F', $timestamp),
             "sentry_client={$client}",
             sprintf('sentry_version=%s', self::PROTOCOL),
-        );
+        ];
 
         if ($api_key) {
             $header[] = "sentry_key={$api_key}";
@@ -1487,7 +1493,7 @@ class Client
      * Provide a map of PHP Error constants to Sentry logging groups to use instead
      * of the defaults in translateSeverity()
      *
-     * @param array $map
+     * @param string[] $map
      */
     public function registerSeverityMap($map)
     {
@@ -1503,9 +1509,9 @@ class Client
      * @param array       $data  Additional user data
      * @codeCoverageIgnore
      */
-    public function set_user_data($id, $email = null, $data = array())
+    public function set_user_data($id, $email = null, $data = [])
     {
-        $user = array('id' => $id);
+        $user = ['id' => $id];
         if (isset($email)) {
             $user['email'] = $email;
         }

--- a/lib/Raven/Context.php
+++ b/lib/Raven/Context.php
@@ -32,8 +32,8 @@ class Context
      */
     public function clear()
     {
-        $this->tags = array();
-        $this->extra = array();
+        $this->tags = [];
+        $this->extra = [];
         $this->user = null;
     }
 }

--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -28,10 +28,10 @@ class CurlHandler
     {
         $this->options = $options;
         $this->multi_handle = curl_multi_init();
-        $this->requests = array();
+        $this->requests = [];
         $this->join_timeout = 5;
 
-        register_shutdown_function(array($this, 'join'));
+        register_shutdown_function([$this, 'join']);
     }
 
     public function __destruct()
@@ -39,11 +39,11 @@ class CurlHandler
         $this->join();
     }
 
-    public function enqueue($url, $data = null, $headers = array())
+    public function enqueue($url, $data = null, $headers = [])
     {
         $ch = curl_init();
 
-        $new_headers = array();
+        $new_headers = [];
         foreach ($headers as $key => $value) {
             array_push($new_headers, $key .': '. $value);
         }

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -36,7 +36,7 @@ class ErrorHandler
     /** @var \Raven\Client */
     protected $client;
     protected $send_errors_last = false;
-    protected $fatal_error_types = array(
+    protected $fatal_error_types = [
         E_ERROR,
         E_PARSE,
         E_CORE_ERROR,
@@ -44,7 +44,7 @@ class ErrorHandler
         E_COMPILE_ERROR,
         E_COMPILE_WARNING,
         E_STRICT,
-    );
+    ];
 
     /**
      * @var array
@@ -63,7 +63,7 @@ class ErrorHandler
 
         $this->client = $client;
         $this->error_types = $error_types;
-        $this->fatal_error_types = array_reduce($this->fatal_error_types, array($this, 'bitwiseOr'));
+        $this->fatal_error_types = array_reduce($this->fatal_error_types, [$this, 'bitwiseOr']);
         if ($send_errors_last) {
             $this->send_errors_last = true;
             $this->client->store_errors_for_bulk_send = true;
@@ -88,7 +88,7 @@ class ErrorHandler
         }
     }
 
-    public function handleError($type, $message, $file = '', $line = 0, $context = array())
+    public function handleError($type, $message, $file = '', $line = 0, $context = [])
     {
         // http://php.net/set_error_handler
         // The following error types cannot be handled with a user defined function: E_ERROR,
@@ -155,7 +155,7 @@ class ErrorHandler
      */
     public function registerExceptionHandler($call_existing = true)
     {
-        $this->old_exception_handler = set_exception_handler(array($this, 'handleException'));
+        $this->old_exception_handler = set_exception_handler([$this, 'handleException']);
         $this->call_existing_exception_handler = $call_existing;
         return $this;
     }
@@ -174,7 +174,7 @@ class ErrorHandler
         if ($error_types !== null) {
             $this->error_types = $error_types;
         }
-        $this->old_error_handler = set_error_handler(array($this, 'handleError'), E_ALL);
+        $this->old_error_handler = set_error_handler([$this, 'handleError'], E_ALL);
         $this->call_existing_error_handler = $call_existing;
         return $this;
     }
@@ -189,7 +189,7 @@ class ErrorHandler
      */
     public function registerShutdownFunction($reservedMemorySize = 10)
     {
-        register_shutdown_function(array($this, 'handleFatalError'));
+        register_shutdown_function([$this, 'handleFatalError']);
 
         $this->reservedMemory = str_repeat('x', 1024 * $reservedMemorySize);
         return $this;

--- a/lib/Raven/Processor/RemoveHttpBodyProcessor.php
+++ b/lib/Raven/Processor/RemoveHttpBodyProcessor.php
@@ -27,7 +27,9 @@ final class RemoveHttpBodyProcessor extends Processor
      */
     public function process(&$data)
     {
-        if (isset($data['request'], $data['request']['method']) && in_array(strtoupper($data['request']['method']), array('POST', 'PUT', 'PATCH', 'DELETE'))) {
+        if (isset($data['request'], $data['request']['method'])
+            && in_array(strtoupper($data['request']['method']), ['POST', 'PUT', 'PATCH', 'DELETE'])
+        ) {
             $data['request']['data'] = self::STRING_MASK;
         }
     }

--- a/lib/Raven/Processor/SanitizeDataProcessor.php
+++ b/lib/Raven/Processor/SanitizeDataProcessor.php
@@ -84,7 +84,7 @@ class SanitizeDataProcessor extends Processor
     public function sanitizeException(&$data)
     {
         foreach ($data['exception']['values'] as &$value) {
-            return $this->sanitizeStacktrace($value['stacktrace']);
+            $this->sanitizeStacktrace($value['stacktrace']);
         }
     }
 
@@ -98,7 +98,7 @@ class SanitizeDataProcessor extends Processor
             }
         }
         if (!empty($http['data']) && is_array($http['data'])) {
-            array_walk_recursive($http['data'], array($this, 'sanitize'));
+            array_walk_recursive($http['data'], [$this, 'sanitize']);
         }
     }
 
@@ -108,7 +108,7 @@ class SanitizeDataProcessor extends Processor
             if (empty($frame['vars'])) {
                 continue;
             }
-            array_walk_recursive($frame['vars'], array($this, 'sanitize'));
+            array_walk_recursive($frame['vars'], [$this, 'sanitize']);
         }
     }
 
@@ -127,7 +127,7 @@ class SanitizeDataProcessor extends Processor
             $this->sanitizeHttp($data);
         }
         if (!empty($data['extra'])) {
-            array_walk_recursive($data['extra'], array($this, 'sanitize'));
+            array_walk_recursive($data['extra'], [$this, 'sanitize']);
         }
     }
 

--- a/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
+++ b/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
@@ -25,7 +25,7 @@ final class SanitizeHttpHeadersProcessor extends Processor
     /**
      * @var string[] $httpHeadersToSanitize The list of HTTP headers to sanitize
      */
-    private $httpHeadersToSanitize = array();
+    private $httpHeadersToSanitize = [];
 
     /**
      * {@inheritdoc}
@@ -40,7 +40,10 @@ final class SanitizeHttpHeadersProcessor extends Processor
      */
     public function setProcessorOptions(array $options)
     {
-        $this->httpHeadersToSanitize = array_merge($this->getDefaultHeaders(), isset($options['sanitize_http_headers']) ? $options['sanitize_http_headers'] : array());
+        $this->httpHeadersToSanitize = array_merge(
+            $this->getDefaultHeaders(),
+            isset($options['sanitize_http_headers']) ? $options['sanitize_http_headers'] : []
+        );
     }
 
     /**
@@ -64,6 +67,6 @@ final class SanitizeHttpHeadersProcessor extends Processor
      */
     private function getDefaultHeaders()
     {
-        return array('Authorization', 'Proxy-Authorization', 'X-Csrf-Token', 'X-CSRFToken', 'X-XSRF-TOKEN');
+        return ['Authorization', 'Proxy-Authorization', 'X-Csrf-Token', 'X-CSRFToken', 'X-XSRF-TOKEN'];
     }
 }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -75,7 +75,7 @@ class Serializer
     {
         if ($_depth < $max_depth) {
             if (is_array($value)) {
-                $new = array();
+                $new = [];
                 foreach ($value as $k => $v) {
                     $new[$this->serializeValue($k)] = $this->serialize($v, $max_depth, $_depth + 1);
                 }

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -18,12 +18,12 @@ class TransactionStack
 
     public function __construct()
     {
-        $this->stack = array();
+        $this->stack = [];
     }
 
     public function clear()
     {
-        $this->stack = array();
+        $this->stack = [];
     }
 
     public function peek()

--- a/tests/Breadcrumbs/ErrorHandlerTest.php
+++ b/tests/Breadcrumbs/ErrorHandlerTest.php
@@ -13,9 +13,9 @@ class Raven_Tests_ErrorHandlerBreadcrumbHandlerTest extends PHPUnit_Framework_Te
 {
     public function testSimple()
     {
-        $client = new \Raven\Client(array(
+        $client = new \Raven\Client([
             'install_default_breadcrumb_handlers' => false,
-        ));
+        ]);
 
         $handler = new \Raven\Breadcrumbs\ErrorHandler($client);
         $handler->handleError(E_WARNING, 'message');

--- a/tests/Breadcrumbs/MonologTest.php
+++ b/tests/Breadcrumbs/MonologTest.php
@@ -37,9 +37,9 @@ EOF;
 
     public function testSimple()
     {
-        $client = new \Raven\Client(array(
+        $client = new \Raven\Client([
             'install_default_breadcrumb_handlers' => false,
-        ));
+        ]);
         $handler = new \Raven\Breadcrumbs\MonologHandler($client);
 
         $logger = new \Monolog\Logger('sentry');
@@ -55,9 +55,9 @@ EOF;
 
     public function testErrorInMessage()
     {
-        $client = new \Raven\Client(array(
+        $client = new \Raven\Client([
             'install_default_breadcrumb_handlers' => false,
-        ));
+        ]);
         $handler = new \Raven\Breadcrumbs\MonologHandler($client);
 
         $logger = new \Monolog\Logger('sentry');

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -15,7 +15,7 @@ class Raven_Tests_BreadcrumbsTest extends PHPUnit_Framework_TestCase
     {
         $breadcrumbs = new \Raven\Breadcrumbs(10);
         for ($i = 0; $i <= 10; $i++) {
-            $breadcrumbs->record(array('message' => $i));
+            $breadcrumbs->record(['message' => $i]);
         }
 
         $results = $breadcrumbs->fetch();
@@ -29,7 +29,7 @@ class Raven_Tests_BreadcrumbsTest extends PHPUnit_Framework_TestCase
     public function testJson()
     {
         $breadcrumbs = new \Raven\Breadcrumbs(1);
-        $breadcrumbs->record(array('message' => 'test'));
+        $breadcrumbs->record(['message' => 'test']);
         $json = $breadcrumbs->to_json();
 
         $this->assertEquals(count($json['values']), 1);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,7 +29,7 @@ function invalid_encoding()
 // XXX: Is there a better way to stub the client?
 class Dummy_Raven_Client extends \Raven\Client
 {
-    private $__sent_events = array();
+    private $__sent_events = [];
     public $dummy_breadcrumbs_handlers_has_set = false;
     public $dummy_shutdown_handlers_has_set = false;
 
@@ -40,7 +40,7 @@ class Dummy_Raven_Client extends \Raven\Client
 
     public function send(&$data)
     {
-        if (is_callable($this->send_callback) && call_user_func_array($this->send_callback, array(&$data)) === false) {
+        if (is_callable($this->send_callback) && call_user_func_array($this->send_callback, [&$data]) === false) {
             // if send_callback returns falsely, end native send
             return;
         }
@@ -189,12 +189,12 @@ class Dummy_Raven_CurlHandler extends \Raven\CurlHandler
     public $_enqueue_called = false;
     public $_join_called = false;
 
-    public function __construct($options = array(), $join_timeout = 5)
+    public function __construct($options = [], $join_timeout = 5)
     {
         parent::__construct($options, $join_timeout);
     }
 
-    public function enqueue($url, $data = null, $headers = array())
+    public function enqueue($url, $data = null, $headers = [])
     {
         $this->_enqueue_called = true;
         $this->_set_url = $url;
@@ -345,9 +345,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testDsnFirstArgumentWithOptions()
     {
-        $client = new Dummy_Raven_Client('http://public:secret@example.com/1', array(
+        $client = new Dummy_Raven_Client('http://public:secret@example.com/1', [
             'site' => 'foo',
-        ));
+        ]);
 
         $this->assertEquals(1, $client->project);
         $this->assertEquals('http://example.com/api/1/store/', $client->server);
@@ -361,10 +361,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testOptionsFirstArgument()
     {
-        $client = new Dummy_Raven_Client(array(
+        $client = new Dummy_Raven_Client([
             'server' => 'http://example.com/api/1/store/',
             'project' => 1,
-        ));
+        ]);
 
         $this->assertEquals('http://example.com/api/1/store/', $client->server);
     }
@@ -374,9 +374,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testDsnInOptionsFirstArg()
     {
-        $client = new Dummy_Raven_Client(array(
+        $client = new Dummy_Raven_Client([
             'dsn' => 'http://public:secret@example.com/1',
-        ));
+        ]);
 
         $this->assertEquals(1, $client->project);
         $this->assertEquals('http://example.com/api/1/store/', $client->server);
@@ -389,9 +389,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testDsnInOptionsSecondArg()
     {
-        $client = new Dummy_Raven_Client(null, array(
+        $client = new Dummy_Raven_Client(null, [
             'dsn' => 'http://public:secret@example.com/1',
-        ));
+        ]);
 
         $this->assertEquals(1, $client->project);
         $this->assertEquals('http://example.com/api/1/store/', $client->server);
@@ -404,12 +404,12 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testOptionsFirstArgumentWithOptions()
     {
-        $client = new Dummy_Raven_Client(array(
+        $client = new Dummy_Raven_Client([
             'server' => 'http://example.com/api/1/store/',
             'project' => 1,
-        ), array(
+        ], [
             'site' => 'foo',
-        ));
+        ]);
 
         $this->assertEquals('http://example.com/api/1/store/', $client->server);
         $this->assertEquals('foo', $client->site);
@@ -420,9 +420,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testOptionsExtraData()
     {
-        $client = new Dummy_Raven_Client(array('extra' => array('foo' => 'bar')));
+        $client = new Dummy_Raven_Client(['extra' => ['foo' => 'bar']]);
 
-        $client->captureMessage('Test Message %s', array('foo'));
+        $client->captureMessage('Test Message %s', ['foo']);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -434,9 +434,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testOptionsExtraDataWithNull()
     {
-        $client = new Dummy_Raven_Client(array('extra' => array('foo' => 'bar')));
+        $client = new Dummy_Raven_Client(['extra' => ['foo' => 'bar']]);
 
-        $client->captureMessage('Test Message %s', array('foo'), null);
+        $client->captureMessage('Test Message %s', ['foo'], null);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -448,9 +448,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testEmptyExtraData()
     {
-        $client = new Dummy_Raven_Client(array('extra' => array()));
+        $client = new Dummy_Raven_Client(['extra' => []]);
 
-        $client->captureMessage('Test Message %s', array('foo'));
+        $client->captureMessage('Test Message %s', ['foo']);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -478,7 +478,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->captureMessage('Test Message %s', array('foo'));
+        $client->captureMessage('Test Message %s', ['foo']);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -495,7 +495,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(20160909144742, $client->getRelease());
 
-        $client->captureMessage('Test Message %s', array('foo'));
+        $client->captureMessage('Test Message %s', ['foo']);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -510,15 +510,15 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->captureMessage('Test Message %s', array('foo'));
+        $client->captureMessage('Test Message %s', ['foo']);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'message' => 'Test Message %s',
-            'params' => array('foo'),
+            'params' => ['foo'],
             'formatted' => 'Test Message foo',
-        ), $event['sentry.interfaces.Message']);
+        ], $event['sentry.interfaces.Message']);
         $this->assertEquals('Test Message foo', $event['message']);
     }
 
@@ -529,10 +529,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->captureMessage('Test Message %s', array('foo'), array(
+        $client->captureMessage('Test Message %s', ['foo'], [
             'level' => Dummy_Raven_Client::WARNING,
-            'extra' => array('foo' => 'bar')
-        ));
+            'extra' => ['foo' => 'bar']
+        ]);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -548,7 +548,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->captureMessage('Test Message %s', array('foo'), Dummy_Raven_Client::WARNING);
+        $client->captureMessage('Test Message %s', ['foo'], Dummy_Raven_Client::WARNING);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -646,7 +646,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
         $ex = $this->create_exception();
-        $client->captureException($ex, array('culprit' => 'test'));
+        $client->captureException($ex, ['culprit' => 'test']);
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
@@ -658,9 +658,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCaptureExceptionHandlesExcludeOption()
     {
-        $client = new Dummy_Raven_Client(array(
-            'exclude' => array('Exception'),
-        ));
+        $client = new Dummy_Raven_Client([
+            'exclude' => ['Exception'],
+        ]);
         $ex = $this->create_exception();
         $client->captureException($ex, 'test');
         $events = $client->getSentEvents();
@@ -694,9 +694,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testDoesRegisterProcessors()
     {
-        $client = new Dummy_Raven_Client(array(
-            'processors' => array('\\Raven\\Processor\\SanitizeDataProcessor'),
-        ));
+        $client = new Dummy_Raven_Client([
+            'processors' => ['\\Raven\\Processor\\SanitizeDataProcessor'],
+        ]);
 
         $this->assertEquals(1, count($client->processors));
         $this->assertInstanceOf('\\Raven\\Processor\\SanitizeDataProcessor', $client->processors[0]);
@@ -704,10 +704,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testProcessDoesCallProcessors()
     {
-        $data = array("key"=>"value");
+        $data = ["key"=>"value"];
 
         $processor = $this->getMockBuilder('Processor')
-                          ->setMethods(array('process'))
+                          ->setMethods(['process'])
                           ->getMock();
         $processor->expects($this->once())
                ->method('process')
@@ -746,19 +746,19 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
         $client->transaction->push('test');
-        $expected = array(
+        $expected = [
             'platform' => 'php',
             'project' => $client->project,
             'server_name' => $client->name,
             'site' => $client->site,
             'logger' => $client->logger,
             'tags' => $client->tags,
-            'sdk' => array(
+            'sdk' => [
                 'name' => 'sentry-php',
                 'version' => $client::VERSION,
-            ),
+            ],
             'culprit' => 'test',
-        );
+        ];
         $this->assertEquals($expected, $client->get_default_data());
     }
 
@@ -768,7 +768,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetHttpData()
     {
-        $_SERVER = array(
+        $_SERVER = [
             'REDIRECT_STATUS'     => '200',
             'CONTENT_TYPE'        => 'text/xml',
             'CONTENT_LENGTH'      => '99',
@@ -782,35 +782,35 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
             'QUERY_STRING'        => 'q=bitch&l=en',
             'REQUEST_URI'         => '/welcome/',
             'SCRIPT_NAME'         => '/index.php',
-        );
-        $_POST = array(
+        ];
+        $_POST = [
             'stamp' => '1c',
-        );
-        $_COOKIE = array(
+        ];
+        $_COOKIE = [
             'donut' => 'chocolat',
-        );
+        ];
 
-        $expected = array(
-            'request' => array(
+        $expected = [
+            'request' => [
                 'method' => 'PATCH',
                 'url' => 'https://getsentry.com/welcome/',
                 'query_string' => 'q=bitch&l=en',
-                'data' => array(
+                'data' => [
                     'stamp'           => '1c',
-                ),
-                'cookies' => array(
+                ],
+                'cookies' => [
                     'donut'           => 'chocolat',
-                ),
-                'headers' => array(
+                ],
+                'headers' => [
                     'Host'            => 'getsentry.com',
                     'Accept'          => 'text/html',
                     'Accept-Charset'  => 'utf-8',
                     'Cookie'          => 'cupcake: strawberry',
                     'Content-Type'    => 'text/xml',
                     'Content-Length'  => '99',
-                ),
-            )
-        );
+                ],
+            ]
+        ];
 
         $client = new Dummy_Raven_Client();
         $this->assertEquals($expected, $client->get_http_data());
@@ -826,15 +826,15 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
         $id = 'unique_id';
         $email = 'foo@example.com';
-        $client->user_context(array('id' => $id, 'email' => $email, 'username' => 'my_user', ));
+        $client->user_context(['id' => $id, 'email' => $email, 'username' => 'my_user', ]);
 
-        $expected = array(
-            'user' => array(
+        $expected = [
+            'user' => [
                 'id' => $id,
                 'username' => 'my_user',
                 'email' => $email,
-            )
-        );
+            ]
+        ];
 
         $this->assertEquals($expected, $client->get_user_data());
     }
@@ -846,11 +846,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $expected = array(
-            'user' => array(
+        $expected = [
+            'user' => [
                 'id' => session_id(),
-            )
-        );
+            ]
+        ];
         $this->assertEquals($expected, $client->get_user_data());
     }
 
@@ -893,15 +893,15 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->user_context(array('email' => 'foo@example.com'));
+        $client->user_context(['email' => 'foo@example.com']);
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'email' => 'foo@example.com',
-        ), $event['user']);
+        ], $event['user']);
     }
 
     /**
@@ -911,12 +911,12 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->user_context(array(
+        $client->user_context([
             'email' => 'foo@example.com',
-            'data' => array(
+            'data' => [
                 'error' => new \Exception('test'),
-            )
-        ));
+            ]
+        ]);
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
@@ -933,18 +933,18 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->tags_context(array('foo' => 'bar'));
-        $client->tags_context(array('biz' => 'boz'));
-        $client->tags_context(array('biz' => 'baz'));
+        $client->tags_context(['foo' => 'bar']);
+        $client->tags_context(['biz' => 'boz']);
+        $client->tags_context(['biz' => 'baz']);
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'foo' => 'bar',
             'biz' => 'baz',
-        ), $event['tags']);
+        ], $event['tags']);
     }
 
     /**
@@ -955,18 +955,18 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
 
-        $client->extra_context(array('foo' => 'bar'));
-        $client->extra_context(array('biz' => 'boz'));
-        $client->extra_context(array('biz' => 'baz'));
+        $client->extra_context(['foo' => 'bar']);
+        $client->extra_context(['biz' => 'boz']);
+        $client->extra_context(['biz' => 'baz']);
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals(array(
+        $this->assertEquals([
             'foo' => 'bar',
             'biz' => 'baz',
-        ), $event['extra']);
+        ], $event['extra']);
     }
 
     /**
@@ -975,11 +975,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testCaptureExceptionContainingLatin1()
     {
         // If somebody has a non-utf8 codebase, she/he should add the encoding to the detection order
-        $options = array(
-            'mb_detect_order' => array(
+        $options = [
+            'mb_detect_order' => [
                 'ISO-8859-1', 'ASCII', 'UTF-8'
-            )
-        );
+            ]
+        ];
 
         $client = new Dummy_Raven_Client($options);
 
@@ -1000,11 +1000,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testCaptureExceptionInLatin1File()
     {
         // If somebody has a non-utf8 codebase, she/he should add the encoding to the detection order
-        $options = array(
-            'mb_detect_order' => array(
+        $options = [
+            'mb_detect_order' => [
                 'ISO-8859-1', 'ASCII', 'UTF-8'
-            )
-        );
+            ]
+        ];
 
         $client = new Dummy_Raven_Client($options);
 
@@ -1039,6 +1039,8 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($client->captureLastError());
         $this->assertEquals(0, count($client->getSentEvents()));
 
+        /** @var $undefined */
+        /** @noinspection PhpExpressionResultUnusedInspection */
         @$undefined;
 
         $client->captureLastError();
@@ -1054,7 +1056,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testGetLastEventID()
     {
         $client = new Dummy_Raven_Client();
-        $client->capture(array('message' => 'test', 'event_id' => 'abc'));
+        $client->capture(['message' => 'test', 'event_id' => 'abc']);
         $this->assertEquals('abc', $client->getLastEventID());
     }
 
@@ -1063,16 +1065,16 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCustomTransport()
     {
-        $events = array();
+        $events = [];
 
         // transport test requires default client
-        $client = new \Raven\Client('https://public:secret@sentry.example.com/1', array(
+        $client = new \Raven\Client('https://public:secret@sentry.example.com/1', [
             'install_default_breadcrumb_handlers' => false,
-        ));
+        ]);
         $client->setTransport(function ($client, $data) use (&$events) {
             $events[] = $data;
         });
-        $client->capture(array('message' => 'test', 'event_id' => 'abc'));
+        $client->capture(['message' => 'test', 'event_id' => 'abc']);
         $this->assertEquals(1, count($events));
     }
 
@@ -1136,17 +1138,17 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testSendCallback()
     {
-        $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb1')));
+        $client = new Dummy_Raven_Client(['send_callback' => [$this, 'cb1']]);
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(0, count($events));
 
-        $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb2')));
+        $client = new Dummy_Raven_Client(['send_callback' => [$this, 'cb2']]);
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
 
-        $client = new Dummy_Raven_Client(array('send_callback' => array($this, 'cb3')));
+        $client = new Dummy_Raven_Client(['send_callback' => [$this, 'cb3']]);
         $client->captureMessage('test');
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
@@ -1159,24 +1161,24 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSanitizeExtra()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('extra' => array(
-            'context' => array(
+        $data = ['extra' => [
+            'context' => [
                 'line' => 1216,
-                'stack' => array(
-                    1, array(2), 3
-                ),
-            ),
-        ));
+                'stack' => [
+                    1, [2], 3
+                ],
+            ],
+        ]];
         $client->sanitize($data);
 
-        $this->assertEquals(array('extra' => array(
-            'context' => array(
+        $this->assertEquals(['extra' => [
+            'context' => [
                 'line' => 1216,
-                'stack' => array(
+                'stack' => [
                     1, 'Array of length 1', 3
-                ),
-            ),
-        )), $data);
+                ],
+            ],
+        ]], $data);
     }
 
     /**
@@ -1190,11 +1192,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
             ]
         );
         $clone = new Dummy_Raven_Client();
-        $data = array(
-            'extra' => array(
+        $data = [
+            'extra' => [
                 'object' => $clone,
-            ),
-        );
+            ],
+        ];
 
         $reflection = new \ReflectionClass($clone);
         $expected = [];
@@ -1240,7 +1242,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
             }
         }
 
-        $this->assertEquals(array('extra' => array('object' => $expected)), $data);
+        $this->assertEquals(['extra' => ['object' => $expected]], $data);
     }
 
     /**
@@ -1249,16 +1251,16 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSanitizeTags()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('tags' => array(
+        $data = ['tags' => [
             'foo' => 'bar',
-            'baz' => array('biz'),
-        ));
+            'baz' => ['biz'],
+        ]];
         $client->sanitize($data);
 
-        $this->assertEquals(array('tags' => array(
+        $this->assertEquals(['tags' => [
             'foo' => 'bar',
             'baz' => 'Array',
-        )), $data);
+        ]], $data);
     }
 
     /**
@@ -1267,14 +1269,14 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSanitizeUser()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('user' => array(
+        $data = ['user' => [
             'email' => 'foo@example.com',
-        ));
+        ]];
         $client->sanitize($data);
 
-        $this->assertEquals(array('user' => array(
+        $this->assertEquals(['user' => [
             'email' => 'foo@example.com',
-        )), $data);
+        ]], $data);
     }
 
     /**
@@ -1283,24 +1285,24 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSanitizeRequest()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('request' => array(
-            'context' => array(
+        $data = ['request' => [
+            'context' => [
                 'line' => 1216,
-                'stack' => array(
-                    1, array(2), 3
-                ),
-            ),
-        ));
+                'stack' => [
+                    1, [2], 3
+                ],
+            ],
+        ]];
         $client->sanitize($data);
 
-        $this->assertEquals(array('request' => array(
-            'context' => array(
+        $this->assertEquals(['request' => [
+            'context' => [
                 'line' => 1216,
-                'stack' => array(
+                'stack' => [
                     1, 'Array of length 1', 3
-                ),
-            ),
-        )), $data);
+                ],
+            ],
+        ]], $data);
     }
 
     /**
@@ -1309,30 +1311,30 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSanitizeContexts()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('contexts' => array(
-            'context' => array(
+        $data = ['contexts' => [
+            'context' => [
                 'line' => 1216,
-                'stack' => array(
-                    1, array(
+                'stack' => [
+                    1, [
                         'foo' => 'bar',
-                        'level4' => array(array('level5', 'level5 a'), 2),
-                    ), 3
-                ),
-            ),
-        ));
+                        'level4' => [['level5', 'level5 a'], 2],
+                    ], 3
+                ],
+            ],
+        ]];
         $client->sanitize($data);
 
-        $this->assertEquals(array('contexts' => array(
-            'context' => array(
+        $this->assertEquals(['contexts' => [
+            'context' => [
                 'line' => 1216,
-                'stack' => array(
-                    1, array(
+                'stack' => [
+                    1, [
                         'foo' => 'bar',
-                        'level4' => array('Array of length 2', 2),
-                    ), 3
-                ),
-            ),
-        )), $data);
+                        'level4' => ['Array of length 2', 2],
+                    ], 3
+                ],
+            ],
+        ]], $data);
     }
 
     /**
@@ -1342,17 +1344,17 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $data = '{"foo": "\'; ls;"}';
         $client = new Dummy_Raven_Client();
-        $result = $client->buildCurlCommand('http://foo.com', $data, array());
+        $result = $client->buildCurlCommand('http://foo.com', $data, []);
         $this->assertEquals('curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &', $result);
 
-        $result = $client->buildCurlCommand('http://foo.com', $data, array('key' => 'value'));
+        $result = $client->buildCurlCommand('http://foo.com', $data, ['key' => 'value']);
         $this->assertEquals('curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 > /dev/null 2>&1 &', $result);
 
         $client->verify_ssl = false;
-        $result = $client->buildCurlCommand('http://foo.com', $data, array());
+        $result = $client->buildCurlCommand('http://foo.com', $data, []);
         $this->assertEquals('curl -X POST -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &', $result);
 
-        $result = $client->buildCurlCommand('http://foo.com', $data, array('key' => 'value'));
+        $result = $client->buildCurlCommand('http://foo.com', $data, ['key' => 'value']);
         $this->assertEquals('curl -X POST -H \'key: value\' -d \'{"foo": "\'\\\'\'; ls;"}\' \'http://foo.com\' -m 5 -k > /dev/null 2>&1 &', $result);
     }
 
@@ -1362,9 +1364,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testUserContextWithoutMerge()
     {
         $client = new Dummy_Raven_Client();
-        $client->user_context(array('foo' => 'bar'), false);
-        $client->user_context(array('baz' => 'bar'), false);
-        $this->assertEquals(array('baz' => 'bar'), $client->context->user);
+        $client->user_context(['foo' => 'bar'], false);
+        $client->user_context(['baz' => 'bar'], false);
+        $this->assertEquals(['baz' => 'bar'], $client->context->user);
     }
 
     /**
@@ -1373,9 +1375,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testUserContextWithMerge()
     {
         $client = new Dummy_Raven_Client();
-        $client->user_context(array('foo' => 'bar'), true);
-        $client->user_context(array('baz' => 'bar'), true);
-        $this->assertEquals(array('foo' => 'bar', 'baz' => 'bar'), $client->context->user);
+        $client->user_context(['foo' => 'bar'], true);
+        $client->user_context(['baz' => 'bar'], true);
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'bar'], $client->context->user);
     }
 
     /**
@@ -1384,9 +1386,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testUserContextWithMergeAndNull()
     {
         $client = new Dummy_Raven_Client();
-        $client->user_context(array('foo' => 'bar'), true);
+        $client->user_context(['foo' => 'bar'], true);
         $client->user_context(null, true);
-        $this->assertEquals(array('foo' => 'bar'), $client->context->user);
+        $this->assertEquals(['foo' => 'bar'], $client->context->user);
     }
 
     /**
@@ -1421,63 +1423,63 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function currentUrlProvider()
     {
-        return array(
-            array(
-                array(),
-                array(),
+        return [
+            [
+                [],
+                [],
                 null,
                 'No url expected for empty REQUEST_URI'
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
-                ),
-                array(),
+                ],
+                [],
                 'http://example.com/',
                 'The url is expected to be http with the request uri'
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'HTTPS' => 'on'
-                ),
-                array(),
+                ],
+                [],
                 'https://example.com/',
                 'The url is expected to be https because of HTTPS on'
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'SERVER_PORT' => '443'
-                ),
-                array(),
+                ],
+                [],
                 'https://example.com/',
                 'The url is expected to be https because of the server port'
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'X-FORWARDED-PROTO' => 'https'
-                ),
-                array(),
+                ],
+                [],
                 'http://example.com/',
                 'The url is expected to be http because the X-Forwarded header is ignored'
-            ),
-            array(
-                array(
+            ],
+            [
+                [
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
                     'X-FORWARDED-PROTO' => 'https'
-                ),
-                array('trust_x_forwarded_proto' => true),
+                ],
+                ['trust_x_forwarded_proto' => true],
                 'https://example.com/',
                 'The url is expected to be https because the X-Forwarded header is trusted'
-            )
-        );
+            ]
+        ];
     }
 
     /**
@@ -1520,40 +1522,40 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         $client = new Dummy_Raven_Client();
         $property_method__convert_path = new \ReflectionMethod('\\Raven\\Client', '_convertPath');
         $property_method__convert_path->setAccessible(true);
-        $callable = array($this, 'stabClosureVoid');
+        $callable = [$this, 'stabClosureVoid'];
 
-        $data = array(
-            array('environment', null, 'value', ),
-            array('environment', null, null, ),
-            array('release', null, 'value', ),
-            array('release', null, null, ),
-            array('app_path', null, 'value', $property_method__convert_path->invoke($client, 'value')),
-            array('app_path', null, null, ),
-            array('app_path', null, false, null, ),
-            array('excluded_app_paths', null, array('value'),
-                  array($property_method__convert_path->invoke($client, 'value'))),
-            array('excluded_app_paths', null, array(), null),
-            array('excluded_app_paths', null, null),
-            array('prefixes', null, array('value'), array($property_method__convert_path->invoke($client, 'value'))),
-            array('prefixes', null, array()),
-            array('send_callback', null, $callable),
-            array('send_callback', null, null),
-            array('transport', null, $callable),
-            array('transport', null, null),
-            array('server', 'ServerEndpoint', 'http://example.com/'),
-            array('server', 'ServerEndpoint', 'http://example.org/'),
-            array('_lasterror', null, null, ),
-            array('_lasterror', null, 'value', ),
-            array('_lasterror', null, mt_rand(100, 999), ),
-            array('_last_sentry_error', null, (object)array('error' => 'test',), ),
-            array('_last_event_id', null, mt_rand(100, 999), ),
-            array('_last_event_id', null, 'value', ),
-            array('extra_data', '_extra_data', array('key' => 'value'), ),
-            array('processors', 'processors', array(), ),
-            array('processors', 'processors', array('key' => 'value'), ),
-            array('_shutdown_function_has_been_set', null, true),
-            array('_shutdown_function_has_been_set', null, false),
-        );
+        $data = [
+            ['environment', null, 'value', ],
+            ['environment', null, null, ],
+            ['release', null, 'value', ],
+            ['release', null, null, ],
+            ['app_path', null, 'value', $property_method__convert_path->invoke($client, 'value')],
+            ['app_path', null, null,],
+            ['app_path', null, false, null,],
+            ['excluded_app_paths', null, ['value'],
+             [$property_method__convert_path->invoke($client, 'value')]],
+            ['excluded_app_paths', null, [], null],
+            ['excluded_app_paths', null, null],
+            ['prefixes', null, ['value'], [$property_method__convert_path->invoke($client, 'value')]],
+            ['prefixes', null, []],
+            ['send_callback', null, $callable],
+            ['send_callback', null, null],
+            ['transport', null, $callable],
+            ['transport', null, null],
+            ['server', 'ServerEndpoint', 'http://example.com/'],
+            ['server', 'ServerEndpoint', 'http://example.org/'],
+            ['_lasterror', null, null,],
+            ['_lasterror', null, 'value',],
+            ['_lasterror', null, mt_rand(100, 999),],
+            ['_last_sentry_error', null, (object)['error' => 'test',],],
+            ['_last_event_id', null, mt_rand(100, 999),],
+            ['_last_event_id', null, 'value',],
+            ['extra_data', '_extra_data', ['key' => 'value'],],
+            ['processors', 'processors', [],],
+            ['processors', 'processors', ['key' => 'value'],],
+            ['_shutdown_function_has_been_set', null, true],
+            ['_shutdown_function_has_been_set', null, false],
+        ];
         foreach ($data as &$datum) {
             $this->subTestGettersAndSettersDatum($client, $datum);
         }
@@ -1672,14 +1674,14 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         $reflection->setAccessible(true);
         $client = new Dummy_Raven_Client();
 
-        $predefined = array(E_ERROR, E_WARNING, E_PARSE, E_NOTICE, E_CORE_ERROR, E_CORE_WARNING,
+        $predefined = [E_ERROR, E_WARNING, E_PARSE, E_NOTICE, E_CORE_ERROR, E_CORE_WARNING,
                        E_COMPILE_ERROR, E_COMPILE_WARNING, E_USER_ERROR, E_USER_WARNING,
-                       E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR, );
+                       E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR, ];
         if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
             $predefined[] = E_DEPRECATED;
             $predefined[] = E_USER_DEPRECATED;
         }
-        $predefined_values = array('debug', 'info', 'warning', 'warning', 'error', 'fatal', );
+        $predefined_values = ['debug', 'info', 'warning', 'warning', 'error', 'fatal', ];
 
         // step 1
         foreach ($predefined as &$key) {
@@ -1687,28 +1689,28 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertEquals('error', $client->translateSeverity(123456));
         // step 2
-        $client->registerSeverityMap(array());
-        $this->assertMixedValueAndArray(array(), $reflection->getValue($client));
+        $client->registerSeverityMap([]);
+        $this->assertMixedValueAndArray([], $reflection->getValue($client));
         foreach ($predefined as &$key) {
             $this->assertContains($client->translateSeverity($key), $predefined_values);
         }
         $this->assertEquals('error', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123456));
         // step 3
-        $client->registerSeverityMap(array(123456 => 'foo', ));
-        $this->assertMixedValueAndArray(array(123456 => 'foo'), $reflection->getValue($client));
+        $client->registerSeverityMap([123456 => 'foo', ]);
+        $this->assertMixedValueAndArray([123456 => 'foo'], $reflection->getValue($client));
         foreach ($predefined as &$key) {
             $this->assertContains($client->translateSeverity($key), $predefined_values);
         }
         $this->assertEquals('foo', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123457));
         // step 4
-        $client->registerSeverityMap(array(E_USER_ERROR => 'bar', ));
+        $client->registerSeverityMap([E_USER_ERROR => 'bar', ]);
         $this->assertEquals('bar', $client->translateSeverity(E_USER_ERROR));
         $this->assertEquals('error', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123457));
         // step 5
-        $client->registerSeverityMap(array(E_USER_ERROR => 'bar', 123456 => 'foo', ));
+        $client->registerSeverityMap([E_USER_ERROR => 'bar', 123456 => 'foo', ]);
         $this->assertEquals('bar', $client->translateSeverity(E_USER_ERROR));
         $this->assertEquals('foo', $client->translateSeverity(123456));
         $this->assertEquals('error', $client->translateSeverity(123457));
@@ -1743,10 +1745,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $client->captureMessage('foobar');
         $this->assertTrue($client->_send_http_synchronous);
@@ -1754,10 +1756,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
         // step 2
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'exec',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $client->captureMessage('foobar');
         $this->assertFalse($client->_send_http_synchronous);
@@ -1774,10 +1776,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'async',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $object = $client->get_curl_handler();
         $this->assertInternalType('object', $object);
@@ -1823,7 +1825,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
             $this->assertNotNull($actual);
             $this->assertEquals($value, $actual);
         }
-        foreach (array('foo', 'bar', 'foobar', '123456', 'SomeLongNonExistedKey') as $key => $value) {
+        foreach (['foo', 'bar', 'foobar', '123456', 'SomeLongNonExistedKey'] as $key => $value) {
             if (!isset($_SERVER[$key])) {
                 $actual = $method->invoke(null, $key);
                 $this->assertNotNull($actual);
@@ -1839,9 +1841,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testEncodeTooDepth()
     {
         $client = new Dummy_Raven_Client();
-        $data_broken = array();
+        $data_broken = [];
         for ($i = 0; $i < 1024; $i++) {
-            $data_broken = array($data_broken);
+            $data_broken = [$data_broken];
         }
         $value = $client->encode($data_broken);
         if (version_compare(PHP_VERSION, '5.5.0', '>=')) {
@@ -1858,7 +1860,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testEncode()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('some' => (object)array('value' => 'data'), 'foo' => array('bar', null, 123), false);
+        $data = ['some' => (object)['value' => 'data'], 'foo' => ['bar', null, 123], false];
         $json_stringify = json_encode($data);
         $value = $client->encode($data);
         $this->assertNotFalse($value);
@@ -1883,8 +1885,8 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('HHVM stacktrace behaviour');
             return;
         }
-        $previous = set_error_handler(array($this, 'stabClosureErrorHandler'), E_USER_NOTICE);
-        new \Raven\Client(null, array());
+        $previous = set_error_handler([$this, 'stabClosureErrorHandler'], E_USER_NOTICE);
+        new \Raven\Client(null, []);
         $this->_closure_called = false;
         trigger_error('foobar', E_USER_NOTICE);
         $u = $this->_closure_called;
@@ -1924,9 +1926,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         return false;
     }
 
-    private $_debug_backtrace = array();
+    private $_debug_backtrace = [];
 
-    public function stabClosureErrorHandler($code, $message, $file = '', $line = 0, $context = array())
+    public function stabClosureErrorHandler($code, $message, $file = '', $line = 0, $context = [])
     {
         $this->_closure_called = true;
         $this->_debug_backtrace = debug_backtrace();
@@ -1943,13 +1945,13 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $this->assertEquals(0, count($client->_pending_events));
-        $client->_pending_events[] = array('foo' => 'bar');
+        $client->_pending_events[] = ['foo' => 'bar'];
         $client->sendUnsentErrors();
         $this->assertTrue($client->_send_http_synchronous);
         $this->assertFalse($client->_send_http_asynchronous_curl_exec_called);
@@ -1975,10 +1977,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         // step 1
         $client = null;
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'async',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $ch = new Dummy_Raven_CurlHandler();
         $client->set_curl_handler($ch);
@@ -1995,15 +1997,15 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $this->_closure_called = false;
-        $client->setSendCallback(array($this, 'stabClosureNull'));
+        $client->setSendCallback([$this, 'stabClosureNull']);
         $this->assertFalse($this->_closure_called);
-        $data = array('foo' => 'bar');
+        $data = ['foo' => 'bar'];
         $client->send($data);
         $this->assertTrue($this->_closure_called);
         $this->assertTrue($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
@@ -2011,9 +2013,9 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         $this->_closure_called = false;
         $client->_send_http_synchronous = false;
         $client->_send_http_asynchronous_curl_exec_called = false;
-        $client->setSendCallback(array($this, 'stabClosureFalse'));
+        $client->setSendCallback([$this, 'stabClosureFalse']);
         $this->assertFalse($this->_closure_called);
-        $data = array('foo' => 'bar');
+        $data = ['foo' => 'bar'];
         $client->send($data);
         $this->assertTrue($this->_closure_called);
         $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
@@ -2025,13 +2027,13 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testNonWorkingSendDSNEmpty()
     {
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $client->server = null;
-        $data = array('foo' => 'bar');
+        $data = ['foo' => 'bar'];
         $client->send($data);
         $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
     }
@@ -2043,23 +2045,23 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         $this->_closure_called = false;
-        $client->setTransport(array($this, 'stabClosureNull'));
+        $client->setTransport([$this, 'stabClosureNull']);
         $this->assertFalse($this->_closure_called);
-        $data = array('foo' => 'bar');
+        $data = ['foo' => 'bar'];
         $client->send($data);
         $this->assertTrue($this->_closure_called);
         $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
         // step 2
         $this->_closure_called = false;
-        $client->setSendCallback(array($this, 'stabClosureFalse'));
+        $client->setSendCallback([$this, 'stabClosureFalse']);
         $this->assertFalse($this->_closure_called);
-        $data = array('foo' => 'bar');
+        $data = ['foo' => 'bar'];
         $client->send($data);
         $this->assertTrue($this->_closure_called);
         $this->assertFalse($client->_send_http_synchronous or $client->_send_http_asynchronous_curl_exec_called);
@@ -2070,13 +2072,13 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function test__construct_handlers()
     {
-        foreach (array(true, false) as $u1) {
-            foreach (array(true, false) as $u2) {
+        foreach ([true, false] as $u1) {
+            foreach ([true, false] as $u2) {
                 $client = new Dummy_Raven_Client(
-                    null, array(
+                    null, [
                         'install_default_breadcrumb_handlers' => $u1,
                         'install_shutdown_handler' => $u2,
-                    )
+                    ]
                 );
                 $this->assertEquals($u1, $client->dummy_breadcrumbs_handlers_has_set);
                 $this->assertEquals($u2, $client->dummy_shutdown_handlers_has_set);
@@ -2091,10 +2093,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function test__destruct_calls_close_functions()
     {
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'install_default_breadcrumb_handlers' => false,
                 'install_shutdown_handler' => false,
-            )
+            ]
         );
         $client::$_close_curl_resource_called = false;
         $client->close_all_children_link();
@@ -2125,8 +2127,8 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
         // step 3
         session_id($session_id);
-        @session_start(array('use_cookies' => false, ));
-        $_SESSION = array('foo' => 'bar');
+        @session_start(['use_cookies' => false, ]);
+        $_SESSION = ['foo' => 'bar'];
         $output = $client->get_user_data();
         $this->assertInternalType('array', $output);
         $this->assertArrayHasKey('user', $output);
@@ -2144,13 +2146,13 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCaptureLevel()
     {
-        foreach (array(\Raven\Client::MESSAGE_LIMIT * 3, 100) as $length) {
+        foreach ([\Raven\Client::MESSAGE_LIMIT * 3, 100] as $length) {
             $message = '';
             for ($i = 0; $i < $length; $i++) {
                 $message .= chr($i % 256);
             }
             $client = new Dummy_Raven_Client();
-            $client->capture(array('message' => $message, ));
+            $client->capture(['message' => $message, ]);
             $events = $client->getSentEvents();
             $this->assertEquals(1, count($events));
             $event = array_pop($events);
@@ -2162,7 +2164,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         }
 
         $client = new Dummy_Raven_Client();
-        $client->capture(array('message' => 'foobar'));
+        $client->capture(['message' => 'foobar', ]);
         $events = $client->getSentEvents();
         $event = array_pop($events);
         $input = $client->get_http_data();
@@ -2171,15 +2173,15 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('environment', $event);
 
         $client = new Dummy_Raven_Client();
-        $client->capture(array('message' => 'foobar', 'request' => array('foo' => 'bar'), ));
+        $client->capture(['message' => 'foobar', 'request' => ['foo' => 'bar'], ]);
         $events = $client->getSentEvents();
         $event = array_pop($events);
-        $this->assertEquals(array('foo' => 'bar'), $event['request']);
+        $this->assertEquals(['foo' => 'bar'], $event['request']);
         $this->assertArrayNotHasKey('release', $event);
         $this->assertArrayNotHasKey('environment', $event);
 
-        foreach (array(false, true) as $u1) {
-            foreach (array(false, true) as $u2) {
+        foreach ([false, true] as $u1) {
+            foreach ([false, true] as $u2) {
                 $client = new Dummy_Raven_Client();
                 if ($u1) {
                     $client->setRelease('foo');
@@ -2187,7 +2189,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
                 if ($u2) {
                     $client->setEnvironment('bar');
                 }
-                $client->capture(array('message' => 'foobar', ));
+                $client->capture(['message' => 'foobar', ]);
                 $events = $client->getSentEvents();
                 $event = array_pop($events);
                 if ($u1) {
@@ -2209,13 +2211,13 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
      */
     public function testCaptureNoUserAndRequest()
     {
-        $client = new Dummy_Raven_Client_No_Http(null, array(
+        $client = new Dummy_Raven_Client_No_Http(null, [
             'install_default_breadcrumb_handlers' => false,
-        ));
+        ]);
         $session_id = session_id();
         session_write_close();
         session_id('');
-        $client->capture(array('user' => '', 'request' => ''));
+        $client->capture(['user' => '', 'request' => '']);
         $events = $client->getSentEvents();
         $event = array_pop($events);
         $this->assertArrayNotHasKey('user', $event);
@@ -2223,7 +2225,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
         // step 3
         session_id($session_id);
-        @session_start(array('use_cookies' => false, ));
+        @session_start(['use_cookies' => false, ]);
     }
 
     /**
@@ -2233,19 +2235,19 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         $client = new Dummy_Raven_Client();
         $ts1 = microtime(true);
-        $client->breadcrumbs->record(array('foo' => 'bar'));
-        $client->breadcrumbs->record(array('honey' => 'clover'));
-        $client->capture(array());
+        $client->breadcrumbs->record(['foo' => 'bar']);
+        $client->breadcrumbs->record(['honey' => 'clover']);
+        $client->capture([]);
         $events = $client->getSentEvents();
         $event = array_pop($events);
         foreach ($event['breadcrumbs'] as &$crumb) {
             $this->assertGreaterThanOrEqual($ts1, $crumb['timestamp']);
             unset($crumb['timestamp']);
         }
-        $this->assertEquals(array(
-            array('foo' => 'bar'),
-            array('honey' => 'clover'),
-        ), $event['breadcrumbs']);
+        $this->assertEquals([
+            ['foo' => 'bar'],
+            ['honey' => 'clover'],
+        ], $event['breadcrumbs']);
     }
 
 
@@ -2255,7 +2257,7 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testCaptureAutoLogStacks()
     {
         $client = new Dummy_Raven_Client();
-        $client->capture(array('auto_log_stacks' => true), true);
+        $client->capture(['auto_log_stacks' => true], true);
         $events = $client->getSentEvents();
         $event = array_pop($events);
         $this->assertArrayHasKey('stacktrace', $event);
@@ -2268,10 +2270,10 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSend_http_asynchronous_curl_exec()
     {
         $client = new Dummy_Raven_Client_With_Sync_Override(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method' => 'exec',
                 'install_default_breadcrumb_handlers' => false,
-            )
+            ]
         );
         if (file_exists(Dummy_Raven_Client_With_Sync_Override::test_filename())) {
             unlink(Dummy_Raven_Client_With_Sync_Override::test_filename());
@@ -2305,11 +2307,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     {
         // step 1
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method'                         => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
                 'sample_rate'                         => 0,
-            )
+            ]
         );
         for ($i = 0; $i < 1000; $i++) {
             $client->captureMessage('foobar');
@@ -2318,11 +2320,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
 
         // step 2
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method'                         => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
                 'sample_rate'                         => 1,
-            )
+            ]
         );
         for ($i = 0; $i < 1000; $i++) {
             $client->captureMessage('foobar');
@@ -2336,11 +2338,11 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
     public function testSampleRatePrc()
     {
         $client = new Dummy_Raven_Client_With_Overrided_Direct_Send(
-            'http://public:secret@example.com/1', array(
+            'http://public:secret@example.com/1', [
                 'curl_method'                         => 'foobar',
                 'install_default_breadcrumb_handlers' => false,
                 'sample_rate'                         => 0.5,
-            )
+            ]
         );
         $u_true = false;
         $u_false = false;

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -21,7 +21,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $this->errorLevel = error_reporting();
         $this->errorHandlerCalled = false;
-        $this->existingErrorHandler = set_error_handler(array($this, 'errorHandler'), -1);
+        $this->existingErrorHandler = set_error_handler([$this, 'errorHandler'], -1);
         // improves the reliability of tests
         if (function_exists('error_clear_last')) {
             error_clear_last();
@@ -38,14 +38,14 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
         restore_exception_handler();
         set_error_handler($this->existingErrorHandler);
         // // XXX(dcramer): this isn't great as it doesnt restore the old error reporting level
-        // set_error_handler(array($this, 'errorHandler'), error_reporting());
+        // set_error_handler([$this, 'errorHandler'], error_reporting());
         error_reporting($this->errorLevel);
     }
 
     public function testErrorsAreLoggedAsExceptions()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException', 'sendUnsentErrors'))
+                       ->setMethods(['captureException', 'sendUnsentErrors'])
                        ->getMock();
         $client->expects($this->once())
                ->method('captureException')
@@ -58,7 +58,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testExceptionsAreLogged()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->once())
                ->method('captureException')
@@ -73,7 +73,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testErrorHandlerPassErrorReportingPass()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->once())
                ->method('captureException');
@@ -88,7 +88,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testErrorHandlerPropagates()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->never())
                ->method('captureException');
@@ -105,7 +105,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testExceptionHandlerPropagatesToNative()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->exactly(2))
                ->method('captureException')
@@ -146,7 +146,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testErrorHandlerRespectsErrorReportingDefault()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->once())
                ->method('captureException');
@@ -167,7 +167,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testSilentErrorsAreNotReportedWithGlobal()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->never())
                ->method('captureException');
@@ -188,7 +188,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testSilentErrorsAreNotReportedWithLocal()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->never())
                ->method('captureException');
@@ -205,7 +205,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testShouldCaptureFatalErrorBehavior()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $handler = new \Raven\ErrorHandler($client);
 
@@ -217,7 +217,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testErrorHandlerDefaultsErrorReporting()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $client->expects($this->never())
                ->method('captureException');
@@ -233,7 +233,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testFluidInterface()
     {
         $client = $this->getMockBuilder('Client')
-                       ->setMethods(array('captureException'))
+                       ->setMethods(['captureException'])
                        ->getMock();
         $handler = new \Raven\ErrorHandler($client);
         $result = $handler->registerErrorHandler();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -12,7 +12,7 @@ namespace Raven\Tests;
 
 class DummyIntegration_Raven_Client extends \Raven\Client
 {
-    private $__sent_events = array();
+    private $__sent_events = [];
 
     public function getSentEvents()
     {
@@ -20,7 +20,7 @@ class DummyIntegration_Raven_Client extends \Raven\Client
     }
     public function send(&$data)
     {
-        if (is_callable($this->send_callback) && call_user_func_array($this->send_callback, array(&$data)) === false) {
+        if (is_callable($this->send_callback) && call_user_func_array($this->send_callback, [&$data]) === false) {
             // if send_callback returns falsely, end native send
             return;
         }

--- a/tests/Processor/RemoveCookiesProcessorTest.php
+++ b/tests/Processor/RemoveCookiesProcessorTest.php
@@ -43,41 +43,38 @@ class RemoveCookiesProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function processDataProvider()
     {
-        return array(
-            array(
-                array(
-                    'request' => array(
+        return [
+            [
+                [
+                    'request' => [
                         'foo' => 'bar',
-                    ),
-                ),
-                array(
-                    'request' => array(
+                    ],
+                ], [
+                    'request' => [
                         'foo' => 'bar',
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'request' => array(
-                        'foo' => 'bar',
+                    ],
+                ],
+            ], [
+                [
+                    'request' => [
+                        'foo'     => 'bar',
                         'cookies' => 'baz',
-                        'headers' => array(
-                            'Cookie' => 'bar',
+                        'headers' => [
+                            'Cookie'        => 'bar',
                             'AnotherHeader' => 'foo',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
-                        'foo' => 'bar',
+                        ],
+                    ],
+                ], [
+                    'request' => [
+                        'foo'     => 'bar',
                         'cookies' => RemoveCookiesProcessor::STRING_MASK,
-                        'headers' => array(
-                            'Cookie' => RemoveCookiesProcessor::STRING_MASK,
+                        'headers' => [
+                            'Cookie'        => RemoveCookiesProcessor::STRING_MASK,
                             'AnotherHeader' => 'foo',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Processor/RemoveHttpBodyProcessorTest.php
+++ b/tests/Processor/RemoveHttpBodyProcessorTest.php
@@ -43,84 +43,76 @@ class RemoveHttpBodyProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function processDataProvider()
     {
-        return array(
-            array(
-                array(
-                    'request' => array(
+        return [
+            [
+                [
+                    'request' => [
                         'method' => 'POST',
-                        'data' => array(
+                        'data' => [
                             'foo' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
+                        ],
+                    ],
+                ], [
+                    'request' => [
                         'data' => RemoveHttpBodyProcessor::STRING_MASK,
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'request' => array(
+                    ],
+                ],
+            ], [
+                [
+                    'request' => [
                         'method' => 'PUT',
-                        'data' => array(
+                        'data' => [
                             'foo' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
+                        ],
+                    ],
+                ], [
+                    'request' => [
                         'data' => RemoveHttpBodyProcessor::STRING_MASK,
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'request' => array(
+                    ],
+                ],
+            ], [
+                [
+                    'request' => [
                         'method' => 'PATCH',
-                        'data' => array(
+                        'data' => [
                             'foo' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
+                        ],
+                    ],
+                ],
+                [
+                    'request' => [
                         'data' => RemoveHttpBodyProcessor::STRING_MASK,
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'request' => array(
+                    ],
+                ],
+            ], [
+                [
+                    'request' => [
                         'method' => 'DELETE',
-                        'data' => array(
+                        'data' => [
                             'foo' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
+                        ],
+                    ],
+                ], [
+                    'request' => [
                         'data' => RemoveHttpBodyProcessor::STRING_MASK,
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'request' => array(
+                    ],
+                ],
+            ], [
+                [
+                    'request' => [
                         'method' => 'GET',
-                        'data' => array(
+                        'data' => [
                             'foo' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
-                        'data' => array(
+                        ],
+                    ],
+                ], [
+                    'request' => [
+                        'data' => [
                             'foo' => 'bar',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Processor/SanitizeDataProcessorTest.php
+++ b/tests/Processor/SanitizeDataProcessorTest.php
@@ -17,24 +17,24 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
 {
     public function testDoesFilterHttpData()
     {
-        $data = array(
-            'request' => array(
-                'data' => array(
+        $data = [
+            'request' => [
+                'data' => [
                     'foo' => 'bar',
                     'password' => 'hello',
                     'the_secret' => 'hello',
                     'a_password_here' => 'hello',
                     'mypasswd' => 'hello',
                     'authorization' => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
-                    'card_number' => array(
+                    'card_number' => [
                         '1111',
                         '2222',
                         '3333',
                         '4444'
-                    )
-                ),
-            )
-        );
+                    ]
+                ],
+            ]
+        ];
 
         $client = new Dummy_Raven_Client();
         $processor = new SanitizeDataProcessor($client);
@@ -55,13 +55,13 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testDoesFilterSessionId()
     {
-        $data = array(
-            'request' => array(
-                'cookies' => array(
+        $data = [
+            'request' => [
+                'cookies' => [
                     ini_get('session.name') => 'abc',
-                ),
-            )
-        );
+                ],
+            ]
+        ];
 
         $client = new Dummy_Raven_Client();
         $processor = new SanitizeDataProcessor($client);
@@ -73,11 +73,11 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function testDoesFilterCreditCard()
     {
-        $data = array(
-            'extra' => array(
+        $data = [
+            'extra' => [
                 'ccnumba' => '4242424242424242',
-            ),
-        );
+            ],
+        ];
 
         $client = new Dummy_Raven_Client();
         $processor = new SanitizeDataProcessor($client);
@@ -94,10 +94,10 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($processor->getFieldsRe(), '/(authorization|password|passwd|secret|password_confirmation|card_number|auth_pw)/i', 'got default fields');
         $this->assertEquals($processor->getValuesRe(), '/^(?:\d[ -]*?){13,16}$/', 'got default values');
 
-        $options = array(
+        $options = [
             'fields_re' => '/(api_token)/i',
             'values_re' => '/^(?:\d[ -]*?){15,16}$/'
-        );
+        ];
 
         $processor->setProcessorOptions($options);
 
@@ -135,9 +135,9 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public function testOverridenSanitize($processorOptions, $client_options, $dsn)
     {
-        $data = array(
-            'request' => array(
-                'data' => array(
+        $data = [
+            'request' => [
+                'data' => [
                     'foo'               => 'bar',
                     'password'          => 'hello',
                     'the_secret'        => 'hello',
@@ -145,13 +145,13 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
                     'mypasswd'          => 'hello',
                     'api_token'         => 'nioenio3nrio3jfny89nby9bhr#RML#R',
                     'authorization'     => 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=',
-                    'card_number'   => array(
+                    'card_number'   => [
                         '1111111111111111',
                         '2222',
-                    )
-                ),
-            )
-        );
+                    ]
+                ],
+            ]
+        ];
 
         $client = new Dummy_Raven_Client($dsn, $client_options);
         /**
@@ -185,22 +185,22 @@ class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
      */
     public static function overrideDataProvider()
     {
-        $processorOptions = array(
-            SanitizeDataProcessor::class => array(
+        $processorOptions = [
+            SanitizeDataProcessor::class => [
                 'fields_re' => '/(api_token)/i',
-                'values_re' => '/^(?:\d[ -]*?){15,16}$/'
-            )
-        );
+                'values_re' => '/^(?:\d[ -]*?){15,16}$/',
+            ],
+        ];
 
-        $client_options = array(
-            'processors' => array(SanitizeDataProcessor::class),
+        $client_options = [
+            'processors' => [SanitizeDataProcessor::class],
             'processorOptions' => $processorOptions
-        );
+        ];
 
         $dsn = 'http://9aaa31f9a05b4e72aaa06aa8157a827a:9aa7aa82a9694a08a1a7589a2a035a9a@sentry.domain.tld/1';
 
-        return array(
-            array($processorOptions, $client_options, $dsn)
-        );
+        return [
+            [$processorOptions, $client_options, $dsn]
+        ];
     }
 }

--- a/tests/Processor/SanitizeHttpHeadersProcessorTest.php
+++ b/tests/Processor/SanitizeHttpHeadersProcessorTest.php
@@ -29,9 +29,9 @@ class SanitizeHttpHeadersProcessorTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->processor = new SanitizeHttpHeadersProcessor($client);
-        $this->processor->setProcessorOptions(array(
-            'sanitize_http_headers' => array('User-Defined-Header'),
-        ));
+        $this->processor->setProcessorOptions([
+            'sanitize_http_headers' => ['User-Defined-Header'],
+        ]);
     }
 
     /**
@@ -46,43 +46,40 @@ class SanitizeHttpHeadersProcessorTest extends \PHPUnit_Framework_TestCase
 
     public function processDataProvider()
     {
-        return array(
-            array(
-                array(
-                    'request' => array(
-                        'headers' => array(
+        return [
+            [
+                [
+                    'request' => [
+                        'headers' => [
                             'Authorization' => 'foo',
                             'AnotherHeader' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
-                        'headers' => array(
+                        ],
+                    ],
+                ], [
+                    'request' => [
+                        'headers' => [
                             'Authorization' => SanitizeHttpHeadersProcessor::STRING_MASK,
                             'AnotherHeader' => 'bar',
-                        ),
-                    ),
-                ),
-            ),
-            array(
-                array(
-                    'request' => array(
-                        'headers' => array(
+                        ],
+                    ],
+                ],
+            ], [
+                [
+                    'request' => [
+                        'headers' => [
                             'User-Defined-Header' => 'foo',
                             'AnotherHeader' => 'bar',
-                        ),
-                    ),
-                ),
-                array(
-                    'request' => array(
-                        'headers' => array(
+                        ],
+                    ],
+                ], [
+                    'request' => [
+                        'headers' => [
                             'User-Defined-Header' => SanitizeHttpHeadersProcessor::STRING_MASK,
                             'AnotherHeader' => 'bar',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -75,25 +75,4 @@ class SanitizeStacktraceProcessorTest extends \PHPUnit_Framework_TestCase
             }
         }
     }
-
-    /**
-     * Gets all the public and abstracts methods of a given class.
-     *
-     * @param string $className The FCQN of the class
-     *
-     * @return array
-     */
-    private function getClassMethods($className)
-    {
-        $class = new \ReflectionClass($className);
-        $methods = array();
-
-        foreach ($class->getMethods() as $method) {
-            if ($method->isPublic() || $method->isAbstract()) {
-                $methods[] = $method->getName();
-            }
-        }
-
-        return $methods;
-    }
 }

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -54,9 +54,9 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         if ($serialize_all_objects) {
             $serializer->setAllObjectSerialize(true);
         }
-        $input = array(1, 2, 3);
+        $input = [1, 2, 3];
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('1', '2', '3'), $result);
+        $this->assertEquals(['1', '2', '3'], $result);
     }
 
     /**
@@ -74,7 +74,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $input = new \stdClass();
         $input->foo = 'BAR';
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => 'BAR'), $result);
+        $this->assertEquals(['foo' => 'BAR'], $result);
     }
 
     public function testObjectsAreStrings()
@@ -95,7 +95,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $serializer->setAllObjectSerialize(true);
         $input = new \Raven\Tests\SerializerTestObject();
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('key' => 'value'), $result);
+        $this->assertEquals(['key' => 'value'], $result);
     }
 
     /**
@@ -184,10 +184,10 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         if ($serialize_all_objects) {
             $serializer->setAllObjectSerialize(true);
         }
-        $input = array();
+        $input = [];
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array of length 1'))), $result);
+        $this->assertEquals([[['Array of length 1']]], $result);
 
         $result = $serializer->serialize([], 3);
         $this->assertEquals([], $result);
@@ -327,9 +327,9 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $class_name = static::get_test_class();
         /** @var \Raven\Serializer $serializer **/
         $serializer = new $class_name();
-        $input = array('foo' => new \Raven\Tests\SerializerTestObject());
+        $input = ['foo' => new \Raven\Tests\SerializerTestObject()];
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => 'Object Raven\\Tests\\SerializerTestObject'), $result);
+        $this->assertEquals(['foo' => 'Object Raven\\Tests\\SerializerTestObject'], $result);
     }
 
     public function testObjectInArraySerializeAll()
@@ -338,9 +338,9 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         /** @var \Raven\Serializer $serializer **/
         $serializer = new $class_name();
         $serializer->setAllObjectSerialize(true);
-        $input = array('foo' => new \Raven\Tests\SerializerTestObject());
+        $input = ['foo' => new \Raven\Tests\SerializerTestObject()];
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => array('key' => 'value')), $result);
+        $this->assertEquals(['foo' => ['key' => 'value']], $result);
     }
 
     /**
@@ -355,12 +355,12 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         if ($serialize_all_objects) {
             $serializer->setAllObjectSerialize(true);
         }
-        foreach (array('7efbce4384', 'b782b5d8e5', '9dde8d1427', '8fd4c373ca', '9b8e84cb90') as $key) {
+        foreach (['7efbce4384', 'b782b5d8e5', '9dde8d1427', '8fd4c373ca', '9b8e84cb90'] as $key) {
             $input = pack('H*', $key);
             $result = $serializer->serialize($input);
             $this->assertInternalType('string', $result);
             if (function_exists('mb_detect_encoding')) {
-                $this->assertContains(mb_detect_encoding($result), array('ASCII', 'UTF-8'));
+                $this->assertContains(mb_detect_encoding($result), ['ASCII', 'UTF-8']);
             }
         }
     }
@@ -378,7 +378,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
             $serializer->setAllObjectSerialize(true);
         }
         for ($i = 0; $i < 100; $i++) {
-            foreach (array(100, 1000, 1010, 1024, 1050, 1100, 10000) as $length) {
+            foreach ([100, 1000, 1010, 1024, 1050, 1100, 10000] as $length) {
                 $input = '';
                 for ($i = 0; $i < $length; $i++) {
                     $input .= chr(mt_rand(0, 255));

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -241,19 +241,19 @@ class StacktraceTest extends \PHPUnit_Framework_TestCase
         // Modification of these would be really bad, since if control is returned (non-fatal error) we'll have altered the state of things!
         $originalFoo = 'bloopblarp';
         $newFoo = $originalFoo;
-        $nestedArray = array(
+        $nestedArray = [
             'key' => 'xxxxxxxxxx',
-        );
+        ];
 
-        $frame = array(
+        $frame = [
             "file" => dirname(__FILE__) . "/resources/a.php",
             "line" => 9,
-            "args"=> array(
+            "args"=> [
                 &$newFoo,
                 &$nestedArray,
-            ),
+            ],
             "function" => "a_test",
-        );
+        ];
 
         $result = Stacktrace::getFrameArguments($frame, 5);
 

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -20,14 +20,14 @@ class Raven_Tests_UtilTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetReturnsDefaultOnMissing()
     {
-        $input = array('foo' => 'bar');
+        $input = ['foo' => 'bar'];
         $result = \Raven\Util::get($input, 'baz', 'foo');
         $this->assertEquals('foo', $result);
     }
 
     public function testGetReturnsPresentValuesEvenWhenEmpty()
     {
-        $input = array('foo' => '');
+        $input = ['foo' => ''];
         $result = \Raven\Util::get($input, 'foo', 'bar');
         $this->assertEquals('', $result);
     }


### PR DESCRIPTION
* Set PHP 7.1 as **required** version because RC is already ready
* Raven Client initialization refactoring
* PHP 5.4: Force short syntax arrays (add rule to code style checking script)
* PHPDoc changes
* ~~Delete old PHP version~~

Issue #424

I'm afraid we must do coverage for all code we have.