### PR TITLE
Test PHP 5.3 in separate environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 sudo: false
-dist: precise
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
@@ -21,7 +20,12 @@ matrix:
   include:
     - php: hhvm-3.12
       env: REMOVE_XDEBUG="0" HHVM="1"
-      dist: trusty
+    - php: 5.3
+      env: REMOVE_XDEBUG="0"
+      dist: precise
+    - php: 5.3
+      env: REMOVE_XDEBUG="1"
+      dist: precise
 
 cache:
   directories:


### PR DESCRIPTION
I admit that `precise`, like all Ubuntu LTS, is an important milestone in Linux history, but let's use something newer than the software released more than 5 years ago.

https://blog.travis-ci.com/2017-08-31-trusty-as-default-status