### PR TITLE
[2.0] Upgrade PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "monolog/monolog": "~1.0",
         "php-http/curl-client": "~1.7",
         "php-http/mock-client": "~1.0",
-        "phpunit/phpunit": "^4.8 || ^5.0",
+        "phpunit/phpunit": "^5.7|^6.0",
         "symfony/phpunit-bridge": "~2.7|~3.0",
         "zendframework/zend-diactoros": "~1.4"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupStaticAttributes="false"
+         backupGlobals="true"
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"

--- a/tests/Breadcrumbs/BreadcrumbTest.php
+++ b/tests/Breadcrumbs/BreadcrumbTest.php
@@ -11,13 +11,14 @@
 
 namespace Raven\Tests\Breadcrumbs;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Client;
 
 /**
  * @group time-sensitive
  */
-class BreadcrumbTest extends \PHPUnit_Framework_TestCase
+class BreadcrumbTest extends TestCase
 {
     /**
      * @expectedException \Raven\Exception\InvalidArgumentException

--- a/tests/Breadcrumbs/ErrorHandlerTest.php
+++ b/tests/Breadcrumbs/ErrorHandlerTest.php
@@ -11,11 +11,12 @@
 
 namespace Raven\Tests\Breadcrumbs;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Breadcrumbs\ErrorHandler;
 use Raven\Client;
 use Raven\ClientBuilder;
 
-class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
+class ErrorHandlerTest extends TestCase
 {
     public function testSimple()
     {

--- a/tests/Breadcrumbs/MonologHandlerTest.php
+++ b/tests/Breadcrumbs/MonologHandlerTest.php
@@ -12,12 +12,13 @@
 namespace Raven\Tests\Breadcrumbs;
 
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Raven\Breadcrumbs\MonologHandler;
 use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Client;
 use Raven\ClientBuilder;
 
-class MonologHandlerTest extends \PHPUnit_Framework_TestCase
+class MonologHandlerTest extends TestCase
 {
     protected function getSampleErrorMessage()
     {

--- a/tests/Breadcrumbs/RecorderTest.php
+++ b/tests/Breadcrumbs/RecorderTest.php
@@ -11,6 +11,7 @@
 
 namespace Raven\Tests\Breadcrumbs;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Breadcrumbs\Recorder;
@@ -18,7 +19,7 @@ use Raven\Breadcrumbs\Recorder;
 /**
  * @group time-sensitive
  */
-class RecorderTest extends \PHPUnit_Framework_TestCase
+class RecorderTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -15,12 +15,13 @@ use Http\Client\Common\Plugin;
 use Http\Client\HttpAsyncClient;
 use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Raven\Client;
 use Raven\ClientBuilder;
 use Raven\Configuration;
 
-class ClientBuilderTest extends \PHPUnit_Framework_TestCase
+class ClientBuilderTest extends TestCase
 {
     public function testCreate()
     {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -14,6 +14,7 @@ use Http\Client\HttpAsyncClient;
 use Http\Message\RequestFactory;
 use Http\Mock\Client as MockClient;
 use Http\Promise\Promise;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Raven\Breadcrumbs\ErrorHandler;
 use Raven\Client;
@@ -125,7 +126,7 @@ class Dummy_Raven_Client_With_Sync_Override extends \Raven\Client
     }
 }
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     protected static $_folder = null;
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -11,13 +11,14 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Configuration;
 use Raven\Processor\RemoveCookiesProcessor;
 use Raven\Processor\RemoveHttpBodyProcessor;
 use Raven\Processor\SanitizeDataProcessor;
 use Raven\Processor\SanitizeHttpHeadersProcessor;
 
-class ConfigurationTest extends \PHPUnit_Framework_TestCase
+class ConfigurationTest extends TestCase
 {
     /**
      * @dataProvider optionsDataProvider

--- a/tests/ErrorHandlerTest.php
+++ b/tests/ErrorHandlerTest.php
@@ -11,7 +11,9 @@
 
 namespace Raven\Tests;
 
-class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ErrorHandlerTest extends TestCase
 {
     private $errorLevel;
     private $errorHandlerCalled;

--- a/tests/HttpClient/Authentication/SentryAuthTest.php
+++ b/tests/HttpClient/Authentication/SentryAuthTest.php
@@ -11,6 +11,7 @@
 
 namespace Raven\Tests\HttpClient\Authentication;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Raven\Client;
 use Raven\Configuration;
@@ -19,7 +20,7 @@ use Raven\HttpClient\Authentication\SentryAuth;
 /**
  * @group time-sensitive
  */
-class SentryAuthTest extends \PHPUnit_Framework_TestCase
+class SentryAuthTest extends TestCase
 {
     public function testAuthenticate()
     {

--- a/tests/HttpClient/Encoding/Base64EncodingStreamTest.php
+++ b/tests/HttpClient/Encoding/Base64EncodingStreamTest.php
@@ -11,11 +11,12 @@
 
 namespace Raven\Tests\HttpClient\Encoding;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use Raven\HttpClient\Encoding\Base64EncodingStream;
 use Zend\Diactoros\Stream;
 
-class Base64EncodingStreamTest extends \PHPUnit_Framework_TestCase
+class Base64EncodingStreamTest extends TestCase
 {
     /**
      * @dataProvider getSizeDataProvider

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -10,6 +10,7 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\ClientBuilder;
 use Raven\Configuration;
 
@@ -39,7 +40,7 @@ class DummyIntegration_Raven_Client extends \Raven\Client
     }
 }
 
-class IntegrationTest extends \PHPUnit_Framework_TestCase
+class IntegrationTest extends TestCase
 {
     private function create_chained_exception()
     {

--- a/tests/Processor/RemoveCookiesProcessorTest.php
+++ b/tests/Processor/RemoveCookiesProcessorTest.php
@@ -11,10 +11,11 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Client;
 use Raven\Processor\RemoveCookiesProcessor;
 
-class RemoveCookiesProcessorTest extends \PHPUnit_Framework_TestCase
+class RemoveCookiesProcessorTest extends TestCase
 {
     /**
      * @var RemoveCookiesProcessor|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Processor/RemoveCookiesProcessorTest.php
+++ b/tests/Processor/RemoveCookiesProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests;
+namespace Raven\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Client;

--- a/tests/Processor/RemoveHttpBodyProcessorTest.php
+++ b/tests/Processor/RemoveHttpBodyProcessorTest.php
@@ -11,10 +11,11 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Client;
 use Raven\Processor\RemoveHttpBodyProcessor;
 
-class RemoveHttpBodyProcessorTest extends \PHPUnit_Framework_TestCase
+class RemoveHttpBodyProcessorTest extends TestCase
 {
     /**
      * @var RemoveHttpBodyProcessor|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Processor/RemoveHttpBodyProcessorTest.php
+++ b/tests/Processor/RemoveHttpBodyProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests;
+namespace Raven\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Client;

--- a/tests/Processor/SanitizeDataProcessorTest.php
+++ b/tests/Processor/SanitizeDataProcessorTest.php
@@ -11,10 +11,11 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\ClientBuilder;
 use Raven\Processor\SanitizeDataProcessor;
 
-class SanitizeDataProcessorTest extends \PHPUnit_Framework_TestCase
+class SanitizeDataProcessorTest extends TestCase
 {
     public function testDoesFilterHttpData()
     {

--- a/tests/Processor/SanitizeDataProcessorTest.php
+++ b/tests/Processor/SanitizeDataProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests;
+namespace Raven\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Raven\ClientBuilder;

--- a/tests/Processor/SanitizeHttpHeadersProcessorTest.php
+++ b/tests/Processor/SanitizeHttpHeadersProcessorTest.php
@@ -11,10 +11,11 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Client;
 use Raven\Processor\SanitizeHttpHeadersProcessor;
 
-class SanitizeHttpHeadersProcessorTest extends \PHPUnit_Framework_TestCase
+class SanitizeHttpHeadersProcessorTest extends TestCase
 {
     /**
      * @var SanitizeHttpHeadersProcessor|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Processor/SanitizeHttpHeadersProcessorTest.php
+++ b/tests/Processor/SanitizeHttpHeadersProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests;
+namespace Raven\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Client;

--- a/tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -11,11 +11,12 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Client;
 use Raven\ClientBuilder;
 use Raven\Processor\SanitizeStacktraceProcessor;
 
-class SanitizeStacktraceProcessorTest extends \PHPUnit_Framework_TestCase
+class SanitizeStacktraceProcessorTest extends TestCase
 {
     /**
      * @var Client

--- a/tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests;
+namespace Raven\Tests\Processor;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Client;

--- a/tests/ReprSerializerTest.php
+++ b/tests/ReprSerializerTest.php
@@ -13,7 +13,7 @@ namespace Raven\Tests;
 
 require_once 'SerializerAbstractTest.php';
 
-class ReprSerializerTest extends \Raven\Tests\Raven_Tests_SerializerAbstractTest
+class ReprSerializerTest extends \Raven\Tests\SerializerAbstractTest
 {
     /**
      * @return string

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -13,20 +13,7 @@ namespace Raven\Tests;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class SerializerTestObject
- *
- * @package Raven\Tests
- * @property mixed $keys
- */
-class SerializerTestObject
-{
-    private $foo = 'bar';
-
-    public $key = 'value';
-}
-
-abstract class Raven_Tests_SerializerAbstractTest extends TestCase
+abstract class SerializerAbstractTest extends TestCase
 {
     /**
      * @return string|\Raven\Serializer
@@ -423,4 +410,17 @@ abstract class Raven_Tests_SerializerAbstractTest extends TestCase
         $serializer->setAllObjectSerialize(false);
         $this->assertFalse($serializer->getAllObjectSerialize());
     }
+}
+
+/**
+ * Class SerializerTestObject
+ *
+ * @package Raven\Tests
+ * @property mixed $keys
+ */
+class SerializerTestObject
+{
+    private $foo = 'bar';
+
+    public $key = 'value';
 }

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -11,6 +11,8 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * Class SerializerTestObject
  *
@@ -24,7 +26,7 @@ class SerializerTestObject
     public $key = 'value';
 }
 
-abstract class Raven_Tests_SerializerAbstractTest extends \PHPUnit_Framework_TestCase
+abstract class Raven_Tests_SerializerAbstractTest extends TestCase
 {
     /**
      * @return string|\Raven\Serializer

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -4,7 +4,7 @@ namespace Raven\Tests;
 
 require_once 'SerializerAbstractTest.php';
 
-class SerializerTest extends \Raven\Tests\Raven_Tests_SerializerAbstractTest
+class SerializerTest extends \Raven\Tests\SerializerAbstractTest
 {
     /**
      * @return string

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -185,7 +185,8 @@ class StacktraceTest extends TestCase
     public function testRemoveFrame($index, $throwException)
     {
         if ($throwException) {
-            $this->setExpectedException(\OutOfBoundsException::class, 'Invalid frame index to remove.');
+            $this->expectException(\OutOfBoundsException::class);
+            $this->expectExceptionMessage('Invalid frame index to remove.');
         }
 
         $stacktrace = new Stacktrace($this->client);

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -11,11 +11,12 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Client;
 use Raven\ClientBuilder;
 use Raven\Stacktrace;
 
-class StacktraceTest extends \PHPUnit_Framework_TestCase
+class StacktraceTest extends TestCase
 {
     /**
      * @var Client

--- a/tests/TransactionStackTest.php
+++ b/tests/TransactionStackTest.php
@@ -11,7 +11,9 @@
 
 namespace Raven\Tests;
 
-class Raven_Tests_TransactionStackTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class Raven_Tests_TransactionStackTest extends TestCase
 {
     public function testSimple()
     {

--- a/tests/TransactionStackTest.php
+++ b/tests/TransactionStackTest.php
@@ -13,7 +13,7 @@ namespace Raven\Tests;
 
 use PHPUnit\Framework\TestCase;
 
-class Raven_Tests_TransactionStackTest extends TestCase
+class TransactionStackTest extends TestCase
 {
     public function testSimple()
     {

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -11,11 +11,12 @@
 
 namespace Raven\Tests\Util;
 
+use PHPUnit\Framework\TestCase;
 use Raven\Tests\Util\Fixtures\JsonSerializableClass;
 use Raven\Tests\Util\Fixtures\SimpleClass;
 use Raven\Util\JSON;
 
-class JSONTest extends \PHPUnit_Framework_TestCase
+class JSONTest extends TestCase
 {
     /**
      * @dataProvider encodeDataProvider

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -11,12 +11,14 @@
 
 namespace Raven\Tests;
 
+use PHPUnit\Framework\TestCase;
+
 class StacktraceTestObject
 {
     private $foo = 'bar';
 }
 
-class Raven_Tests_UtilTest extends \PHPUnit_Framework_TestCase
+class Raven_Tests_UtilTest extends TestCase
 {
     public function testGetReturnsDefaultOnMissing()
     {

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -13,12 +13,7 @@ namespace Raven\Tests;
 
 use PHPUnit\Framework\TestCase;
 
-class StacktraceTestObject
-{
-    private $foo = 'bar';
-}
-
-class Raven_Tests_UtilTest extends TestCase
+class UtilTest extends TestCase
 {
     public function testGetReturnsDefaultOnMissing()
     {


### PR DESCRIPTION
This PR moves the 2.0 codebase onto PHPUnit 5.7/6, using the new namespaced classes, so we will be more future-proof.