### PR TITLE
Increase minimum PHP version requirement to 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
         "monolog/monolog": "*"
     },
     "require": {
-        "php": ">=5.2.4",
+        "php": "^5.3|^7.0",
         "ext-curl": "*"
     },
     "suggest": {
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "immobiliare/sentry-php": "Fork that fixes support for PHP 5.2",
         "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
     },
     "conflict": {


### PR DESCRIPTION
This fixes #437, and it starts suggesting the fork for users that may need to use this lib with PHP 5.2.