### PR TITLE
Serializing all objects

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -203,8 +203,7 @@ class Client
         $this->serializer = new \Raven\Serializer($this->mb_detect_order);
         $this->reprSerializer = new \Raven\ReprSerializer($this->mb_detect_order);
         if (\Raven\Util::get($options, 'serialize_all_object', false)) {
-            $this->serializer->setAllObjectSerialize(true);
-            $this->reprSerializer->setAllObjectSerialize(true);
+            $this->setAllObjectSerialize(true);
         }
 
         if ($this->curl_method == 'async') {
@@ -1446,5 +1445,11 @@ class Client
             curl_close($this->_curl_instance);
             $this->_curl_instance = null;
         }
+    }
+
+    public function setAllObjectSerialize($value)
+    {
+        $this->serializer->setAllObjectSerialize($value);
+        $this->reprSerializer->setAllObjectSerialize($value);
     }
 }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -123,6 +123,10 @@ class Client
      * @var bool
      */
     protected $_shutdown_function_has_been_set;
+    /**
+     * @var \Raven\TransactionStack
+     */
+    public $transaction;
 
     public function __construct($options_or_dsn = null, $options = array())
     {
@@ -198,6 +202,10 @@ class Client
         ));
         $this->serializer = new \Raven\Serializer($this->mb_detect_order);
         $this->reprSerializer = new \Raven\ReprSerializer($this->mb_detect_order);
