### PR TITLE
Prevent fatal error in Raven_Stacktrace

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -257,6 +257,10 @@ class Raven_Stacktrace
             $frame['filename'] = $filename = $matches[1];
             $frame['lineno'] = $lineno = $matches[2];
         }
+        
+        if (!file_exists($filename)) {
+            return $frame;
+        }
 
         try {
             $file = new SplFileObject($filename);

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -264,4 +264,23 @@ class Raven_Tests_StacktraceTest extends \PHPUnit\Framework\TestCase
          */
         $this->assertEquals($frames[count($frames) -1]['filename'], __FILE__);
     }
+
+    public function testWarningOnMissingFile()
+    {
+        $old_error_reporting = error_reporting();
+
+        error_reporting(E_ALL);
+
+        $trace = raven_test_create_stacktrace();
+
+        $trace[0]['file'] = 'filedoesnotexists404.php';
+
+        Raven_Stacktrace::get_stack_info($trace);
+
+        $last_error = error_get_last();
+
+        $this->assertNotEquals('SplFileObject::__construct(filedoesnotexists404.php): failed to open stream: No such file or directory', $last_error['message']);
+
+        error_reporting($old_error_reporting);
+    }
 }


### PR DESCRIPTION
When a PHP extension has an error, raven tries to load a non-existent file (in our case newrelic/guzzle6), causing SplFileObject to throw a fatal error.
Do not attempt to load the file if it does not exist.