### PR TITLE
[2.0] Serializer interface

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -26,7 +26,7 @@ namespace Raven;
  *
  * @package raven
  */
-class Serializer
+class Serializer implements SerializerInterface
 {
     /*
      * The default mb detect order
@@ -67,17 +67,44 @@ class Serializer
      * sanitization and encoding.
      *
      * @param mixed $value
+     * @param array $context
+     * @return string|bool|double|int|null|object|array
+     */
+    public function serialize($value, array $context = [])
+    {
+        $full_context = $this->get_full_context($context);
+        return $this->serializeInner($value, $full_context['max_depth'], 0);
+    }
+
+    /**
+     * @param array $context
+     * @return array
+     */
+    protected function get_full_context(array $context)
+    {
+        if (!array_key_exists('max_depth', $context)) {
+            $context['max_depth'] = 3;
+        }
+
+        return $context;
+    }
+
+    /**
+     * Serialize an object (recursively) into something safe for data
+     * sanitization and encoding.
+     *
+     * @param mixed $value
      * @param int   $max_depth
      * @param int   $_depth
      * @return string|bool|double|int|null|object|array
      */
-    public function serialize($value, $max_depth = 3, $_depth = 0)
+    protected function serializeInner($value, $max_depth, $_depth)
     {
         if ($_depth < $max_depth) {
             if (is_array($value)) {
                 $new = [];
                 foreach ($value as $k => $v) {
-                    $new[$this->serializeValue($k)] = $this->serialize($v, $max_depth, $_depth + 1);
+                    $new[$this->serializeValue($k)] = $this->serializeInner($v, $max_depth, $_depth + 1);
                 }
 
                 return $new;
@@ -111,7 +138,7 @@ class Serializer
             if (is_object($value)) {
                 $new_value = $this->serializeObject($value, $max_depth, $_depth + 1, $hashes);
             } else {
-                $new_value = $this->serialize($value, $max_depth, $_depth + 1);
+                $new_value = $this->serialize($value, ['max_depth' => $max_depth - $_depth - 1]);
             }
             $return[$key] = $new_value;
         }

--- a/lib/Raven/SerializerInterface.php
+++ b/lib/Raven/SerializerInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Raven;
+
+interface SerializerInterface
+{
+    /**
+     * Serialize an object (recursively) into something safe for data
+     * sanitization and encoding.
+     *
+     * @param mixed $value
+     * @param array $context
+     * @return string|bool|double|int|null|object|array
+     */
+    public function serialize($value, array $context = []);
+}

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -29,7 +29,7 @@ class Stacktrace implements \JsonSerializable
     protected $client;
 
     /**
-     * @var Serializer The serializer
+     * @var SerializerInterface The serializer
      */
     protected $serializer;
 

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -186,19 +186,19 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         }
         $input = [];
         $input[] = &$input;
-        $result = $serializer->serialize($input, 3);
+        $result = $serializer->serialize($input, ['max_depth' => 3]);
         $this->assertEquals([[['Array of length 1']]], $result);
 
-        $result = $serializer->serialize([], 3);
+        $result = $serializer->serialize([], ['max_depth' => 3]);
         $this->assertEquals([], $result);
 
-        $result = $serializer->serialize([[]], 3);
+        $result = $serializer->serialize([[]], ['max_depth' => 3]);
         $this->assertEquals([[]], $result);
 
-        $result = $serializer->serialize([[[]]], 3);
+        $result = $serializer->serialize([[[]]], ['max_depth' => 3]);
         $this->assertEquals([[[]]], $result);
 
-        $result = $serializer->serialize([[[[]]]], 3);
+        $result = $serializer->serialize([[[[]]]], ['max_depth' => 3]);
         $this->assertEquals([[['Array of length 0']]], $result);
     }
 
@@ -297,7 +297,7 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $serializer = new $class_name();
         $serializer->setAllObjectSerialize(true);
 
-        $result1 = $serializer->serialize($object, 3);
+        $result1 = $serializer->serialize($object, ['max_depth' => 3]);
         $result2 = $serializer->serializeObject($object, 3);
         $this->assertEquals($result_serialize, $result1);
         $this->assertEquals($result_serialize_object, $result2);
@@ -310,14 +310,17 @@ abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_Tes
         $serializer = new $class_name();
         $serializer->setAllObjectSerialize(true);
 
-        $result = $serializer->serialize((object)['key' => (object)['key' => 12345]], 3);
+        $result = $serializer->serialize((object)['key' => (object)['key' => 12345]], ['max_depth' => 3]);
         $this->assertEquals(['key' => ['key' => 12345]], $result);
 
-        $result = $serializer->serialize((object)['key' => (object)['key' => (object)['key' => 12345]]], 3);
+        $result = $serializer->serialize(
+            (object)['key' => (object)['key' => (object)['key' => 12345]]],
+            ['max_depth' => 3]
+        );
         $this->assertEquals(['key' => ['key' => ['key' => 12345]]], $result);
 
         $result = $serializer->serialize(
-            (object)['key' => (object)['key' => (object)['key' => (object)['key' => 12345]]]], 3
+            (object)['key' => (object)['key' => (object)['key' => (object)['key' => 12345]]]], ['max_depth' => 3]
         );
         $this->assertEquals(['key' => ['key' => ['key' => 'Object stdClass']]], $result);
     }


### PR DESCRIPTION
> I meant that we should provide a sort of `SerializerInterface` interface and a basic implementation (that actually can even check if the object being passed implements some methods like `toDebugContext`, but this is up to us) and if a user wants to send a custom serialization of an object then he can just (yes, using dependency injection) set the serializer to something else and do whatever he wants.