### PR TITLE
Prevent segmentation fault in Reflection->getParameters() 

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -184,8 +184,10 @@ class Raven_Stacktrace
                 } else {
                     $reflection = new ReflectionMethod($frame['class'], '__call');
                 }
-            } else {
+            } elseif(function_exists($frame['function'])) {
                 $reflection = new ReflectionFunction($frame['function']);
+            } else {
+                return self::get_default_context($frame, $frame_arg_limit);
             }
         } catch (ReflectionException $e) {
             return self::get_default_context($frame, $frame_arg_limit);

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -184,7 +184,7 @@ class Raven_Stacktrace
                 } else {
                     $reflection = new ReflectionMethod($frame['class'], '__call');
                 }
-            } elseif(function_exists($frame['function'])) {
+            } elseif (function_exists($frame['function'])) {
                 $reflection = new ReflectionFunction($frame['function']);
             } else {
                 return self::get_default_context($frame, $frame_arg_limit);


### PR DESCRIPTION
When a native php function has been disabled via disabled_functions (php.ini) calling getParameters() on the reflection object of the disabled function causes a segmentation fault on PHP 5.6.31.

Reproducible on both Arch Linux and CentOS 6 with the following script:

php.ini
```
disable_functions = "passthru"
```

console.php
 ```php
<?php

require_once 'vendor/autoload.php';

use Raven_Client;

$connection = false;
$client = new Raven_Client($connection);
$client->environment = 'test';
$client->install();

passthru('clear');
```

Run straight through either php or php-cli `php56 console.php` gives a segmentation fault as follows:
```
[1]    22373 segmentation fault (core dumped)  php56 console.php
```

Testing through php 7 does not segfault and reflection seems to be able to cope with the disabled function:

```
PHP Warning:  passthru() has been disabled for security reasons in /home/kandrews/NetBeansProjects/compareandrecycle.co.uk/console.php on line 12
PHP Stack trace:
PHP   1. {main}() /home/kandrews/NetBeansProjects/compareandrecycle.co.uk/console.php:0
PHP   2. passthru() /home/kandrews/NetBeansProjects/compareandrecycle.co.uk/console.php:12
```