+        if (\Raven\Util::get($options, 'serialize_all_object', false)) {
+            $this->serializer->setAllObjectSerialize(true);
+            $this->reprSerializer->setAllObjectSerialize(true);
+        }
 
         if ($this->curl_method == 'async') {
             $this->_curl_handler = new \Raven\CurlHandler($this->get_curl_options());

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -73,18 +73,50 @@ class Serializer
      */
     public function serialize($value, $max_depth = 3, $_depth = 0)
     {
-        $className = is_object($value) ? get_class($value) : null;
-        $toArray = (is_array($value) or ($className == 'stdClass') or
-            (is_object($value) and $this->_all_object_serialize));
-        if ($toArray && $_depth < $max_depth) {
-            $new = array();
-            foreach ($value as $k => $v) {
-                $new[$this->serializeValue($k)] = $this->serialize($v, $max_depth, $_depth + 1);
+        if ($_depth < $max_depth) {
+            if (is_array($value)) {
+                $new = array();
+                foreach ($value as $k => $v) {
+                    $new[$this->serializeValue($k)] = $this->serialize($v, $max_depth, $_depth + 1);
+                }
+
+                return $new;
             }
 
-            return $new;
+            if (is_object($value)) {
+                if ((get_class($value) == 'stdClass') or $this->_all_object_serialize) {
+                    return $this->serializeObject($value, $max_depth, $_depth, []);
+                }
+            }
         }
         return $this->serializeValue($value);
+    }
+
+    /**
+     * @param object   $object
+     * @param integer  $max_depth
+     * @param integer  $_depth
+     * @param string[] $hashes
+     *
+     * @return array|string
+     */
+    public function serializeObject($object, $max_depth = 3, $_depth = 0, $hashes = [])
+    {
+        if (($_depth >= $max_depth) or in_array(spl_object_hash($object), $hashes)) {
+            return $this->serializeValue($object);
+        }
+        $hashes[] = spl_object_hash($object);
+        $return = [];
+        foreach ($object as $key => &$value) {
+            if (is_object($value)) {
+                $new_value = $this->serializeObject($value, $max_depth, $_depth + 1, $hashes);
+            } else {
+                $new_value = $this->serialize($value, $max_depth, $_depth + 1);
+            }
+            $return[$key] = $new_value;
+        }
+
+        return $return;
     }
 
     protected function serializeString($value)

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -48,6 +48,11 @@ class Serializer
     protected $mb_detect_order = self::DEFAULT_MB_DETECT_ORDER;
 
     /**
+     * @var boolean $_all_object_serialize
+     */
+    protected $_all_object_serialize = false;
+
+    /**
      * @param null|string $mb_detect_order
      */
     public function __construct($mb_detect_order = null)
@@ -69,7 +74,8 @@ class Serializer
     public function serialize($value, $max_depth = 3, $_depth = 0)
     {
         $className = is_object($value) ? get_class($value) : null;
-        $toArray = is_array($value) || $className === 'stdClass';
+        $toArray = (is_array($value) or ($className == 'stdClass') or
+            (is_object($value) and $this->_all_object_serialize));
         if ($toArray && $_depth < $max_depth) {
             $new = array();
             foreach ($value as $k => $v) {
@@ -142,5 +148,21 @@ class Serializer
         $this->mb_detect_order = $mb_detect_order;
 
         return $this;
+    }
+
+    /**
+     * @param boolean $value
+     */
+    public function setAllObjectSerialize($value)
+    {
+        $this->_all_object_serialize = $value;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getAllObjectSerialize()
+    {
+        return $this->_all_object_serialize;
     }
 }

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -11,6 +11,11 @@ namespace Raven;
 
 class TransactionStack
 {
+    /**
+     * @var array $stack
+     */
+    public $stack;
+
     public function __construct()
     {
         $this->stack = array();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -10,6 +10,9 @@
 
 namespace Raven\Tests;
 
+use Raven\Client;
+use Raven\Serializer;
+
 function simple_function($a = null, $b = null, $c = null)
 {
     assert(0);
@@ -2355,5 +2358,33 @@ class Raven_Tests_ClientTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->fail('sample_rate=0.5 can not produce fails and successes at the same time');
+    }
+
+    /**
+     * @covers \Raven\Client::setAllObjectSerialize
+     */
+    public function testSetAllObjectSerialize()
+    {
+        $client = new \Raven\Client;
+
+        $ref1 = new \ReflectionProperty($client, 'serializer');
+        $ref1->setAccessible(true);
+        $ref2 = new \ReflectionProperty($client, 'reprSerializer');
+        $ref2->setAccessible(true);
+
+        /**
+         * @var \Raven\Serializer $o1
+         * @var \Raven\Serializer $o2
+         */
+        $o1 = $ref1->getValue($client);
+        $o2 = $ref2->getValue($client);
+
+        $client->setAllObjectSerialize(true);
+        $this->assertTrue($o1->getAllObjectSerialize());
+        $this->assertTrue($o2->getAllObjectSerialize());
+
+        $client->setAllObjectSerialize(false);
+        $this->assertFalse($o1->getAllObjectSerialize());
+        $this->assertFalse($o2->getAllObjectSerialize());
     }
 }

--- a/tests/ReprSerializerTest.php
+++ b/tests/ReprSerializerTest.php
@@ -11,45 +11,60 @@
 
 namespace Raven\Tests;
 
-class ReprSerializerTest extends \PHPUnit_Framework_TestCase
+require_once 'SerializerAbstractTest.php';
+
+class ReprSerializerTest extends \Raven\Tests\Raven_Tests_SerializerAbstractTest
 {
-    public function testArraysAreArrays()
+    /**
+     * @return string
+     */
+    protected static function get_test_class()
     {
-        $serializer = new \Raven\ReprSerializer();
-        $input = array(1, 2, 3);
-        $result = $serializer->serialize($input);
-        $this->assertEquals(array('1', '2', '3'), $result);
+        return '\\Raven\\ReprSerializer';
     }
 
-    public function testObjectsAreStrings()
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testIntsAreInts($serialize_all_objects)
     {
         $serializer = new \Raven\ReprSerializer();
-        $input = new \Raven\Tests\StacktraceTestObject();
-        $result = $serializer->serialize($input);
-        $this->assertEquals('Object Raven\Tests\StacktraceTestObject', $result);
-    }
-
-    public function testIntsAreInts()
-    {
-        $serializer = new \Raven\ReprSerializer();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
         $input = 1;
         $result = $serializer->serialize($input);
         $this->assertInternalType('string', $result);
         $this->assertEquals(1, $result);
     }
 
-    public function testFloats()
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testFloats($serialize_all_objects)
     {
         $serializer = new \Raven\ReprSerializer();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
         $input = 1.5;
         $result = $serializer->serialize($input);
         $this->assertInternalType('string', $result);
         $this->assertEquals('1.5', $result);
     }
 
-    public function testBooleans()
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testBooleans($serialize_all_objects)
     {
         $serializer = new \Raven\ReprSerializer();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
         $input = true;
         $result = $serializer->serialize($input);
         $this->assertEquals('true', $result);
@@ -60,44 +75,33 @@ class ReprSerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('false', $result);
     }
 
-    public function testNull()
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testNull($serialize_all_objects)
     {
         $serializer = new \Raven\ReprSerializer();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
         $input = null;
         $result = $serializer->serialize($input);
         $this->assertInternalType('string', $result);
         $this->assertEquals('null', $result);
     }
 
-    public function testRecursionMaxDepth()
-    {
-        $serializer = new \Raven\ReprSerializer();
-        $input = array();
-        $input[] = &$input;
-        $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array of length 1'))), $result);
-    }
-
     /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
      * @covers \Raven\ReprSerializer::serializeValue
      */
-    public function testSerializeValueResource()
+    public function testSerializeRoundedFloat($serialize_all_objects)
     {
         $serializer = new \Raven\ReprSerializer();
-        $filename = tempnam(sys_get_temp_dir(), 'sentry_test_');
-        $fo = fopen($filename, 'wb');
-
-        $result = $serializer->serialize($fo);
-        $this->assertInternalType('string', $result);
-        $this->assertEquals('Resource stream', $result);
-    }
-
-    /**
-     * @covers \Raven\ReprSerializer::serializeValue
-     */
-    public function testSerializeRoundedFloat()
-    {
-        $serializer = new \Raven\ReprSerializer();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
 
         $result = $serializer->serialize((double)1);
         $this->assertInternalType('string', $result);

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Tests;
+
+class SerializerTestObject
+{
+    private $foo = 'bar';
+
+    public $key = 'value';
+}
+
+abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return string|\Raven\Serializer
+     */
+    protected static function get_test_class()
+    {
+        return '';
+    }
+
+    public function dataGetBaseParam()
+    {
+        return [
+            ['serialize_all_objects' => false],
+            ['serialize_all_objects' => true],
+        ];
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testArraysAreArrays($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer * */
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = array(1, 2, 3);
+        $result = $serializer->serialize($input);
+        $this->assertEquals(array('1', '2', '3'), $result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testStdClassAreArrays($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = new \stdClass();
+        $input->foo = 'BAR';
+        $result = $serializer->serialize($input);
+        $this->assertEquals(array('foo' => 'BAR'), $result);
+    }
+
+    public function testObjectsAreStrings()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer * */
+        $serializer = new $class_name();
+        $input = new \Raven\Tests\SerializerTestObject();
+        $result = $serializer->serialize($input);
+        $this->assertEquals('Object Raven\Tests\SerializerTestObject', $result);
+    }
+
+    public function testObjectsAreNotStrings()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer * */
+        $serializer = new $class_name();
+        $serializer->setAllObjectSerialize(true);
+        $input = new \Raven\Tests\SerializerTestObject();
+        $result = $serializer->serialize($input);
+        $this->assertEquals(array('key' => 'value'), $result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testIntsAreInts($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = 1;
+        $result = $serializer->serialize($input);
+        $this->assertInternalType('integer', $result);
+        $this->assertEquals(1, $result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testFloats($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = 1.5;
+        $result = $serializer->serialize($input);
+        $this->assertInternalType('double', $result);
+        $this->assertEquals(1.5, $result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testBooleans($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = true;
+        $result = $serializer->serialize($input);
+        $this->assertTrue($result);
+
+        $input = false;
+        $result = $serializer->serialize($input);
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testNull($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = null;
+        $result = $serializer->serialize($input);
+        $this->assertNull($result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testRecursionMaxDepth($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $input = array();
+        $input[] = &$input;
+        $result = $serializer->serialize($input, 3);
+        $this->assertEquals(array(array(array('Array of length 1'))), $result);
+
+        $result = $serializer->serialize([], 3);
+        $this->assertEquals([], $result);
+
+        $result = $serializer->serialize([[]], 3);
+        $this->assertEquals([[]], $result);
+
+        $result = $serializer->serialize([[[]]], 3);
+        $this->assertEquals([[[]]], $result);
+
+        $result = $serializer->serialize([[[[]]]], 3);
+        $this->assertEquals([[['Array of length 0']]], $result);
+    }
+
+    public function testRecursionMaxDepthForObject()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        $serializer->setAllObjectSerialize(true);
+
+        $result = $serializer->serialize((object)['key' => (object)['key' => 12345]], 3);
+        $this->assertEquals(['key' => ['key' => 12345]], $result);
+
+        $result = $serializer->serialize((object)['key' => (object)['key' => (object)['key' => 12345]]], 3);
+        $this->assertEquals(['key' => ['key' => ['key' => 12345]]], $result);
+
+        $result = $serializer->serialize(
+            (object)['key' => (object)['key' => (object)['key' => (object)['key' => 12345]]]], 3
+        );
+        $this->assertEquals(['key' => ['key' => ['key' => 'Object stdClass']]], $result);
+    }
+
+    public function testObjectInArray()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        $input = array('foo' => new \Raven\Tests\SerializerTestObject());
+        $result = $serializer->serialize($input);
+        $this->assertEquals(array('foo' => 'Object Raven\\Tests\\SerializerTestObject'), $result);
+    }
+
+    public function testObjectInArraySerializeAll()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        $serializer->setAllObjectSerialize(true);
+        $input = array('foo' => new \Raven\Tests\SerializerTestObject());
+        $result = $serializer->serialize($input);
+        $this->assertEquals(array('foo' => array('key' => 'value')), $result);
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testBrokenEncoding($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        foreach (array('7efbce4384', 'b782b5d8e5', '9dde8d1427', '8fd4c373ca', '9b8e84cb90') as $key) {
+            $input = pack('H*', $key);
+            $result = $serializer->serialize($input);
+            $this->assertInternalType('string', $result);
+            if (function_exists('mb_detect_encoding')) {
+                $this->assertContains(mb_detect_encoding($result), array('ASCII', 'UTF-8'));
+            }
+        }
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testLongString($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        for ($i = 0; $i < 100; $i++) {
+            foreach (array(100, 1000, 1010, 1024, 1050, 1100, 10000) as $length) {
+                $input = '';
+                for ($i = 0; $i < $length; $i++) {
+                    $input .= chr(mt_rand(0, 255));
+                }
+                $result = $serializer->serialize($input);
+                $this->assertInternalType('string', $result);
+                $this->assertLessThanOrEqual(1024, strlen($result));
+            }
+        }
+    }
+
+    /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
+     */
+    public function testSerializeValueResource($serialize_all_objects)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        if ($serialize_all_objects) {
+            $serializer->setAllObjectSerialize(true);
+        }
+        $filename = tempnam(sys_get_temp_dir(), 'sentry_test_');
+        $fo = fopen($filename, 'wb');
+
+        $result = $serializer->serialize($fo);
+        $this->assertInternalType('string', $result);
+        $this->assertEquals('Resource stream', $result);
+    }
+
+    public function testSetAllObjectSerialize()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        $serializer->setAllObjectSerialize(true);
+        $this->assertTrue($serializer->getAllObjectSerialize());
+        $serializer->setAllObjectSerialize(false);
+        $this->assertFalse($serializer->getAllObjectSerialize());
+    }
+}

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -1,149 +1,46 @@
 <?php
 
-/*
- * This file is part of Raven.
- *
- * (c) Sentry Team
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Raven\Tests;
 
-class SerializerTestObject
+require_once 'SerializerAbstractTest.php';
+
+class SerializerTest extends \Raven\Tests\Raven_Tests_SerializerAbstractTest
 {
-    private $foo = 'bar';
-}
-
-class Raven_Tests_SerializerTest extends \PHPUnit_Framework_TestCase
-{
-    public function testArraysAreArrays()
+    /**
+     * @return string
+     */
+    protected static function get_test_class()
     {
-        $serializer = new \Raven\Serializer();
-        $input = array(1, 2, 3);
-        $result = $serializer->serialize($input);
-        $this->assertEquals(array('1', '2', '3'), $result);
-    }
-
-    public function testStdClassAreArrays()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = new \stdClass();
-        $input->foo = 'BAR';
-        $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => 'BAR'), $result);
-    }
-
-    public function testObjectsAreStrings()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = new \Raven\Tests\SerializerTestObject();
-        $result = $serializer->serialize($input);
-        $this->assertEquals('Object Raven\Tests\SerializerTestObject', $result);
-    }
-
-    public function testIntsAreInts()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = 1;
-        $result = $serializer->serialize($input);
-        $this->assertInternalType('integer', $result);
-        $this->assertEquals(1, $result);
-    }
-
-    public function testFloats()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = 1.5;
-        $result = $serializer->serialize($input);
-        $this->assertInternalType('double', $result);
-        $this->assertEquals(1.5, $result);
-    }
-
-    public function testBooleans()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = true;
-        $result = $serializer->serialize($input);
-        $this->assertTrue($result);
-
-        $input = false;
-        $result = $serializer->serialize($input);
-        $this->assertFalse($result);
-    }
-
-    public function testNull()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = null;
-        $result = $serializer->serialize($input);
-        $this->assertNull($result);
-    }
-
-    public function testRecursionMaxDepth()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = array();
-        $input[] = &$input;
-        $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array of length 1'))), $result);
-    }
-
-    public function testObjectInArray()
-    {
-        $serializer = new \Raven\Serializer();
-        $input = array('foo' => new \Raven\Serializer());
-        $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => 'Object Raven\\Serializer'), $result);
+        return '\\Raven\\Serializer';
     }
 
     /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
      * @covers \Raven\Serializer::serializeString
      */
-    public function testBrokenEncoding()
+    public function testBrokenEncoding($serialize_all_objects)
     {
-        $serializer = new \Raven\Serializer();
-        foreach (array('7efbce4384', 'b782b5d8e5', '9dde8d1427', '8fd4c373ca', '9b8e84cb90') as $key) {
-            $input = pack('H*', $key);
-            $result = $serializer->serialize($input);
-            $this->assertInternalType('string', $result);
-            if (function_exists('mb_detect_encoding')) {
-                $this->assertContains(mb_detect_encoding($result), array('ASCII', 'UTF-8'));
-            }
-        }
+        parent::testBrokenEncoding($serialize_all_objects);
     }
 
     /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
      * @covers \Raven\Serializer::serializeString
      */
-    public function testLongString()
+    public function testLongString($serialize_all_objects)
     {
-        $serializer = new \Raven\Serializer();
-        for ($i = 0; $i < 100; $i++) {
-            foreach (array(100, 1000, 1010, 1024, 1050, 1100, 10000) as $length) {
-                $input = '';
-                for ($i = 0; $i < $length; $i++) {
-                    $input .= chr(mt_rand(0, 255));
-                }
-                $result = $serializer->serialize($input);
-                $this->assertInternalType('string', $result);
-                $this->assertLessThanOrEqual(1024, strlen($result));
-            }
-        }
+        parent::testLongString($serialize_all_objects);
     }
 
     /**
+     * @param boolean $serialize_all_objects
+     * @dataProvider dataGetBaseParam
      * @covers \Raven\Serializer::serializeValue
      */
-    public function testSerializeValueResource()
+    public function testSerializeValueResource($serialize_all_objects)
     {
-        $serializer = new \Raven\Serializer();
-        $filename = tempnam(sys_get_temp_dir(), 'sentry_test_');
-        $fo = fopen($filename, 'wb');
-
-        $result = $serializer->serialize($fo);
-        $this->assertInternalType('string', $result);
-        $this->assertEquals('Resource stream', $result);
+        parent::testSerializeValueResource($serialize_all_objects);
     }
 }


### PR DESCRIPTION
Serializing all objects by their public properties.
And some small refactoring for Serializer tests.

I don't know why we serialize only stdClass. Objects are just array with some behaviour and always named keys. So we should treat them appropriately.

```php
$client = new \Raven\Client(..., [
    'serialize_all_object' => true,
]);
```