### PR TITLE
Adding X-Authorization and Cookie to sanitized headers

### DIFF
--- a/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
+++ b/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
@@ -67,6 +67,6 @@ final class SanitizeHttpHeadersProcessor extends Processor
      */
     private function getDefaultHeaders()
     {
-        return ['Authorization', 'Proxy-Authorization', 'X-Csrf-Token', 'X-CSRFToken', 'X-XSRF-TOKEN'];
+        return ['Authorization', 'Proxy-Authorization', 'X-Authorization', 'X-Csrf-Token', 'X-CSRFToken', 'X-XSRF-TOKEN'];
     }
 }


### PR DESCRIPTION
Cookie values are sanitized by default at the default `SanitizeDataProcessor`, so it's safe to consider they should also be sanitized in headers. The cookie keys list will be available on the "cookie" data point anyway (unless `RemoveCookiesProcessor` is enabled), thus it makes no sense to sanitize cookies there but not in the header.
X-Authorization is a very common header user to transmit arbitrary Token values on APIs.