### PR TITLE
Reflection for missing filenames

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -40,16 +40,27 @@ class Raven_Stacktrace
 
             if (!array_key_exists('file', $frame)) {
                 $context = array();
+
                 if (!empty($frame['class'])) {
-                    $context['line'] = sprintf('%s%s%s',
-                        $frame['class'], $frame['type'], $frame['function']);
+                    $context['line'] = sprintf('%s%s%s', $frame['class'], $frame['type'], $frame['function']);
+
+                    try {
+                        $reflect = new ReflectionClass($frame['class']);
+                        $context['filename'] = $filename = $reflect->getFileName();
+                    } catch (ReflectionException $e) {
+                        // Forget it if we run into errors, it's not worth it.
+                    }
                 } else {
                     $context['line'] = sprintf('%s(anonymous)', $frame['function']);
                 }
+
+                if (empty($context['filename'])) {
+                    $context['filename'] = $filename = '[Anonymous function]';
+                }
+
                 $abs_path = '';
                 $context['prefix'] = '';
                 $context['suffix'] = '';
-                $context['filename'] = $filename = '[Anonymous function]';
                 $context['lineno'] = 0;
             } else {
                 $context = self::read_source_file($frame['file'], $frame['line']);


### PR DESCRIPTION
@dcramer @Jean85 how does this look? It changes the stacktrace for Laravel (5.1 tested) from:

![screen shot 2017-08-02 at 16 54 53](https://user-images.githubusercontent.com/1090754/28879795-5c0f0554-77a3-11e7-9552-6f2265aa8034.png)

To:

![screen shot 2017-08-02 at 14 18 48](https://user-images.githubusercontent.com/1090754/28873336-889d4448-778d-11e7-8b36-e543b555fe41.png)

Which is more correct (considering the app path is set on both correctly).

