### PR TITLE
[2.0] Add serialization for callables without invoking

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -84,7 +84,9 @@ class Serializer
             }
 
             if (is_object($value)) {
-                if ((get_class($value) == 'stdClass') or $this->_all_object_serialize) {
+                if (is_callable($value)) {
+                    return $this->serializeCallable($value);
+                } elseif ((get_class($value) == 'stdClass') or $this->_all_object_serialize) {
                     return $this->serializeObject($value, $max_depth, $_depth, []);
                 }
             }
@@ -159,6 +161,53 @@ class Serializer
         }
     }
 
+    /**
+     * @param Callable $callable
+     *
+     * @return string
+     */
+    public function serializeCallable($callable)
+    {
+        if (is_array($callable)) {
+            $reflection = new \ReflectionMethod($callable[0], $callable[1]);
+            $class = $reflection->getDeclaringClass();
+        } else {
+            $reflection = new \ReflectionFunction($callable);
+            $class=null;
+        }
+        $value = $reflection->isClosure() ? 'Lambda ' : 'Callable ';
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            $value .= $reflection->getReturnType()." ";
+        }
+        $value .= (!is_null($class) ? $class->getName().'::' : '').$reflection->getName()." [";
+        $params = [];
+        foreach ($reflection->getParameters() as &$param) {
+            if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+                if (($param->hasType())) {
+                    $this_param = $param->getType().($param->allowsNull() ? '|null' : '');
+                } else {
+                    $this_param = ($param->allowsNull() ? 'mixed|null' : '');
+                }
+            } else {
+                if ($param->isArray()) {
+                    $this_param = 'array';
+                } elseif ($param->isCallable()) {
+                    $this_param = 'callable';
+                } else {
+                    $this_param = '';
+                }
+                if (($this_param != '') and $param->allowsNull()) {
+                    $this_param .= '|null';
+                }
+            }
+            $this_param .= (($this_param != '') ? ' ' : '').($param->isOptional() ? '[' : '').
+                ($param->isPassedByReference() ? '&' : '').$param->getName().($param->isOptional() ? ']' : '');
+            $params[] = $this_param;
+        }
+        $value .= implode('; ', $params).']';
+
+        return preg_replace('_\\s{2,}_', ' ', $value);
+    }
 
     /**
      * @return string

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -34,6 +34,13 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         return '';
     }
 
+    /**
+     * This method is only existed because of testSerializeCallable
+     */
+    public static function setUpBeforeClass()
+    {
+    }
+
     public function dataGetBaseParam()
     {
         return [
@@ -49,7 +56,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
     public function testArraysAreArrays($serialize_all_objects)
     {
         $class_name = static::get_test_class();
-        /** @var \Raven\Serializer $serializer * */
+        /** @var \Raven\Serializer $serializer **/
         $serializer = new $class_name();
         if ($serialize_all_objects) {
             $serializer->setAllObjectSerialize(true);
@@ -57,6 +64,9 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $input = [1, 2, 3];
         $result = $serializer->serialize($input);
         $this->assertEquals(['1', '2', '3'], $result);
+
+        $result = $serializer->serialize(['\\Raven\\Client', 'getUserAgent']);
+        $this->assertEquals(['\\Raven\\Client', 'getUserAgent'], $result);
     }
 
     /**
@@ -80,7 +90,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
     public function testObjectsAreStrings()
     {
         $class_name = static::get_test_class();
-        /** @var \Raven\Serializer $serializer * */
+        /** @var \Raven\Serializer $serializer **/
         $serializer = new $class_name();
         $input = new \Raven\Tests\SerializerTestObject();
         $result = $serializer->serialize($input);
@@ -90,7 +100,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
     public function testObjectsAreNotStrings()
     {
         $class_name = static::get_test_class();
-        /** @var \Raven\Serializer $serializer * */
+        /** @var \Raven\Serializer $serializer **/
         $serializer = new $class_name();
         $serializer->setAllObjectSerialize(true);
         $input = new \Raven\Tests\SerializerTestObject();
@@ -300,7 +310,9 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $result1 = $serializer->serialize($object, 3);
         $result2 = $serializer->serializeObject($object, 3);
         $this->assertEquals($result_serialize, $result1);
+        $this->assertTrue(in_array(gettype($result1), ['array', 'string', 'null', 'float', 'integer', 'object']));
         $this->assertEquals($result_serialize_object, $result2);
+        $this->assertTrue(in_array(gettype($result2), ['array', 'string',]));
     }
 
     public function testRecursionMaxDepthForObject()
@@ -419,5 +431,144 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $this->assertTrue($serializer->getAllObjectSerialize());
         $serializer->setAllObjectSerialize(false);
         $this->assertFalse($serializer->getAllObjectSerialize());
+    }
+
+    public function dataSerializeCallable()
+    {
+        $closure1 = function (array $param1) {
+            return $param1 * 2;
+        };
+        $closure2 = function ($param1a) {
+            throw new \Exception('Don\'t even think about invoke me');
+        };
+        $closure4 = function (callable $param1c) {
+            throw new \Exception('Don\'t even think about invoke me');
+        };
+        $closure5 = function (\stdClass $param1d) {
+            throw new \Exception('Don\'t even think about invoke me');
+        };
+        $closure6 = function (\stdClass $param1e = null) {
+            throw new \Exception('Don\'t even think about invoke me');
+        };
+        $closure7 = function (array &$param1f) {
+            throw new \Exception('Don\'t even think about invoke me');
+        };
+        $closure8 = function (array &$param1g = null) {
+            throw new \Exception('Don\'t even think about invoke me');
+        };
+
+        if (version_compare(PHP_VERSION, '7.0.0') >= 0) {
+            $data = [
+                [
+                    'callable' => $closure1,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [array param1]',
+                ], [
+                    'callable' => $closure2,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [mixed|null param1a]',
+                ], [
+                    'callable' => $closure4,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [callable param1c]',
+                ], [
+                    'callable' => $closure5,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [stdClass param1d]',
+                ], [
+                    'callable' => $closure6,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [stdClass|null [param1e]]',
+                ], [
+                    'callable' => $closure7,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [array &param1f]',
+                ], [
+                    'callable' => $closure8,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [array|null [&param1g]]',
+                ], [
+                    'callable' => [$this, 'dataSerializeCallable'],
+                    'expected' => 'Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::dataSerializeCallable []',
+                ], [
+                    'callable' => ['\\Raven\\Client', 'getUserAgent'],
+                    'expected' => 'Callable Raven\Client::getUserAgent []',
+                ], [
+                    'callable' => ['\\PHPUnit_Framework_TestCase', 'setUpBeforeClass'],
+                    'expected' => 'Callable PHPUnit_Framework_TestCase::setUpBeforeClass []',
+                ], [
+                    'callable' => [$this, 'setUpBeforeClass'],
+                    'expected' => 'Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::setUpBeforeClass []',
+                ], [
+                    'callable' => [self::class, 'setUpBeforeClass'],
+                    'expected' => 'Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::setUpBeforeClass []',
+                ],
+            ];
+            require_once('php70_serializing.inc');
+
+            if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
+                require_once('php71_serializing.inc');
+            }
+
+            return $data;
+        } else {
+            return [
+                [
+                    'callable' => $closure1,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [array param1]',
+                ], [
+                    'callable' => $closure2,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [param1a]',
+                ], [
+                    'callable' => $closure4,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [callable param1c]',
+                ], [
+                    'callable' => $closure5,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [param1d]',
+                ], [
+                    'callable' => $closure6,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [[param1e]]',
+                ], [
+                    'callable' => $closure7,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [array &param1f]',
+                ], [
+                    'callable' => $closure8,
+                    'expected' => 'Lambda Raven\\Tests\\{closure} [array|null [&param1g]]',
+                ], [
+                    'callable' => [$this, 'dataSerializeCallable'],
+                    'expected' => 'Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::dataSerializeCallable []',
+                ], [
+                    'callable' => ['\\Raven\\Client', 'getUserAgent'],
+                    'expected' => 'Callable Raven\Client::getUserAgent []',
+                ], [
+                    'callable' => ['\\PHPUnit_Framework_TestCase', 'setUpBeforeClass'],
+                    'expected' => 'Callable PHPUnit_Framework_TestCase::setUpBeforeClass []',
+                ], [
+                    'callable' => [$this, 'setUpBeforeClass'],
+                    'expected' => 'Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::setUpBeforeClass []',
+                ], [
+                    'callable' => [self::class, 'setUpBeforeClass'],
+                    'expected' => 'Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::setUpBeforeClass []',
+                ],
+            ];
+        }
+    }
+
+    /**
+     * @param Callable $callable
+     * @param string   $expected
+     *
+     * @dataProvider dataSerializeCallable
+     */
+    public function testSerializeCallable($callable, $expected)
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer **/
+        $serializer = new $class_name();
+        $actual = $serializer->serializeCallable($callable);
+        $this->assertEquals($expected, $actual);
+
+        $actual2 = $serializer->serialize($callable);
+        $actual3 = $serializer->serialize([$callable]);
+        if (is_array($callable)) {
+            $this->assertInternalType('array', $actual2);
+            $this->assertInternalType('array', $actual3);
+        } else {
+            $this->assertEquals($expected, $actual2);
+            $this->assertEquals([$expected], $actual3);
+        }
     }
 }

