### PR TITLE
Link the Sentry logo to the Sentry website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <a href="https://symfony.com" target="_blank" align="center">
+    <a href="https://sentry.io" target="_blank" align="center">
         <img src="https://a0wx592cvgzripj.global.ssl.fastly.net/_static/f9c485ccdb254095d3cac55524daba0a/getsentry/images/branding/svg/sentry-horizontal-black.svg" width="280">
     </a>
 </p>


### PR DESCRIPTION
In #435 the Sentry logo was added to the README.md but linked to the Symfony website.