### PR TITLE
Remove ini_set call for unneeded functionality

### DIFF
--- a/lib/Raven/Autoloader.php
+++ b/lib/Raven/Autoloader.php
@@ -21,7 +21,6 @@ class Raven_Autoloader
      */
     public static function register()
     {
-        ini_set('unserialize_callback_func', 'spl_autoload_call');
         spl_autoload_register(array('Raven_Autoloader', 'autoload'));
     }
 


### PR DESCRIPTION
This would fix #499.

I'm not sure why this was placed here, but we are not serializing or unserializing any data so this "failsafe" is not needed for out autoloader if i'm correct.