### PR TITLE
[2.0] Prevent segmentation fault in Reflection->getParameters()

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -9,6 +9,7 @@ return PhpCsFixer\Config::create()
         'concat_space' => ['spacing' => 'one'],
         'ordered_imports' => true,
         'random_api_migration' => true,
+        'yoda_style' => true,
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/lib/Raven/Breadcrumbs/ErrorHandler.php
+++ b/lib/Raven/Breadcrumbs/ErrorHandler.php
@@ -29,7 +29,7 @@ class ErrorHandler
             ])
         );
 
-        if ($this->existingHandler !== null) {
+        if (null !== $this->existingHandler) {
             return call_user_func($this->existingHandler, $code, $message, $file, $line, $context);
         } else {
             return false;

--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -71,6 +71,7 @@ class MonologHandler extends AbstractProcessingHandler
              */
             $exc = $record['context']['exception'];
 
+            /** @noinspection PhpUndefinedMethodInspection */
             $breadcrumb = new Breadcrumb($this->logLevels[$record['level']], Breadcrumb::TYPE_ERROR, $record['channel'], null, [
                 'type' => get_class($exc),
                 'value' => $exc->getMessage(),

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -46,7 +46,7 @@ class Client
     const MESSAGE_LIMIT = 1024;
 
     /**
-     * @var Recorder The bredcrumbs recorder
+     * @var Recorder The breadcrumbs recorder
      */
     protected $recorder;
 
@@ -329,7 +329,7 @@ class Client
             $formatted_message = $message;
         }
 
-        if ($data === null) {
+        if (null === $data) {
             $data = [];
             // support legacy method of passing in a level name as the third arg
         } elseif (!is_array($data)) {
@@ -364,7 +364,7 @@ class Client
             return null;
         }
 
-        if ($data === null) {
+        if (null === $data) {
             $data = [];
         }
 
@@ -404,7 +404,7 @@ class Client
         $data['exception'] = [
             'values' => array_reverse($exceptions),
         ];
-        if ($logger !== null) {
+        if (null !== $logger) {
             $data['logger'] = $logger;
         }
 
@@ -460,7 +460,7 @@ class Client
             ],
         ];
 
-        if ($engine !== '') {
+        if (!empty($engine)) {
             $data['sentry.interfaces.Query']['engine'] = $engine;
         }
 
@@ -507,7 +507,7 @@ class Client
                 $header_key =
                     str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
                 $headers[$header_key] = $value;
-            } elseif (in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH']) && $value !== '') {
+            } elseif (in_array($key, ['CONTENT_TYPE', 'CONTENT_LENGTH']) && !empty($value)) {
                 $header_key = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', $key))));
                 $headers[$header_key] = $value;
             }
@@ -641,7 +641,7 @@ class Client
             $data['breadcrumbs'] = iterator_to_array($this->recorder);
         }
 
-        if ((!$stack && $this->config->getAutoLogStacks()) || $stack === true) {
+        if ((!$stack && $this->config->getAutoLogStacks()) || (true === $stack)) {
             $stack = debug_backtrace();
 
             // Drop last stack
@@ -850,17 +850,17 @@ class Client
      */
     protected function isHttps()
     {
-        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+        if (!empty($_SERVER['HTTPS']) && ('off' !== $_SERVER['HTTPS'])) {
             return true;
         }
 
-        if (!empty($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) {
+        if (!empty($_SERVER['SERVER_PORT']) && (443 == $_SERVER['SERVER_PORT'])) {
             return true;
         }
 
         if (!empty($this->config->isTrustXForwardedProto()) &&
             !empty($_SERVER['X-FORWARDED-PROTO']) &&
-            $_SERVER['X-FORWARDED-PROTO'] === 'https') {
+            ('https' === $_SERVER['X-FORWARDED-PROTO'])) {
             return true;
         }
 

--- a/lib/Raven/ClientBuilder.php
+++ b/lib/Raven/ClientBuilder.php
@@ -187,7 +187,6 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $this->messageFactory = $this->messageFactory ?: MessageFactoryDiscovery::find();
         $this->uriFactory = $this->uriFactory ?: UriFactoryDiscovery::find();
-        $this->messageFactory = $this->messageFactory ?: MessageFactoryDiscovery::find();
         $this->httpClient = $this->httpClient ?: HttpAsyncClientDiscovery::find();
 
         return new Client($this->configuration, $this->createHttpClientInstance(), $this->messageFactory);

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -58,7 +58,7 @@ class ErrorHandler
                                 $__error_types = null
     ) {
         // support legacy fourth argument for error types
-        if ($error_types === null) {
+        if (null === $error_types) {
             $error_types = $__error_types;
         }
 
@@ -81,7 +81,7 @@ class ErrorHandler
         $e->event_id = $this->client->captureException($e, null, null, $vars);
 
         if (!$isError && $this->call_existing_exception_handler) {
-            if ($this->old_exception_handler !== null) {
+            if (null !== $this->old_exception_handler) {
                 call_user_func($this->old_exception_handler, $e);
             } else {
                 throw $e;
@@ -96,9 +96,9 @@ class ErrorHandler
         // E_PARSE, E_CORE_ERROR, E_CORE_WARNING, E_COMPILE_ERROR, E_COMPILE_WARNING, and
         // most of E_STRICT raised in the file where set_error_handler() is called.
 
-        if (error_reporting() !== 0) {
+        if (0 !== error_reporting()) {
             $error_types = $this->error_types;
-            if ($error_types === null) {
+            if (null === $error_types) {
                 $error_types = error_reporting();
             }
             if ($error_types & $type) {
@@ -108,7 +108,7 @@ class ErrorHandler
         }
 
         if ($this->call_existing_error_handler) {
-            if ($this->old_error_handler !== null) {
+            if (null !== $this->old_error_handler) {
                 return call_user_func(
                     $this->old_error_handler,
                     $type,
@@ -177,7 +177,7 @@ class ErrorHandler
      */
     public function registerErrorHandler($call_existing = true, $error_types = null)
     {
-        if ($error_types !== null) {
+        if (null !== $error_types) {
             $this->error_types = $error_types;
         }
         $this->old_error_handler = set_error_handler([$this, 'handleError'], E_ALL);

--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -19,17 +19,17 @@ class ReprSerializer extends \Raven\Serializer
 {
     protected function serializeValue($value)
     {
-        if ($value === null) {
+        if (null === $value) {
             return 'null';
-        } elseif ($value === false) {
+        } elseif (false === $value) {
             return 'false';
-        } elseif ($value === true) {
+        } elseif (true === $value) {
             return 'true';
         } elseif (is_float($value) && (int) $value == $value) {
             return $value . '.0';
         } elseif (is_int($value) || is_float($value)) {
             return (string) $value;
-        } elseif (is_object($value) || gettype($value) == 'object') {
+        } elseif (is_object($value) || ('object' == gettype($value))) {
             return 'Object ' . get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource ' . get_resource_type($value);

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -55,7 +55,7 @@ class Serializer
      */
     public function __construct($mb_detect_order = null)
     {
-        if ($mb_detect_order != null) {
+        if (null != $mb_detect_order) {
             $this->mb_detect_order = $mb_detect_order;
         }
     }
@@ -83,7 +83,7 @@ class Serializer
             }
 
             if (is_object($value)) {
-                if ((get_class($value) == 'stdClass') or $this->_all_object_serialize) {
+                if (('stdClass' == get_class($value)) or $this->_all_object_serialize) {
                     return $this->serializeObject($value, $max_depth, $_depth, []);
                 }
             }
@@ -147,9 +147,9 @@ class Serializer
      */
     protected function serializeValue($value)
     {
-        if (null === $value || is_bool($value) || is_float($value) || is_int($value)) {
+        if ((null === $value) || is_bool($value) || is_float($value) || is_int($value)) {
             return $value;
-        } elseif (is_object($value) || gettype($value) == 'object') {
+        } elseif (is_object($value) || ('object' == gettype($value))) {
             return 'Object ' . get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource ' . get_resource_type($value);

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -348,8 +348,10 @@ class Stacktrace implements \JsonSerializable
                 } else {
                     $reflection = new \ReflectionMethod($frame['class'], '__call');
                 }
-            } else {
+            } elseif (function_exists($frame['function'])) {
                 $reflection = new \ReflectionFunction($frame['function']);
+            } else {
+                return self::getFrameArgumentsValues($frame, $maxValueLength);
             }
         } catch (\ReflectionException $ex) {
             return self::getFrameArgumentsValues($frame, $maxValueLength);

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -246,8 +246,10 @@ class Stacktrace implements \JsonSerializable
 
                 $file->next();
             }
+            // @codeCoverageIgnoreStart
         } catch (\Exception $ex) {
         }
+        // @codeCoverageIgnoreEnd
 
         $frame['pre_context'] = $this->serializer->serialize($frame['pre_context']);
         $frame['context_line'] = $this->serializer->serialize($frame['context_line']);
@@ -343,7 +345,7 @@ class Stacktrace implements \JsonSerializable
             if (isset($frame['class'])) {
                 if (method_exists($frame['class'], $frame['function'])) {
                     $reflection = new \ReflectionMethod($frame['class'], $frame['function']);
-                } elseif ($frame['type'] === '::') {
+                } elseif ('::' === $frame['type']) {
                     $reflection = new \ReflectionMethod($frame['class'], '__callStatic');
                 } else {
                     $reflection = new \ReflectionMethod($frame['class'], '__call');

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -30,7 +30,7 @@ class TransactionStack
     public function peek()
     {
         $len = count($this->stack);
-        if ($len === 0) {
+        if (0 === $len) {
             return null;
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1153,7 +1153,7 @@ class ClientTest extends TestCase
 
     private function subTestGettersAndSettersDatum(\Raven\Client $client, $datum)
     {
-        if (count($datum) == 3) {
+        if (3 == count($datum)) {
             list($property_name, $function_name, $value_in) = $datum;
             $value_out = $value_in;
         } else {
@@ -1192,9 +1192,9 @@ class ClientTest extends TestCase
     {
         if (null === $expected_value) {
             $this->assertNull($actual_value);
-        } elseif ($expected_value === true) {
+        } elseif (true === $expected_value) {
             $this->assertTrue($actual_value);
-        } elseif ($expected_value === false) {
+        } elseif (false === $expected_value) {
             $this->assertFalse($actual_value);
         } elseif (is_string($expected_value) or is_int($expected_value) or is_float($expected_value)) {
             $this->assertEquals($expected_value, $actual_value);
@@ -1299,7 +1299,7 @@ class ClientTest extends TestCase
 
     public function testRegisterDefaultBreadcrumbHandlers()
     {
-        if (isset($_ENV['HHVM']) and ($_ENV['HHVM'] == 1)) {
+        if (isset($_ENV['HHVM']) and (1 == $_ENV['HHVM'])) {
             $this->markTestSkipped('HHVM stacktrace behaviour');
 
             return;
@@ -1673,6 +1673,26 @@ class ClientTest extends TestCase
         $this->assertFalse($client->getSerializer()->getAllObjectSerialize());
         $this->assertFalse($client->getReprSerializer()->getAllObjectSerialize());
     }
+
+    public function testClearBreadcrumb()
+    {
+        $client = ClientBuilder::create()->getClient();
+        $client->leaveBreadcrumb(
+            new \Raven\Breadcrumbs\Breadcrumb(
+                'warning', \Raven\Breadcrumbs\Breadcrumb::TYPE_ERROR, 'error_reporting', 'message', [
+                    'code' => 127,
+                    'line' => 10,
+                    'file' => '/tmp/delme.php',
+                ]
+            )
+        );
+        $reflection = new \ReflectionProperty($client, 'recorder');
+        $reflection->setAccessible(true);
+        $this->assertNotEmpty(iterator_to_array($reflection->getValue($client)));
+
+        $client->clearBreadcrumbs();
+        $this->assertEmpty(iterator_to_array($reflection->getValue($client)));
+    }
 }
 
 class PromiseMock implements Promise
@@ -1712,20 +1732,18 @@ class PromiseMock implements Promise
     public function wait($unwrap = true)
     {
         switch ($this->state) {
-            case self::FULFILLED: {
+            case self::FULFILLED:
                 foreach ($this->onFullfilledCallbacks as $onFullfilledCallback) {
                     $onFullfilledCallback($this->result);
                 }
 
                 break;
-            }
-            case self::REJECTED: {
+            case self::REJECTED:
                 foreach ($this->onRejectedCallbacks as $onRejectedCallback) {
                     $onRejectedCallback($this->result);
                 }
 
                 break;
-            }
         }
 
         if ($unwrap) {


### PR DESCRIPTION
https://github.com/getsentry/sentry-php/pull/504

When a native php function has been disabled via disabled_functions (php.ini) calling getParameters() on the reflection object of the disabled function causes a segmentation fault on PHP 5.6.31.

Reproducible on both Arch Linux and CentOS 6 with the following script:

php.ini
```
disable_functions = "passthru"
```

console.php
 ```php
<?php

require_once 'vendor/autoload.php';

use Raven_Client;

$connection = false;
$client = new Raven_Client($connection);
$client->environment = 'test';
$client->install();

passthru('clear');
```

Run straight through either php or php-cli `php56 console.php` gives a segmentation fault as follows:
```
[1]    22373 segmentation fault (core dumped)  php56 console.php
```

Testing through php 7 does not segfault and reflection seems to be able to cope with the disabled function:

```
PHP Warning:  passthru() has been disabled for security reasons in /home/kandrews/NetBeansProjects/compareandrecycle.co.uk/console.php on line 12
PHP Stack trace:
PHP   1. {main}() /home/kandrews/NetBeansProjects/compareandrecycle.co.uk/console.php:0
PHP   2. passthru() /home/kandrews/NetBeansProjects/compareandrecycle.co.uk/console.php:12
```

