### PR TITLE
[2.0] Improve Client and refactor Context

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -259,7 +259,7 @@ There are three primary methods for providing request context:
 .. code-block:: php
 
     // bind the logged in user
-    $client->user_context(array('email' => 'foo@example.com'));
+    $client->setUserContext(array('email' => 'foo@example.com'));
 
     // tag the request with something interesting
     $client->tags_context(array('interesting' => 'yes'));

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,11 +48,11 @@ Much of the usefulness of Sentry comes from additional context data with
 the events.  The PHP client makes this very convenient by providing
 methods to set thread local context data that is then submitted
 automatically with all events.  For instance you can use the
-``user_context`` method to add information about the current user:
+``setUserContext`` method to add information about the current user:
 
 .. sourcecode:: php
 
-    $client->user_context(array(
+    $client->setUserContext(array(
         'email' => $USER->getEmail()
     ));
 

--- a/docs/integrations/laravel.rst
+++ b/docs/integrations/laravel.rst
@@ -244,9 +244,9 @@ In the following example, we'll use a middleware:
 
                 // Add user context
                 if (auth()->check()) {
-                    $sentry->user_context([...]);
+                    $sentry->setUserContext([...]);
                 } else {
-                    $sentry->user_context(['id' => null]);
+                    $sentry->setUserContext(['id' => null]);
                 }
 
                 // Add tags context
@@ -290,13 +290,13 @@ The following settings are available for the client:
         'breadcrumbs.sql_bindings' => false,
 
 
-.. describe:: user_context
+.. describe:: setUserContext
 
-    Capture user_context automatically.
+    Capture setUserContext automatically.
 
     Defaults to ``true``.
 
     .. code-block:: php
 
-        'user_context' => false,
+        'setUserContext' => false,
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -32,7 +32,7 @@ class Client
     const PROTOCOL = '6';
 
     /**
-     * Debug log levels
+     * Debug log levels.
      */
     const LEVEL_DEBUG = 'debug';
     const LEVEL_INFO = 'info';
@@ -218,6 +218,7 @@ class Client
 
     /**
      * Installs any available automated hooks (such as error_reporting).
+     *
      * @throws \Raven\Exception
      */
     public function install()
@@ -230,6 +231,7 @@ class Client
         $this->errorHandler->registerExceptionHandler();
         $this->errorHandler->registerErrorHandler();
         $this->errorHandler->registerShutdownFunction();
+
         return $this;
     }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -913,7 +913,7 @@ class Client
             case E_USER_NOTICE:
             case E_STRICT:
                 return self::LEVEL_INFO;
-            default:                   
+            default:
                 return self::LEVEL_ERROR;
         }
     }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -536,8 +536,8 @@ class Client
 
     protected function getUserData()
     {
-        $user = $this->context->user;
-        if ($user === null) {
+        $user = $this->context->getUserData();
+        if (empty($user)) {
             if (!function_exists('session_id') || !session_id()) {
                 return [];
             }
@@ -613,12 +613,12 @@ class Client
 
         $data['tags'] = array_merge(
             $this->config->getTags(),
-            $this->context->tags,
+            $this->context->getTags(),
             $data['tags']
         );
 
         $data['extra'] = array_merge(
-            $this->context->extra,
+            $this->context->getExtraData(),
             $data['extra']
         );
 
@@ -929,25 +929,6 @@ class Client
         $this->severityMap = $map;
     }
 
-    /**
-     * Convenience function for setting a user's ID and Email.
-     *
-     * @deprecated
-     *
-     * @param string      $id    User's ID
-     * @param string|null $email User's email
-     * @param array       $data  Additional user data
-     * @codeCoverageIgnore
-     */
-    public function setUserData($id, $email = null, $data = [])
-    {
-        $user = ['id' => $id];
-        if (isset($email)) {
-            $user['email'] = $email;
-        }
-        $this->setUserContext(array_merge($user, $data));
-    }
-
     public function onShutdown()
     {
         if (!defined('RAVEN_CLIENT_END_REACHED')) {
@@ -957,42 +938,11 @@ class Client
     }
 
     /**
-     * Sets user context.
-     *
-     * @param array $data  Associative array of user data
-     * @param bool  $merge Merge existing context with new context
+     * @return Context
      */
-    public function setUserContext($data, $merge = true)
+    public function getContext()
     {
-        if ($merge && $this->context->user !== null) {
-            // bail if data is null
-            if (!$data) {
-                return;
-            }
-            $this->context->user = array_merge($this->context->user, $data);
-        } else {
-            $this->context->user = $data;
-        }
-    }
-
-    /**
-     * Appends tags context.
-     *
-     * @param array $data Associative array of tags
-     */
-    public function tags_context($data)
-    {
-        $this->context->tags = array_merge($this->context->tags, $data);
-    }
-
-    /**
-     * Appends additional context.
-     *
-     * @param array $data Associative array of extra data
-     */
-    public function extra_context($data)
-    {
-        $this->context->extra = array_merge($this->context->extra, $data);
+        return $this->context;
     }
 
     /**

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -32,28 +32,12 @@ class Client
     const PROTOCOL = '6';
 
     /**
-     * This constant defines the debug log level.
+     * Debug log levels
      */
     const LEVEL_DEBUG = 'debug';
-
-    /**
-     * This constant defines the info log level.
-     */
     const LEVEL_INFO = 'info';
-
-    /**
-     * This constant defines the warning log level.
-     */
     const LEVEL_WARNING = 'warning';
-
-    /**
-     * This constant defines the error log level.
-     */
     const LEVEL_ERROR = 'error';
-
-    /**
-     * This constant defines the fatal log level.
-     */
     const LEVEL_FATAL = 'fatal';
 
     /**
@@ -84,13 +68,13 @@ class Client
     /**
      * @var string[]|null
      */
-    public $severity_map;
-    public $store_errors_for_bulk_send = false;
+    public $severityMap;
+    public $storeErrorsForBulkSend = false;
 
     /**
-     * @var \Raven\ErrorHandler
+     * @var ErrorHandler
      */
-    protected $error_handler;
+    protected $errorHandler;
 
     /**
      * @var \Raven\Serializer
@@ -109,23 +93,19 @@ class Client
     /**
      * @var string|int|null
      */
-    public $_lasterror;
-    /**
-     * @var object|null
-     */
-    protected $_last_sentry_error;
-    public $_last_event_id;
-    public $_user;
+    private $lastError;
+
+    private $lastEventId;
 
     /**
      * @var array[]
      */
-    public $_pending_events = [];
+    public $pendingEvents = [];
 
     /**
      * @var bool
      */
-    protected $_shutdown_function_has_been_set = false;
+    protected $shutdownFunctionHasBeenSet = false;
 
     /**
      * @var Configuration The client configuration
@@ -166,7 +146,7 @@ class Client
         $this->reprSerializer = new ReprSerializer($this->config->getMbDetectOrder());
         $this->processors = $this->createProcessors();
 
-        if (static::is_http_request() && isset($_SERVER['PATH_INFO'])) {
+        if (static::isHttpRequest() && isset($_SERVER['PATH_INFO'])) {
             $this->transaction->push($_SERVER['PATH_INFO']);
         }
 
@@ -238,17 +218,18 @@ class Client
 
     /**
      * Installs any available automated hooks (such as error_reporting).
+     * @throws \Raven\Exception
      */
     public function install()
     {
-        if ($this->error_handler) {
-            throw new \Raven\Exception(sprintf('%s->install() must only be called once', get_class($this)));
+        if ($this->errorHandler) {
+            throw new \Raven\Exception(__CLASS__ . '->install() must only be called once');
         }
-        $this->error_handler = new \Raven\ErrorHandler($this, false, $this->getConfig()->getErrorTypes());
-        $this->error_handler->registerExceptionHandler();
-        $this->error_handler->registerErrorHandler();
-        $this->error_handler->registerShutdownFunction();
 
+        $this->errorHandler = new ErrorHandler($this, false, $this->getConfig()->getErrorTypes());
+        $this->errorHandler->registerExceptionHandler();
+        $this->errorHandler->registerErrorHandler();
+        $this->errorHandler->registerShutdownFunction();
         return $this;
     }
 
@@ -281,7 +262,7 @@ class Client
 
     public function getLastError()
     {
-        return $this->_lasterror;
+        return $this->lastError;
     }
 
     /**
@@ -314,23 +295,10 @@ class Client
         $message,
         $params = [],
         $level = self::LEVEL_INFO,
-                            $stack = false,
+        $stack = false,
         $vars = null
     ) {
         return $this->captureMessage($message, $params, $level, $stack, $vars);
-    }
-
-    /**
-     * @param Exception $exception
-     *
-     * @return string|null
-     *
-     * @deprecated
-     * @codeCoverageIgnore
-     */
-    public function exception($exception)
-    {
-        return $this->captureException($exception);
     }
 
     /**
@@ -348,7 +316,7 @@ class Client
         $message,
         $params = [],
         $data = [],
-                            $stack = false,
+        $stack = false,
         $vars = null
     ) {
         // Gracefully handle messages which contain formatting characters, but were not
@@ -398,33 +366,28 @@ class Client
             $data = [];
         }
 
-        $exc = $exception;
+        $currentException = $exception;
         do {
-            $exc_data = [
-                'value' => $this->serializer->serialize($exc->getMessage()),
-                'type' => get_class($exc),
+            $exceptionData = [
+                'value' => $this->serializer->serialize($currentException->getMessage()),
+                'type' => get_class($currentException),
             ];
 
-            /**'exception'
+            /**
              * Exception::getTrace doesn't store the point at where the exception
              * was thrown, so we have to stuff it in ourselves. Ugh.
              */
-            $trace = $exc->getTrace();
-            $frame_where_exception_thrown = [
-                'file' => $exc->getFile(),
-                'line' => $exc->getLine(),
+            $trace = $currentException->getTrace();
+            $frameWhereExceptionWasThrown = [
+                'file' => $currentException->getFile(),
+                'line' => $currentException->getLine(),
             ];
 
-            array_unshift($trace, $frame_where_exception_thrown);
+            array_unshift($trace, $frameWhereExceptionWasThrown);
 
-            // manually trigger autoloading, as it's not done in some edge cases due to PHP bugs (see #60149)
-            if (!class_exists('\\Raven\\Stacktrace')) {
-                // @codeCoverageIgnoreStart
-                spl_autoload_call('\\Raven\\Stacktrace');
-                // @codeCoverageIgnoreEnd
-            }
+            $this->autoloadRavenStacktrace();
 
-            $exc_data['stacktrace'] = [
+            $exceptionData['stacktrace'] = [
                 'frames' => Stacktrace::fromBacktrace(
                     $this,
                     $exception->getTrace(),
@@ -433,8 +396,8 @@ class Client
                 )->getFrames(),
             ];
 
-            $exceptions[] = $exc_data;
-        } while ($exc = $exc->getPrevious());
+            $exceptions[] = $exceptionData;
+        } while ($currentException = $currentException->getPrevious());
 
         $data['exception'] = [
             'values' => array_reverse($exceptions),
@@ -505,21 +468,21 @@ class Client
     /**
      * Return the last captured event's ID or null if none available.
      */
-    public function getLastEventID()
+    public function getLastEventId()
     {
-        return $this->_last_event_id;
+        return $this->lastEventId;
     }
 
     protected function registerDefaultBreadcrumbHandlers()
     {
-        $handler = new \Raven\Breadcrumbs\ErrorHandler($this);
+        $handler = new Breadcrumbs\ErrorHandler($this);
         $handler->install();
     }
 
     protected function registerShutdownFunction()
     {
-        if (!$this->_shutdown_function_has_been_set) {
-            $this->_shutdown_function_has_been_set = true;
+        if (!$this->shutdownFunctionHasBeenSet) {
+            $this->shutdownFunctionHasBeenSet = true;
             register_shutdown_function([$this, 'onShutdown']);
         }
     }
@@ -528,12 +491,12 @@ class Client
      * @return bool
      * @codeCoverageIgnore
      */
-    protected static function is_http_request()
+    protected static function isHttpRequest()
     {
         return isset($_SERVER['REQUEST_METHOD']) && PHP_SAPI !== 'cli';
     }
 
-    protected function get_http_data()
+    protected function getHttpData()
     {
         $headers = [];
 
@@ -550,7 +513,7 @@ class Client
 
         $result = [
             'method' => self::_server_variable('REQUEST_METHOD'),
-            'url' => $this->get_current_url(),
+            'url' => $this->getCurrentUrl(),
             'query_string' => self::_server_variable('QUERY_STRING'),
         ];
 
@@ -571,7 +534,7 @@ class Client
         ];
     }
 
-    protected function get_user_data()
+    protected function getUserData()
     {
         $user = $this->context->user;
         if ($user === null) {
@@ -594,7 +557,7 @@ class Client
         ];
     }
 
-    public function get_default_data()
+    public function getDefaultData()
     {
         return [
             'server_name' => $this->config->getServerName(),
@@ -632,13 +595,13 @@ class Client
             $data['message'] = substr($data['message'], 0, self::MESSAGE_LIMIT);
         }
 
-        $data = array_merge($this->get_default_data(), $data);
+        $data = array_merge($this->getDefaultData(), $data);
 
-        if (static::is_http_request()) {
-            $data = array_merge($this->get_http_data(), $data);
+        if (static::isHttpRequest()) {
+            $data = array_merge($this->getHttpData(), $data);
         }
 
-        $data = array_merge($this->get_user_data(), $data);
+        $data = array_merge($this->getUserData(), $data);
 
         if (!empty($this->config->getRelease())) {
             $data['release'] = $this->config->getRelease();
@@ -672,7 +635,7 @@ class Client
             unset($data['request']);
         }
 
-        if (!empty($this->recorder)) {
+        if (null !== $this->recorder) {
             $data['breadcrumbs'] = iterator_to_array($this->recorder);
         }
 
@@ -684,12 +647,7 @@ class Client
         }
 
         if (!empty($stack)) {
-            // manually trigger autoloading, as it's not done in some edge cases due to PHP bugs (see #60149)
-            if (!class_exists('\\Raven\\Stacktrace')) {
-                // @codeCoverageIgnoreStart
-                spl_autoload_call('\\Raven\\Stacktrace');
-                // @codeCoverageIgnoreEnd
-            }
+            $this->autoloadRavenStacktrace();
 
             if (!isset($data['stacktrace']) && !isset($data['exception'])) {
                 $data['stacktrace'] = [
@@ -706,13 +664,13 @@ class Client
         $this->sanitize($data);
         $this->process($data);
 
-        if (!$this->store_errors_for_bulk_send) {
+        if (!$this->storeErrorsForBulkSend) {
             $this->send($data);
         } else {
-            $this->_pending_events[] = $data;
+            $this->pendingEvents[] = $data;
         }
 
-        $this->_last_event_id = $data['event_id'];
+        $this->lastEventId = $data['event_id'];
 
         return $data['event_id'];
     }
@@ -753,15 +711,15 @@ class Client
 
     public function sendUnsentErrors()
     {
-        foreach ($this->_pending_events as $data) {
+        foreach ($this->pendingEvents as $data) {
             $this->send($data);
         }
 
-        $this->_pending_events = [];
+        $this->pendingEvents = [];
 
-        if ($this->store_errors_for_bulk_send) {
+        if ($this->storeErrorsForBulkSend) {
             //in case an error occurs after this is called, on shutdown, send any new errors.
-            $this->store_errors_for_bulk_send = !defined('RAVEN_CLIENT_END_REACHED');
+            $this->storeErrorsForBulkSend = !defined('RAVEN_CLIENT_END_REACHED');
         }
 
         foreach ($this->pendingRequests as $pendingRequest) {
@@ -866,7 +824,7 @@ class Client
      *
      * @return string|null
      */
-    protected function get_current_url()
+    protected function getCurrentUrl()
     {
         // When running from commandline the REQUEST_URI is missing.
         if (!isset($_SERVER['REQUEST_URI'])) {
@@ -932,28 +890,32 @@ class Client
      */
     public function translateSeverity($severity)
     {
-        if (is_array($this->severity_map) && isset($this->severity_map[$severity])) {
-            return $this->severity_map[$severity];
-        }
-        switch ($severity) {
-            case E_DEPRECATED:         return \Raven\Client::LEVEL_WARNING;
-            case E_USER_DEPRECATED:    return \Raven\Client::LEVEL_WARNING;
-            case E_ERROR:              return \Raven\Client::LEVEL_ERROR;
-            case E_WARNING:            return \Raven\Client::LEVEL_WARNING;
-            case E_PARSE:              return \Raven\Client::LEVEL_ERROR;
-            case E_NOTICE:             return \Raven\Client::LEVEL_INFO;
-            case E_CORE_ERROR:         return \Raven\Client::LEVEL_ERROR;
-            case E_CORE_WARNING:       return \Raven\Client::LEVEL_WARNING;
-            case E_COMPILE_ERROR:      return \Raven\Client::LEVEL_ERROR;
-            case E_COMPILE_WARNING:    return \Raven\Client::LEVEL_WARNING;
-            case E_USER_ERROR:         return \Raven\Client::LEVEL_ERROR;
-            case E_USER_WARNING:       return \Raven\Client::LEVEL_WARNING;
-            case E_USER_NOTICE:        return \Raven\Client::LEVEL_INFO;
-            case E_STRICT:             return \Raven\Client::LEVEL_INFO;
-            case E_RECOVERABLE_ERROR:  return \Raven\Client::LEVEL_ERROR;
+        if (is_array($this->severityMap) && isset($this->severityMap[$severity])) {
+            return $this->severityMap[$severity];
         }
 
-        return \Raven\Client::LEVEL_ERROR;
+        switch ($severity) {
+            case E_DEPRECATED:
+            case E_USER_DEPRECATED:
+            case E_WARNING:
+            case E_CORE_WARNING:
+            case E_COMPILE_WARNING:
+            case E_USER_WARNING:
+            case E_RECOVERABLE_ERROR:
+                return self::LEVEL_WARNING;
+            case E_ERROR:
+            case E_PARSE:
+            case E_CORE_ERROR:
+            case E_COMPILE_ERROR:
+            case E_USER_ERROR:
+                return self::LEVEL_ERROR;
+            case E_NOTICE:
+            case E_USER_NOTICE:
+            case E_STRICT:
+                return self::LEVEL_INFO;
+            default:                   
+                return self::LEVEL_ERROR;
+        }
     }
 
     /**
@@ -964,7 +926,7 @@ class Client
      */
     public function registerSeverityMap($map)
     {
-        $this->severity_map = $map;
+        $this->severityMap = $map;
     }
 
     /**
@@ -977,13 +939,13 @@ class Client
      * @param array       $data  Additional user data
      * @codeCoverageIgnore
      */
-    public function set_user_data($id, $email = null, $data = [])
+    public function setUserData($id, $email = null, $data = [])
     {
         $user = ['id' => $id];
         if (isset($email)) {
             $user['email'] = $email;
         }
-        $this->user_context(array_merge($user, $data));
+        $this->setUserContext(array_merge($user, $data));
     }
 
     public function onShutdown()
@@ -1000,7 +962,7 @@ class Client
      * @param array $data  Associative array of user data
      * @param bool  $merge Merge existing context with new context
      */
-    public function user_context($data, $merge = true)
+    public function setUserContext($data, $merge = true)
     {
         if ($merge && $this->context->user !== null) {
             // bail if data is null
@@ -1042,19 +1004,11 @@ class Client
     }
 
     /**
-     * @return object|null
-     */
-    public function getLastSentryError()
-    {
-        return $this->_last_sentry_error;
-    }
-
-    /**
      * @return bool
      */
     public function getShutdownFunctionHasBeenSet()
     {
-        return $this->_shutdown_function_has_been_set;
+        return $this->shutdownFunctionHasBeenSet;
     }
 
     public function setAllObjectSerialize($value)
@@ -1071,5 +1025,15 @@ class Client
     private function isEncodingCompressed()
     {
         return 'gzip' === $this->config->getEncoding();
+    }
+
+    private function autoloadRavenStacktrace()
+    {
+        // manually trigger autoloading, as it's not done in some edge cases due to PHP bugs (see #60149)
+        if (!class_exists('\\Raven\\Stacktrace')) {
+            // @codeCoverageIgnoreStart
+            spl_autoload_call('\\Raven\\Stacktrace');
+            // @codeCoverageIgnoreEnd
+        }
     }
 }

--- a/lib/Raven/Context.php
+++ b/lib/Raven/Context.php
@@ -40,7 +40,7 @@ class Context
     public function setTag($name, $value)
     {
         if (
-            ! is_string($name)
+            !is_string($name)
             || '' === $name
         ) {
             throw new \InvalidArgumentException('Invalid tag name');

--- a/lib/Raven/Context.php
+++ b/lib/Raven/Context.php
@@ -10,15 +10,17 @@ class Context
     /**
      * @var array
      */
-    public $tags;
+    private $tags;
+
     /**
      * @var array
      */
-    public $extra;
+    private $userData;
+
     /**
-     * @var array|null
+     * @var array
      */
-    public $user;
+    private $extraData;
 
     public function __construct()
     {
@@ -31,7 +33,71 @@ class Context
     public function clear()
     {
         $this->tags = [];
-        $this->extra = [];
-        $this->user = null;
+        $this->extraData = [];
+        $this->userData = [];
+    }
+
+    public function setTag($name, $value)
+    {
+        if (
+            ! is_string($name)
+            || '' === $name
+        ) {
+            throw new \InvalidArgumentException('Invalid tag name');
+        }
+
+        $this->tags[$name] = $value;
+    }
+
+    public function setUserId($userId)
+    {
+        $this->userData['id'] = $userId;
+    }
+
+    public function setUserEmail($userEmail)
+    {
+        $this->userData['email'] = $userEmail;
+    }
+
+    /**
+     * @param array $data
+     */
+    public function setUserData(array $data)
+    {
+        $this->userData = $data;
+    }
+
+    public function mergeUserData(array $data = [])
+    {
+        $this->userData = array_merge($this->userData, $data);
+    }
+
+    public function mergeExtraData(array $data = [])
+    {
+        $this->extraData = array_merge($this->extraData, $data);
+    }
+
+    /**
+     * @return array
+     */
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @return array
+     */
+    public function getUserData()
+    {
+        return $this->userData;
+    }
+
+    /**
+     * @return array
+     */
+    public function getExtraData()
+    {
+        return $this->extraData;
     }
 }

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -67,7 +67,7 @@ class ErrorHandler
         $this->fatal_error_types = array_reduce($this->fatal_error_types, [$this, 'bitwiseOr']);
         if ($send_errors_last) {
             $this->send_errors_last = true;
-            $this->client->store_errors_for_bulk_send = true;
+            $this->client->storeErrorsForBulkSend = true;
         }
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -221,7 +221,7 @@ class ClientTest extends TestCase
         $client = ClientBuilder::create()->getClient();
         $client->storeErrorsForBulkSend = true;
 
-        $client->extra_context(['foo' => 'bar']);
+        $client->getContext()->mergeExtraData(['foo' => 'bar']);
         $client->captureMessage('Test Message %s', ['foo']);
 
         $this->assertCount(1, $client->pendingEvents);
@@ -233,7 +233,7 @@ class ClientTest extends TestCase
         $client = ClientBuilder::create()->getClient();
         $client->storeErrorsForBulkSend = true;
 
-        $client->extra_context(['foo' => 'bar']);
+        $client->getContext()->mergeExtraData(['foo' => 'bar']);
         $client->captureMessage('Test Message %s', ['foo'], null);
 
         $this->assertCount(1, $client->pendingEvents);
@@ -555,9 +555,10 @@ class ClientTest extends TestCase
         $client = ClientBuilder::create()->getClient();
         $client->storeErrorsForBulkSend = true;
 
-        $client->setUserContext([
-            'id' => 'unique_id',
-            'email' => 'foo@example.com',
+        $context = $client->getContext();
+        $context->setUserId('unique_id');
+        $context->setUserEmail('foo@example.com');
+        $context->mergeUserData([
             'username' => 'my_user',
         ]);
 
@@ -585,11 +586,10 @@ class ClientTest extends TestCase
         $client = ClientBuilder::create()->getClient();
         $client->storeErrorsForBulkSend = true;
 
-        $client->setUserContext([
-            'email' => 'foo@example.com',
-            'data' => [
-                'error' => new \Exception('test'),
-            ],
+        $context = $client->getContext();
+        $context->setUserEmail('foo@example.com');
+        $context->mergeUserData([
+            'error' => new \Exception('test'),
         ]);
 
         $client->captureMessage('test');
@@ -601,10 +601,11 @@ class ClientTest extends TestCase
     {
         $client = ClientBuilder::create()->getClient();
         $client->storeErrorsForBulkSend = true;
+        $context = $client->getContext();
 
-        $client->tags_context(['foo' => 'bar']);
-        $client->tags_context(['biz' => 'boz']);
-        $client->tags_context(['biz' => 'baz']);
+        $context->setTag('foo', 'bar');
+        $context->setTag('biz', 'boz');
+        $context->setTag('biz', 'baz');
 
         $client->captureMessage('test');
 
@@ -617,9 +618,9 @@ class ClientTest extends TestCase
         $client = ClientBuilder::create()->getClient();
         $client->storeErrorsForBulkSend = true;
 
-        $client->extra_context(['foo' => 'bar']);
-        $client->extra_context(['biz' => 'boz']);
-        $client->extra_context(['biz' => 'baz']);
+        $client->getContext()->mergeExtraData(['foo' => 'bar']);
+        $client->getContext()->mergeExtraData(['biz' => 'boz']);
+        $client->getContext()->mergeExtraData(['biz' => 'baz']);
 
         $client->captureMessage('test');
 
@@ -1013,36 +1014,6 @@ class ClientTest extends TestCase
                 ],
             ],
         ]], $data);
-    }
-
-    public function testUserContextWithoutMerge()
-    {
-        $client = ClientBuilder::create()->getClient();
-
-        $client->setUserContext(['foo' => 'bar'], false);
-        $client->setUserContext(['baz' => 'bar'], false);
-
-        $this->assertEquals(['baz' => 'bar'], $client->context->user);
-    }
-
-    public function testUserContextWithMerge()
-    {
-        $client = ClientBuilder::create()->getClient();
-
-        $client->setUserContext(['foo' => 'bar'], true);
-        $client->setUserContext(['baz' => 'bar'], true);
-
-        $this->assertEquals(['foo' => 'bar', 'baz' => 'bar'], $client->context->user);
-    }
-
-    public function testUserContextWithMergeAndNull()
-    {
-        $client = ClientBuilder::create()->getClient();
-
-        $client->setUserContext(['foo' => 'bar'], true);
-        $client->setUserContext(null, true);
-
-        $this->assertEquals(['foo' => 'bar'], $client->context->user);
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1138,11 +1138,11 @@ class ClientTest extends TestCase
         $client = ClientBuilder::create()->getClient();
 
         $data = [
-            ['lastError', null, null,],
-            ['lastError', null, 'value',],
-            ['lastError', null, mt_rand(100, 999),],
-            ['lastEventId', null, mt_rand(100, 999),],
-            ['lastEventId', null, 'value',],
+            ['lastError', null, null],
+            ['lastError', null, 'value'],
+            ['lastError', null, mt_rand(100, 999)],
+            ['lastEventId', null, mt_rand(100, 999)],
+            ['lastEventId', null, 'value'],
             ['shutdownFunctionHasBeenSet', null, true],
             ['shutdownFunctionHasBeenSet', null, false],
         ];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -55,19 +55,19 @@ class Dummy_Raven_Client extends \Raven\Client
         $this->__sent_events[] = $data;
     }
 
-    public static function is_http_request()
+    public static function isHttpRequest()
     {
         return true;
     }
 
-    public function get_http_data()
+    public function getHttpData()
     {
-        return parent::get_http_data();
+        return parent::getHttpData();
     }
 
-    public function get_user_data()
+    public function getUserData()
     {
-        return parent::get_user_data();
+        return parent::getUserData();
     }
 
     // short circuit breadcrumbs
@@ -88,7 +88,7 @@ class Dummy_Raven_Client extends \Raven\Client
      */
     public function test_get_current_url()
     {
-        return $this->get_current_url();
+        return $this->getCurrentUrl();
     }
 }
 
@@ -97,7 +97,7 @@ class Dummy_Raven_Client_No_Http extends Dummy_Raven_Client
     /**
      * @return bool
      */
-    public static function is_http_request()
+    public static function isHttpRequest()
     {
         return false;
     }
@@ -219,117 +219,117 @@ class ClientTest extends TestCase
     public function testOptionsExtraData()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->extra_context(['foo' => 'bar']);
         $client->captureMessage('Test Message %s', ['foo']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('bar', $client->_pending_events[0]['extra']['foo']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('bar', $client->pendingEvents[0]['extra']['foo']);
     }
 
     public function testOptionsExtraDataWithNull()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->extra_context(['foo' => 'bar']);
         $client->captureMessage('Test Message %s', ['foo'], null);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('bar', $client->_pending_events[0]['extra']['foo']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('bar', $client->pendingEvents[0]['extra']['foo']);
     }
 
     public function testEmptyExtraData()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('Test Message %s', ['foo']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertArrayNotHasKey('extra', $client->_pending_events[0]);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertArrayNotHasKey('extra', $client->pendingEvents[0]);
     }
 
     public function testCaptureMessageDoesHandleUninterpolatedMessage()
     {
         $client = ClientBuilder::create()->getClient();
 
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('foo %s');
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('foo %s', $client->_pending_events[0]['message']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('foo %s', $client->pendingEvents[0]['message']);
     }
 
     public function testCaptureMessageDoesHandleInterpolatedMessage()
     {
         $client = ClientBuilder::create()->getClient();
 
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('foo %s', ['bar']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('foo bar', $client->_pending_events[0]['message']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('foo bar', $client->pendingEvents[0]['message']);
     }
 
     public function testCaptureMessageDoesHandleInterpolatedMessageWithRelease()
     {
         $client = ClientBuilder::create(['release' => '1.2.3'])->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $this->assertEquals('1.2.3', $client->getConfig()->getRelease());
 
         $client->captureMessage('foo %s', ['bar']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('foo bar', $client->_pending_events[0]['message']);
-        $this->assertEquals('1.2.3', $client->_pending_events[0]['release']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('foo bar', $client->pendingEvents[0]['message']);
+        $this->assertEquals('1.2.3', $client->pendingEvents[0]['release']);
     }
 
     public function testCaptureMessageSetsInterface()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('foo %s', ['bar']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('foo bar', $client->_pending_events[0]['message']);
-        $this->assertArrayHasKey('sentry.interfaces.Message', $client->_pending_events[0]);
-        $this->assertEquals('foo bar', $client->_pending_events[0]['sentry.interfaces.Message']['formatted']);
-        $this->assertEquals('foo %s', $client->_pending_events[0]['sentry.interfaces.Message']['message']);
-        $this->assertEquals(['bar'], $client->_pending_events[0]['sentry.interfaces.Message']['params']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('foo bar', $client->pendingEvents[0]['message']);
+        $this->assertArrayHasKey('sentry.interfaces.Message', $client->pendingEvents[0]);
+        $this->assertEquals('foo bar', $client->pendingEvents[0]['sentry.interfaces.Message']['formatted']);
+        $this->assertEquals('foo %s', $client->pendingEvents[0]['sentry.interfaces.Message']['message']);
+        $this->assertEquals(['bar'], $client->pendingEvents[0]['sentry.interfaces.Message']['params']);
     }
 
     public function testCaptureMessageHandlesOptionsAsThirdArg()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('Test Message %s', ['foo'], [
             'level' => Dummy_Raven_Client::LEVEL_WARNING,
             'extra' => ['foo' => 'bar'],
         ]);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals(Dummy_Raven_Client::LEVEL_WARNING, $client->_pending_events[0]['level']);
-        $this->assertEquals('bar', $client->_pending_events[0]['extra']['foo']);
-        $this->assertEquals('Test Message foo', $client->_pending_events[0]['message']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals(Dummy_Raven_Client::LEVEL_WARNING, $client->pendingEvents[0]['level']);
+        $this->assertEquals('bar', $client->pendingEvents[0]['extra']['foo']);
+        $this->assertEquals('Test Message foo', $client->pendingEvents[0]['message']);
     }
 
     public function testCaptureMessageHandlesLevelAsThirdArg()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('Test Message %s', ['foo'], Dummy_Raven_Client::LEVEL_WARNING);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals(Dummy_Raven_Client::LEVEL_WARNING, $client->_pending_events[0]['level']);
-        $this->assertEquals('Test Message foo', $client->_pending_events[0]['message']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals(Dummy_Raven_Client::LEVEL_WARNING, $client->pendingEvents[0]['level']);
+        $this->assertEquals('Test Message foo', $client->pendingEvents[0]['message']);
     }
 
     /**
@@ -339,18 +339,18 @@ class ClientTest extends TestCase
     {
         // TODO: it'd be nice if we could mock the stacktrace extraction function here
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureException($this->create_exception());
 
-        $this->assertCount(1, $client->_pending_events);
+        $this->assertCount(1, $client->pendingEvents);
 
-        $this->assertCount(1, $client->_pending_events[0]['exception']['values']);
-        $this->assertEquals('Foo bar', $client->_pending_events[0]['exception']['values'][0]['value']);
-        $this->assertEquals('Exception', $client->_pending_events[0]['exception']['values'][0]['type']);
-        $this->assertNotEmpty($client->_pending_events[0]['exception']['values'][0]['stacktrace']['frames']);
+        $this->assertCount(1, $client->pendingEvents[0]['exception']['values']);
+        $this->assertEquals('Foo bar', $client->pendingEvents[0]['exception']['values'][0]['value']);
+        $this->assertEquals('Exception', $client->pendingEvents[0]['exception']['values'][0]['type']);
+        $this->assertNotEmpty($client->pendingEvents[0]['exception']['values'][0]['stacktrace']['frames']);
 
-        $frames = $client->_pending_events[0]['exception']['values'][0]['stacktrace']['frames'];
+        $frames = $client->pendingEvents[0]['exception']['values'][0]['stacktrace']['frames'];
         $frame = $frames[count($frames) - 1];
 
         $this->assertTrue($frame['lineno'] > 0);
@@ -365,20 +365,20 @@ class ClientTest extends TestCase
     {
         // TODO: it'd be nice if we could mock the stacktrace extraction function here
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureException($this->create_chained_exception());
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertCount(2, $client->_pending_events[0]['exception']['values']);
-        $this->assertEquals('Foo bar', $client->_pending_events[0]['exception']['values'][0]['value']);
-        $this->assertEquals('Child exc', $client->_pending_events[0]['exception']['values'][1]['value']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertCount(2, $client->pendingEvents[0]['exception']['values']);
+        $this->assertEquals('Foo bar', $client->pendingEvents[0]['exception']['values'][0]['value']);
+        $this->assertEquals('Child exc', $client->pendingEvents[0]['exception']['values'][1]['value']);
     }
 
     public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $e1 = new \ErrorException('First', 0, E_DEPRECATED);
         $e2 = new \ErrorException('Second', 0, E_NOTICE, __FILE__, __LINE__, $e1);
@@ -388,37 +388,37 @@ class ClientTest extends TestCase
         $client->captureException($e2);
         $client->captureException($e3);
 
-        $this->assertCount(3, $client->_pending_events);
-        $this->assertEquals(Client::LEVEL_WARNING, $client->_pending_events[0]['level']);
-        $this->assertEquals(Client::LEVEL_INFO, $client->_pending_events[1]['level']);
-        $this->assertEquals(Client::LEVEL_ERROR, $client->_pending_events[2]['level']);
+        $this->assertCount(3, $client->pendingEvents);
+        $this->assertEquals(Client::LEVEL_WARNING, $client->pendingEvents[0]['level']);
+        $this->assertEquals(Client::LEVEL_INFO, $client->pendingEvents[1]['level']);
+        $this->assertEquals(Client::LEVEL_ERROR, $client->pendingEvents[2]['level']);
     }
 
     public function testCaptureExceptionHandlesOptionsAsSecondArg()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureException($this->create_exception(), ['culprit' => 'test']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('test', $client->_pending_events[0]['culprit']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('test', $client->pendingEvents[0]['culprit']);
     }
 
     public function testCaptureExceptionHandlesExcludeOption()
     {
         $client = ClientBuilder::create(['excluded_exceptions' => ['Exception']])->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureException($this->create_exception(), 'test');
 
-        $this->assertEmpty($client->_pending_events);
+        $this->assertEmpty($client->pendingEvents);
     }
 
     public function testCaptureExceptionInvalidUTF8()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         try {
             invalid_encoding();
@@ -426,10 +426,10 @@ class ClientTest extends TestCase
             $client->captureException($ex);
         }
 
-        $this->assertCount(1, $client->_pending_events);
+        $this->assertCount(1, $client->pendingEvents);
 
         try {
-            $client->send($client->_pending_events[0]);
+            $client->send($client->pendingEvents[0]);
         } catch (\Exception $ex) {
             $this->fail();
         }
@@ -480,7 +480,7 @@ class ClientTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $client->get_default_data());
+        $this->assertEquals($expected, $client->getDefaultData());
     }
 
     /**
@@ -547,15 +547,15 @@ class ClientTest extends TestCase
 
         $client = new Dummy_Raven_Client($config, $httpClient, $requestFactory);
 
-        $this->assertEquals($expected, $client->get_http_data());
+        $this->assertEquals($expected, $client->getHttpData());
     }
 
     public function testCaptureMessageWithUserData()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
-        $client->user_context([
+        $client->setUserContext([
             'id' => 'unique_id',
             'email' => 'foo@example.com',
             'username' => 'my_user',
@@ -563,29 +563,29 @@ class ClientTest extends TestCase
 
         $client->captureMessage('foo');
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('unique_id', $client->_pending_events[0]['user']['id']);
-        $this->assertEquals('my_user', $client->_pending_events[0]['user']['username']);
-        $this->assertEquals('foo@example.com', $client->_pending_events[0]['user']['email']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('unique_id', $client->pendingEvents[0]['user']['id']);
+        $this->assertEquals('my_user', $client->pendingEvents[0]['user']['username']);
+        $this->assertEquals('foo@example.com', $client->pendingEvents[0]['user']['email']);
     }
 
     public function testCaptureMessageWithNoUserData()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureMessage('foo');
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals(session_id(), $client->_pending_events[0]['user']['id']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals(session_id(), $client->pendingEvents[0]['user']['id']);
     }
 
     public function testCaptureMessageWithUnserializableUserData()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
-        $client->user_context([
+        $client->setUserContext([
             'email' => 'foo@example.com',
             'data' => [
                 'error' => new \Exception('test'),
@@ -594,13 +594,13 @@ class ClientTest extends TestCase
 
         $client->captureMessage('test');
 
-        $this->assertCount(1, $client->_pending_events);
+        $this->assertCount(1, $client->pendingEvents);
     }
 
     public function testCaptureMessageWithTagsContext()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->tags_context(['foo' => 'bar']);
         $client->tags_context(['biz' => 'boz']);
@@ -608,14 +608,14 @@ class ClientTest extends TestCase
 
         $client->captureMessage('test');
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals(['foo' => 'bar', 'biz' => 'baz'], $client->_pending_events[0]['tags']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals(['foo' => 'bar', 'biz' => 'baz'], $client->pendingEvents[0]['tags']);
     }
 
     public function testCaptureMessageWithExtraContext()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->extra_context(['foo' => 'bar']);
         $client->extra_context(['biz' => 'boz']);
@@ -623,14 +623,14 @@ class ClientTest extends TestCase
 
         $client->captureMessage('test');
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals(['foo' => 'bar', 'biz' => 'baz'], $client->_pending_events[0]['extra']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals(['foo' => 'bar', 'biz' => 'baz'], $client->pendingEvents[0]['extra']);
     }
 
     public function testCaptureExceptionContainingLatin1()
     {
         $client = ClientBuilder::create(['mb_detect_order' => ['ISO-8859-1', 'ASCII', 'UTF-8']])->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         // we need a non-utf8 string here.
         // nobody writes non-utf8 in exceptions, but it is the easiest way to test.
@@ -639,18 +639,18 @@ class ClientTest extends TestCase
         $latin1String = utf8_decode($utf8String);
         $client->captureException(new \Exception($latin1String));
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals($utf8String, $client->_pending_events[0]['exception']['values'][0]['value']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals($utf8String, $client->pendingEvents[0]['exception']['values'][0]['value']);
     }
 
     public function testCaptureExceptionInLatin1File()
     {
         $client = ClientBuilder::create(['mb_detect_order' => ['ISO-8859-1', 'ASCII', 'UTF-8']])->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         require_once __DIR__ . '/Fixtures/code/Latin1File.php';
 
-        $frames = $client->_pending_events[0]['exception']['values'][0]['stacktrace']['frames'];
+        $frames = $client->pendingEvents[0]['exception']['values'][0]['stacktrace']['frames'];
 
         $utf8String = '// äöü';
         $found = false;
@@ -677,10 +677,10 @@ class ClientTest extends TestCase
         }
 
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $this->assertNull($client->captureLastError());
-        $this->assertEmpty($client->_pending_events);
+        $this->assertEmpty($client->pendingEvents);
 
         /* @var $undefined */
         /* @noinspection PhpExpressionResultUnusedInspection */
@@ -688,21 +688,21 @@ class ClientTest extends TestCase
 
         $client->captureLastError();
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('Undefined variable: undefined', $client->_pending_events[0]['exception']['values'][0]['value']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('Undefined variable: undefined', $client->pendingEvents[0]['exception']['values'][0]['value']);
     }
 
     public function testGetLastEventID()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->capture([
             'message' => 'test',
             'event_id' => 'abc',
         ]);
 
-        $this->assertEquals('abc', $client->getLastEventID());
+        $this->assertEquals('abc', $client->getLastEventId());
     }
 
     public function testCustomTransport()
@@ -1019,8 +1019,8 @@ class ClientTest extends TestCase
     {
         $client = ClientBuilder::create()->getClient();
 
-        $client->user_context(['foo' => 'bar'], false);
-        $client->user_context(['baz' => 'bar'], false);
+        $client->setUserContext(['foo' => 'bar'], false);
+        $client->setUserContext(['baz' => 'bar'], false);
 
         $this->assertEquals(['baz' => 'bar'], $client->context->user);
     }
@@ -1029,8 +1029,8 @@ class ClientTest extends TestCase
     {
         $client = ClientBuilder::create()->getClient();
 
-        $client->user_context(['foo' => 'bar'], true);
-        $client->user_context(['baz' => 'bar'], true);
+        $client->setUserContext(['foo' => 'bar'], true);
+        $client->setUserContext(['baz' => 'bar'], true);
 
         $this->assertEquals(['foo' => 'bar', 'baz' => 'bar'], $client->context->user);
     }
@@ -1039,8 +1039,8 @@ class ClientTest extends TestCase
     {
         $client = ClientBuilder::create()->getClient();
 
-        $client->user_context(['foo' => 'bar'], true);
-        $client->user_context(null, true);
+        $client->setUserContext(['foo' => 'bar'], true);
+        $client->setUserContext(null, true);
 
         $this->assertEquals(['foo' => 'bar'], $client->context->user);
     }
@@ -1054,7 +1054,7 @@ class ClientTest extends TestCase
      * @param array  $options
      * @param string $expected   - the url expected
      * @param string $message    - fail message
-     * @covers \Raven\Client::get_current_url
+     * @covers \Raven\Client::getCurrentUrl
      * @covers \Raven\Client::isHttps
      */
     public function testCurrentUrl($serverVars, $options, $expected, $message)
@@ -1159,30 +1159,23 @@ class ClientTest extends TestCase
 
     /**
      * @covers \Raven\Client::getLastError
-     * @covers \Raven\Client::getLastEventID
-     * @covers \Raven\Client::getLastSentryError
+     * @covers \Raven\Client::getLastEventId
      * @covers \Raven\Client::getShutdownFunctionHasBeenSet
      */
     public function testGettersAndSetters()
     {
         $client = ClientBuilder::create()->getClient();
-        $callable = [$this, 'stabClosureVoid'];
 
         $data = [
-            ['_lasterror', null, null],
-            ['_lasterror', null, 'value'],
-            ['_lasterror', null, mt_rand(100, 999)],
-            ['_last_sentry_error', null, (object) ['error' => 'test']],
-            ['_last_event_id', null, mt_rand(100, 999)],
-            ['_last_event_id', null, 'value'],
-            ['_shutdown_function_has_been_set', null, true],
-            ['_shutdown_function_has_been_set', null, false],
+            ['lastError', null, null,],
+            ['lastError', null, 'value',],
+            ['lastError', null, mt_rand(100, 999),],
+            ['lastEventId', null, mt_rand(100, 999),],
+            ['lastEventId', null, 'value',],
+            ['shutdownFunctionHasBeenSet', null, true],
+            ['shutdownFunctionHasBeenSet', null, false],
         ];
         foreach ($data as &$datum) {
-            $this->subTestGettersAndSettersDatum($client, $datum);
-        }
-        foreach ($data as &$datum) {
-            $client = ClientBuilder::create()->getClient();
             $this->subTestGettersAndSettersDatum($client, $datum);
         }
     }
@@ -1252,7 +1245,7 @@ class ClientTest extends TestCase
      */
     public function testTranslateSeverity()
     {
-        $reflection = new \ReflectionProperty('\\Raven\Client', 'severity_map');
+        $reflection = new \ReflectionProperty(Client::class, 'severityMap');
         $reflection->setAccessible(true);
         $client = ClientBuilder::create()->getClient();
 
@@ -1299,12 +1292,12 @@ class ClientTest extends TestCase
     public function testCaptureExceptionWithLogger()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->captureException(new \Exception(), null, 'foobar');
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertEquals('foobar', $client->_pending_events[0]['logger']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertEquals('foobar', $client->pendingEvents[0]['logger']);
     }
 
     /**
@@ -1402,20 +1395,20 @@ class ClientTest extends TestCase
             ->setHttpClient($httpClient)
             ->getClient();
 
-        $this->assertEquals(0, count($client->_pending_events));
-        $client->_pending_events[] = ['foo' => 'bar'];
+        $this->assertEquals(0, count($client->pendingEvents));
+        $client->pendingEvents[] = ['foo' => 'bar'];
         $client->sendUnsentErrors();
         $this->assertCount(1, $httpClient->getRequests());
-        $this->assertEquals(0, count($client->_pending_events));
+        $this->assertEquals(0, count($client->pendingEvents));
 
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
         $client->captureMessage('foobar');
-        $this->assertEquals(1, count($client->_pending_events));
+        $this->assertEquals(1, count($client->pendingEvents));
 
         // step 3
         $client->onShutdown();
         $this->assertCount(2, $httpClient->getRequests());
-        $this->assertEquals(0, count($client->_pending_events));
+        $this->assertEquals(0, count($client->pendingEvents));
     }
 
     public function testSendChecksShouldCaptureOption()
@@ -1508,7 +1501,7 @@ class ClientTest extends TestCase
 
         // step 1
         $client = new Dummy_Raven_Client(new Configuration(), $httpClient, $requestFactory);
-        $output = $client->get_user_data();
+        $output = $client->getUserData();
         $this->assertInternalType('array', $output);
         $this->assertArrayHasKey('user', $output);
         $this->assertArrayHasKey('id', $output['user']);
@@ -1518,7 +1511,7 @@ class ClientTest extends TestCase
         $session_id = session_id();
         session_write_close();
         session_id('');
-        $output = $client->get_user_data();
+        $output = $client->getUserData();
         $this->assertInternalType('array', $output);
         $this->assertEquals(0, count($output));
 
@@ -1526,7 +1519,7 @@ class ClientTest extends TestCase
         session_id($session_id);
         @session_start(['use_cookies' => false]);
         $_SESSION = ['foo' => 'bar'];
-        $output = $client->get_user_data();
+        $output = $client->getUserData();
         $this->assertInternalType('array', $output);
         $this->assertArrayHasKey('user', $output);
         $this->assertArrayHasKey('id', $output['user']);
@@ -1554,33 +1547,33 @@ class ClientTest extends TestCase
             }
 
             $client = ClientBuilder::create()->getClient();
-            $client->store_errors_for_bulk_send = true;
+            $client->storeErrorsForBulkSend = true;
 
             $client->capture(['message' => $message]);
 
-            $this->assertCount(1, $client->_pending_events);
-            $this->assertEquals('error', $client->_pending_events[0]['level']);
-            $this->assertEquals(substr($message, 0, min(\Raven\Client::MESSAGE_LIMIT, $length)), $client->_pending_events[0]['message']);
-            $this->assertArrayNotHasKey('release', $client->_pending_events[0]);
+            $this->assertCount(1, $client->pendingEvents);
+            $this->assertEquals('error', $client->pendingEvents[0]['level']);
+            $this->assertEquals(substr($message, 0, min(\Raven\Client::MESSAGE_LIMIT, $length)), $client->pendingEvents[0]['message']);
+            $this->assertArrayNotHasKey('release', $client->pendingEvents[0]);
         }
 
         $client = new Dummy_Raven_Client(new Configuration(), $httpClient, $requestFactory);
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->capture(['message' => 'foobar']);
 
-        $input = $client->get_http_data();
+        $input = $client->getHttpData();
 
-        $this->assertEquals($input['request'], $client->_pending_events[0]['request']);
-        $this->assertArrayNotHasKey('release', $client->_pending_events[0]);
+        $this->assertEquals($input['request'], $client->pendingEvents[0]['request']);
+        $this->assertArrayNotHasKey('release', $client->pendingEvents[0]);
 
         $client = new Dummy_Raven_Client(new Configuration(), $httpClient, $requestFactory);
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->capture(['message' => 'foobar', 'request' => ['foo' => 'bar']]);
 
-        $this->assertEquals(['foo' => 'bar'], $client->_pending_events[0]['request']);
-        $this->assertArrayNotHasKey('release', $client->_pending_events[0]);
+        $this->assertEquals(['foo' => 'bar'], $client->pendingEvents[0]['request']);
+        $this->assertArrayNotHasKey('release', $client->pendingEvents[0]);
 
         foreach ([false, true] as $u1) {
             foreach ([false, true] as $u2) {
@@ -1595,18 +1588,18 @@ class ClientTest extends TestCase
                 }
 
                 $client = new Client(new Configuration($options), $httpClient, $requestFactory);
-                $client->store_errors_for_bulk_send = true;
+                $client->storeErrorsForBulkSend = true;
 
                 $client->capture(['message' => 'foobar']);
 
                 if ($u1) {
-                    $this->assertEquals('foo', $client->_pending_events[0]['release']);
+                    $this->assertEquals('foo', $client->pendingEvents[0]['release']);
                 } else {
-                    $this->assertArrayNotHasKey('release', $client->_pending_events[0]);
+                    $this->assertArrayNotHasKey('release', $client->pendingEvents[0]);
                 }
 
                 if ($u2) {
-                    $this->assertEquals('bar', $client->_pending_events[0]['environment']);
+                    $this->assertEquals('bar', $client->pendingEvents[0]['environment']);
                 }
             }
         }
@@ -1623,7 +1616,7 @@ class ClientTest extends TestCase
             ->getMock();
 
         $client = new Dummy_Raven_Client_No_Http(new Configuration(['install_default_breadcrumb_handlers' => false]), $httpClient, $requestFactory);
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $session_id = session_id();
 
@@ -1632,9 +1625,9 @@ class ClientTest extends TestCase
 
         $client->capture(['user' => '', 'request' => '']);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertArrayNotHasKey('user', $client->_pending_events[0]);
-        $this->assertArrayNotHasKey('request', $client->_pending_events[0]);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertArrayNotHasKey('user', $client->pendingEvents[0]);
+        $this->assertArrayNotHasKey('request', $client->pendingEvents[0]);
 
         session_id($session_id);
         @session_start(['use_cookies' => false]);
@@ -1643,13 +1636,13 @@ class ClientTest extends TestCase
     public function testCaptureAutoLogStacks()
     {
         $client = ClientBuilder::create()->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         $client->capture(['auto_log_stacks' => true], true);
 
-        $this->assertCount(1, $client->_pending_events);
-        $this->assertArrayHasKey('stacktrace', $client->_pending_events[0]);
-        $this->assertInternalType('array', $client->_pending_events[0]['stacktrace']['frames']);
+        $this->assertCount(1, $client->pendingEvents);
+        $this->assertArrayHasKey('stacktrace', $client->pendingEvents[0]);
+        $this->assertInternalType('array', $client->pendingEvents[0]['stacktrace']['frames']);
     }
 
     /**

--- a/tests/ContextTest.php
+++ b/tests/ContextTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Raven\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Raven\Context;
+
+class ContextTest extends TestCase
+{
+    public function testSetTag()
+    {
+        $context = new Context();
+
+        $context->setTag('foo', 'bar');
+        $context->setTag('foo', 'baz');
+
+        $this->assertEquals(['foo' => 'baz'], $context->getTags());
+    }
+
+    public function testMergeUserData()
+    {
+        $context = new Context();
+
+        $context->mergeUserData(['foo' => 'bar']);
+        $context->mergeUserData(['baz' => 'bar']);
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'bar'], $context->getUserData());
+    }
+
+    public function testMergeUserDataWithSameKey()
+    {
+        $context = new Context();
+
+        $context->mergeUserData(['foo' => 'bar']);
+        $context->mergeUserData(['foo' => 'baz']);
+
+        $this->assertEquals(['foo' => 'baz'], $context->getUserData());
+    }
+
+    public function testSetUserData()
+    {
+        $context = new Context();
+
+        $context->setUserData(['foo' => 'bar']);
+        $context->setUserData(['bar' => 'baz']);
+
+        $this->assertEquals(['bar' => 'baz'], $context->getUserData());
+    }
+
+    public function testMergeExtraData()
+    {
+        $context = new Context();
+
+        $context->mergeExtraData(['foo' => 'bar']);
+        $context->mergeExtraData(['baz' => 'bar']);
+
+        $this->assertEquals(['foo' => 'bar', 'baz' => 'bar'], $context->getExtraData());
+    }
+
+    public function testMergeExtraDataWithSameKey()
+    {
+        $context = new Context();
+
+        $context->mergeExtraData(['foo' => 'bar']);
+        $context->mergeExtraData(['foo' => 'baz']);
+
+        $this->assertEquals(['foo' => 'baz'], $context->getExtraData());
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -31,7 +31,7 @@ class DummyIntegration_Raven_Client extends \Raven\Client
         $this->__sent_events[] = $data;
     }
 
-    public static function is_http_request()
+    public static function isHttpRequest()
     {
         return true;
     }
@@ -60,13 +60,13 @@ class IntegrationTest extends TestCase
     public function testCaptureSimpleError()
     {
         $client = ClientBuilder::create([])->getClient();
-        $client->store_errors_for_bulk_send = true;
+        $client->storeErrorsForBulkSend = true;
 
         @mkdir('/no/way');
 
         $client->captureLastError();
 
-        $event = $client->_pending_events[0]['exception']['values'][0];
+        $event = $client->pendingEvents[0]['exception']['values'][0];
 
         $this->assertEquals($event['value'], 'mkdir(): No such file or directory');
         $this->assertEquals($event['stacktrace']['frames'][count($event['stacktrace']['frames']) - 1]['filename'], 'tests/IntegrationTest.php');

--- a/tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -31,7 +31,7 @@ class SanitizeStacktraceProcessorTest extends TestCase
     protected function setUp()
     {
         $this->client = ClientBuilder::create()->getClient();
-        $this->client->store_errors_for_bulk_send = true;
+        $this->client->storeErrorsForBulkSend = true;
 
         $this->processor = new SanitizeStacktraceProcessor($this->client);
     }
@@ -44,9 +44,9 @@ class SanitizeStacktraceProcessorTest extends TestCase
             $this->client->captureException($exception);
         }
 
-        $this->processor->process($this->client->_pending_events[0]);
+        $this->processor->process($this->client->pendingEvents[0]);
 
-        foreach ($this->client->_pending_events[0]['exception']['values'] as $exceptionValue) {
+        foreach ($this->client->pendingEvents[0]['exception']['values'] as $exceptionValue) {
             foreach ($exceptionValue['stacktrace']['frames'] as $frame) {
                 $this->assertArrayNotHasKey('pre_context', $frame);
                 $this->assertArrayNotHasKey('context_line', $frame);
@@ -67,9 +67,9 @@ class SanitizeStacktraceProcessorTest extends TestCase
             $this->client->captureException($exception);
         }
 
-        $this->processor->process($this->client->_pending_events[0]);
+        $this->processor->process($this->client->pendingEvents[0]);
 
-        foreach ($this->client->_pending_events[0]['exception']['values'] as $exceptionValue) {
+        foreach ($this->client->pendingEvents[0]['exception']['values'] as $exceptionValue) {
             foreach ($exceptionValue['stacktrace']['frames'] as $frame) {
                 $this->assertArrayNotHasKey('pre_context', $frame);
                 $this->assertArrayNotHasKey('context_line', $frame);


### PR DESCRIPTION
This PR aims at cleaning up the client in respect of code style and to extract the context functionality from it, moving all the logic inside the `Raven\Context` object, that was kinda empty.

This is still WIP since I need to update docs and changelog accordingly.