--- a/tests/php70_serializing.inc
+++ b/tests/php70_serializing.inc
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @var array[] $data
+ */
+
+/**
+ * @param int $param1_70a
+ * @throws Exception
+ */
+$closure_701 = function (int $param1_70a) {
+    throw new \Exception('Don\'t even think about invoke me');
+};
+
+$closure_702 = function (&$param): int {
+    return (int)$param;
+};
+
+$data = array_merge(
+    $data, [
+        [
+            'callable' => $closure_701,
+            'expected' => 'Lambda {closure} [int param1_70a]',
+        ], [
+            'callable' => $closure_702,
+            'expected' => 'Lambda int {closure} [mixed|null &param]',
+        ],
+    ]
+);
+?>

--- a/tests/php71_serializing.inc
+++ b/tests/php71_serializing.inc
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @var array[] $data
+ */
+
+/**
+ * @param int $param
+ * @return int|null
+ * @throws Exception
+ */
+$closure_711 = function (int $param): ?int {
+    throw new \Exception('Don\'t even think about invoke me');
+};
+
+$closure_712 = function (?int $param1_70b) {
+    throw new \Exception('Don\'t even think about invoke me');
+};
+
+$closure_713 = function (?int $param1_70c): void {
+    throw new \Exception('Don\'t even think about invoke me');
+};
+
+$data = array_merge(
+    $data, [
+        [
+            'callable' => $closure_711,
+            'expected' => 'Lambda int {closure} [int param]',
+        ], [
+            'callable' => $closure_712,
+            'expected' => 'Lambda {closure} [int|null param1_70b]',
+        ], [
+            'callable' => $closure_713,
+            'expected' => 'Lambda void {closure} [int|null param1_70c]',
+        ]
+    ]
+);
+?>


### PR DESCRIPTION
Fixed PR #444
We need serialize callables as other specific objects.

We can discuss string format.
```
Lambda Raven\Tests\{closure} [array param1]
Lambda Raven\Tests\{closure} [mixed|null param1a]
Lambda Raven\Tests\{closure} [int param1b]
Callable Raven\Tests\Raven_Tests_SerializerAbstractTest::dataSerializeCallable []
Callable Raven\Client::getUserAgent []
Callable PHPUnit_Framework_TestCase::setUpBeforeClass []
Lambda int {closure} [mixed|null &param]
Lambda int {closure} [int param]
Lambda void {closure} [int|null param1_70c]
```