### PR TITLE
Use ramsey/uuid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php-http/discovery": "~1.2",
         "php-http/httplug": "~1.1",
         "psr/http-message-implementation": "~1.0",
+        "ramsey/uuid": "^3.0",
         "symfony/options-resolver": "~2.7|~3.0"
     },
     "require-dev": {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -19,6 +19,7 @@ use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Breadcrumbs\Recorder;
 use Raven\HttpClient\Encoding\Base64EncodingStream;
 use Raven\Util\JSON;
+use Raven\Util\Uuid4;
 
 /**
  * Raven PHP Client.
@@ -625,7 +626,7 @@ class Client
             $data['extra'] = [];
         }
         if (!isset($data['event_id'])) {
-            $data['event_id'] = static::uuid4();
+            $data['event_id'] = Uuid4::generate();
         }
 
         if (isset($data['message'])) {

--- a/lib/Raven/Util/Uuid4.php
+++ b/lib/Raven/Util/Uuid4.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Raven\Util;
+
+use Ramsey\Uuid\Uuid;
+
+class Uuid4
+{
+    /**
+     * @return string
+     */
+    public static function generate()
+    {
+        $uuid = Uuid::uuid4()->toString();
+        
+        return str_replace('-', '', $uuid);
+    }
+}

--- a/lib/Raven/Util/Uuid4.php
+++ b/lib/Raven/Util/Uuid4.php
@@ -12,7 +12,7 @@ class Uuid4
     public static function generate()
     {
         $uuid = Uuid::uuid4()->toString();
-        
+
         return str_replace('-', '', $uuid);
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1146,18 +1146,6 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @covers \Raven\Client::uuid4()
-     */
-    public function testUuid4()
-    {
-        $method = new \ReflectionMethod('\\Raven\\Client', 'uuid4');
-        $method->setAccessible(true);
-        for ($i = 0; $i < 1000; ++$i) {
-            $this->assertRegExp('/^[0-9a-z-]+$/', $method->invoke(null));
-        }
-    }
-
-    /**
      * @covers \Raven\Client::getLastError
      * @covers \Raven\Client::getLastEventID
      * @covers \Raven\Client::getLastSentryError


### PR DESCRIPTION
This PR replaces the `Client::uuid4()` function with a class that just wraps the same function in the ramsey/uuid package. In this way we do no longer need to maintain the code of that function, which was pretty obscure and hard to comprehend.