### PR TITLE
Laravel doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
     <a href="https://sentry.io" target="_blank" align="center">
-        <img src="https://sentry.io/_static/getsentry/images/branding/png/sentry-horizontal-black.png" width="280">
+        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
     </a>
 </p>
 

--- a/docs/integrations/laravel.rst
+++ b/docs/integrations/laravel.rst
@@ -31,12 +31,12 @@ Add Sentry reporting to ``App/Exceptions/Handler.php``:
 
 .. code-block:: php
 
-    public function report(Exception $e)
+    public function report(Exception $exception)
     {
-        if ($this->shouldReport($e)) {
-            app('sentry')->captureException($e);
+        if ($this->shouldReport($exception)) {
+            app('sentry')->captureException($exception);
         }
-        parent::report($e);
+        parent::report($exception);
     }
 
 Create the Sentry configuration file (``config/sentry.php``):
@@ -64,18 +64,22 @@ error response. To do this, open up ``App/Exceptions/Handler.php`` and extend th
     {
         private $sentryID;
 
-        public function report(Exception $e)
+        public function report(Exception $exception)
         {
-            if ($this->shouldReport($e)) {
+            if ($this->shouldReport($exception)) {
                 // bind the event ID for Feedback
-                $this->sentryID = app('sentry')->captureException($e);
+                $this->sentryID = app('sentry')->captureException($exception);
             }
-            parent::report($e);
+            parent::report($exception);
         }
 
         // ...
-        public function render($request, Exception $e)
+        public function render($request, Exception $exception)
         {
+            if ($exception instanceof AuthenticationException) {
+                return parent::render($request, $exception);
+            }
+
             return response()->view('errors.500', [
                 'sentryID' => $this->sentryID,
             ], 500);


### PR DESCRIPTION
Also the Sentry logo update slipped in :)

Laravel 5.5 renders the `500.blade.php` by default and handles login exceptions correctly so no changes needed. For 5.0-5.4 we need to add a bit of code to the render method to make sure the 500 error is rendered for errors that should be reported.