### PR TITLE
Add serialization for callables

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -106,7 +106,9 @@ class Raven_Serializer
      */
     protected function serializeValue($value)
     {
-        if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
+        if (is_callable($value)) {
+            return $this->serializeValue($value());
+        } elseif (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
             return $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
             return 'Object '.get_class($value);

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -106,11 +106,15 @@ class Raven_Serializer
      */
     protected function serializeValue($value)
     {
-        if (is_callable($value)) {
-            return $this->serializeValue($value());
-        } elseif (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
+        if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
             return $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
+            // If the value is a callable and expects no parameters, we evaluate the
+            // callable value by calling it.
+            if (is_callable($value) && Raven_Util::getCallableParamNum($value) === 0) {
+                return $value();
+            }
+
             return 'Object '.get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);

--- a/lib/Raven/Util.php
+++ b/lib/Raven/Util.php
@@ -45,8 +45,13 @@ class Raven_Util
      *
      * @return int
      */
-    public static function getCallableParamNum(callable $callable)
+    public static function getCallableParamNum($callable)
     {
+        if (!is_callable($callable)) {
+            // PHP5.3 does not support typehint `callable` so we do it this way.
+            throw new InvalidArgumentException('Callable expected');
+        }
+
         $reflection_fn = new ReflectionFunction($callable);
 
         return (int) $reflection_fn->getNumberOfRequiredParameters();

--- a/lib/Raven/Util.php
+++ b/lib/Raven/Util.php
@@ -35,4 +35,20 @@ class Raven_Util
 
         return $default;
     }
+
+    /**
+     * Determine how many parameters a callable/Closure expects when it is called.
+     *
+     * Only checks required parameters.
+     *
+     * @param callable $callable The callable to check
+     *
+     * @return int
+     */
+    public static function getCallableParamNum(callable $callable)
+    {
+        $reflection_fn = new ReflectionFunction($callable);
+
+        return (int) $reflection_fn->getNumberOfRequiredParameters();
+    }
 }

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -96,6 +96,16 @@ class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'Object Raven_Serializer'), $result);
     }
 
+    public function testCallablesAreEvaluated()
+    {
+        $serializer = new Raven_Serializer();
+        $input = function () {
+            return 'hello world';
+        };
+        $result = $serializer->serialize($input);
+        $this->assertEquals('hello world', $result);
+    }
+
     /**
      * @covers Raven_Serializer::serializeString
      */

--- a/test/Raven/Tests/UtilTest.php
+++ b/test/Raven/Tests/UtilTest.php
@@ -50,6 +50,6 @@ class Raven_Tests_UtilTest extends PHPUnit_Framework_TestCase
             Raven_Util::getCallableParamNum($fn_three)
         ];
 
-        $this->assertEquals([0, 2, 4], $results);
+        $this->assertEquals(array(0, 2, 4), $results);
     }
 }

--- a/test/Raven/Tests/UtilTest.php
+++ b/test/Raven/Tests/UtilTest.php
@@ -44,11 +44,11 @@ class Raven_Tests_UtilTest extends PHPUnit_Framework_TestCase
             return true;
         };
 
-        $results = [
+        $results = array(
             Raven_Util::getCallableParamNum($fn_one),
             Raven_Util::getCallableParamNum($fn_two),
             Raven_Util::getCallableParamNum($fn_three)
-        ];
+        );
 
         $this->assertEquals(array(0, 2, 4), $results);
     }

--- a/test/Raven/Tests/UtilTest.php
+++ b/test/Raven/Tests/UtilTest.php
@@ -29,4 +29,27 @@ class Raven_Tests_UtilTest extends PHPUnit_Framework_TestCase
         $result = Raven_Util::get($input, 'foo', 'bar');
         $this->assertEquals('', $result);
     }
+
+    public function testGetCallableParamNumWorks()
+    {
+        $fn_one = function () {
+            return true;
+        };
+
+        $fn_two = function ($a, $b) {
+            return true;
+        };
+
+        $fn_three = function ($a, $b, $c, $d) {
+            return true;
+        };
+
+        $results = [
+            Raven_Util::getCallableParamNum($fn_one),
+            Raven_Util::getCallableParamNum($fn_two),
+            Raven_Util::getCallableParamNum($fn_three)
+        ];
+
+        $this->assertEquals([0, 2, 4], $results);
+    }
 }


### PR DESCRIPTION
If a value to be serialized for transport is of type `callable`, serialize the return value instead of resorting to string casting.

This is useful for lazy-loading values for transport.

Example:

A framework/application uses a hook-filter event system, where the "current hook" changes constantly. By defining a callable which returns the current hook ID, we can define the Raven client context once and it will be lazy-loaded upon serialization.

Otherwise we would have to hook into all possible hooks via some magic and keep redefining the wanted context value, while wasting processing power.

Possible pitfalls that need to be considered:

-   Recursive callables which create infinite loops
-   Callables that use too much system resources
-   Invalid parameters passed to callables (only allow callables that accept no parameters?)
-   Cases where the actual callable is wanted to be passed as a string instead of returning the result.

Example in code

```php
<?php

$client = get_sentry_client_here();

$lazyload = function () {
    return (string) get_some_constantly_changing_value();
};

$client->extra_context([
    'live_value' => $lazyload
]);
```

EDIT:

- PR now includes tests
- Callables are checked via Reflection to prevent calling closures that expect params