### PR TITLE
Fix bug that prevented to filter sensitive data when there is an exception with multiple 'values'

### DIFF
--- a/lib/Raven/Processor/SanitizeDataProcessor.php
+++ b/lib/Raven/Processor/SanitizeDataProcessor.php
@@ -79,7 +79,7 @@ class Raven_Processor_SanitizeDataProcessor extends Raven_Processor
     public function sanitizeException(&$data)
     {
         foreach ($data['exception']['values'] as &$value) {
-            return $this->sanitizeStacktrace($value['stacktrace']);
+            $this->sanitizeStacktrace($value['stacktrace']);
         }
     }
 


### PR DESCRIPTION
While I was reviewing the code to make sure that sensitive data is correctly filtered, I noticed the following bug: if the exception has 2 arrays in `'values'` key, only the 1st one is correctly filtered.

The reason is because there is a not necessary `return` that I removed to fix the bug.
Obviously I also verified that all the callers of this function didn't use its return value. It's likely a bug introduced when porting the implementation from another language where a callback or similar has been used.

Also added test to make sure a regression can not be introduced.