### PR TITLE
Use namespaced TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.8.0",
-        "phpunit/phpunit": "^4.8 || ^5.0",
+        "phpunit/phpunit": "^4.8.35 || ^5.7",
         "monolog/monolog": "*"
     },
     "require": {

--- a/test/Raven/Tests/Breadcrumbs/ErrorHandlerTest.php
+++ b/test/Raven/Tests/Breadcrumbs/ErrorHandlerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_ErrorHandlerBreadcrumbHandlerTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_ErrorHandlerBreadcrumbHandlerTest extends \PHPUnit\Framework\TestCase
 {
     public function testSimple()
     {

--- a/test/Raven/Tests/Breadcrumbs/MonologTest.php
+++ b/test/Raven/Tests/Breadcrumbs/MonologTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_MonologBreadcrumbHandlerTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_MonologBreadcrumbHandlerTest extends \PHPUnit\Framework\TestCase
 {
     protected function getSampleErrorMessage()
     {

--- a/test/Raven/Tests/BreadcrumbsTest.php
+++ b/test/Raven/Tests/BreadcrumbsTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_BreadcrumbsTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_BreadcrumbsTest extends \PHPUnit\Framework\TestCase
 {
     public function testBuffer()
     {

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -205,7 +205,7 @@ class Dummy_Raven_CurlHandler extends Raven_CurlHandler
     }
 }
 
-class Raven_Tests_ClientTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/test/Raven/Tests/CompatTest.php
+++ b/test/Raven/Tests/CompatTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_CompatTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_CompatTest extends \PHPUnit\Framework\TestCase
 {
     public function test_gethostname()
     {

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_ErrorHandlerTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_ErrorHandlerTest extends \PHPUnit\Framework\TestCase
 {
     private $errorLevel;
     private $errorHandlerCalled;

--- a/test/Raven/Tests/IntegrationTest.php
+++ b/test/Raven/Tests/IntegrationTest.php
@@ -34,7 +34,7 @@ class DummyIntegration_Raven_Client extends Raven_Client
     }
 }
 
-class Raven_Tests_IntegrationTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_IntegrationTest extends \PHPUnit\Framework\TestCase
 {
     private function create_chained_exception()
     {

--- a/test/Raven/Tests/Processor/RemoveCookiesProcessorTest.php
+++ b/test/Raven/Tests/Processor/RemoveCookiesProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_RemoveCookiesProcessorTest extends \PHPUnit_Framework_TestCase
+class Raven_Tests_RemoveCookiesProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Raven_Processor_RemoveCookiesProcessor|\PHPUnit_Framework_MockObject_MockObject

--- a/test/Raven/Tests/Processor/RemoveHttpBodyProcessorTest.php
+++ b/test/Raven/Tests/Processor/RemoveHttpBodyProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_RemoveHttpBodyProcessorTest extends \PHPUnit_Framework_TestCase
+class Raven_Tests_RemoveHttpBodyProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Raven_Processor_RemoveHttpBodyProcessor|\PHPUnit_Framework_MockObject_MockObject

--- a/test/Raven/Tests/Processor/SanitizeDataProcessorTest.php
+++ b/test/Raven/Tests/Processor/SanitizeDataProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_SanitizeDataProcessorTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_SanitizeDataProcessorTest extends \PHPUnit\Framework\TestCase
 {
     public function testDoesFilterHttpData()
     {

--- a/test/Raven/Tests/Processor/SanitizeHttpHeadersProcessorTest.php
+++ b/test/Raven/Tests/Processor/SanitizeHttpHeadersProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_SanitizeHttpHeadersProcessorTest extends \PHPUnit_Framework_TestCase
+class Raven_SanitizeHttpHeadersProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Raven_Processor_SanitizeHttpHeadersProcessor|\PHPUnit_Framework_MockObject_MockObject

--- a/test/Raven/Tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/test/Raven/Tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_SanitizeStacktraceProcessorTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_SanitizeStacktraceProcessorTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Raven_Client|PHPUnit_Framework_MockObject_MockObject

--- a/test/Raven/Tests/ReprSerializerTest.php
+++ b/test/Raven/Tests/ReprSerializerTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-class Raven_Tests_ReprSerializerTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_ReprSerializerTest extends \PHPUnit\Framework\TestCase
 {
     public function testArraysAreArrays()
     {

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -14,7 +14,7 @@ class Raven_SerializerTestObject
     private $foo = 'bar';
 }
 
-class Raven_Tests_SerializerTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
 {
     public function testArraysAreArrays()
     {

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -24,7 +24,7 @@ function raven_test_create_stacktrace($args=null, $times=3)
     return raven_test_recurse($times, 'debug_backtrace');
 }
 
-class Raven_Tests_StacktraceTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_StacktraceTest extends \PHPUnit\Framework\TestCase
 {
     public function testCanTraceParamContext()
     {

--- a/test/Raven/Tests/TransactionStackTest.php
+++ b/test/Raven/Tests/TransactionStackTest.php
@@ -10,7 +10,7 @@
  */
 
 
-class Raven_Tests_TransactionStackTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_TransactionStackTest extends \PHPUnit\Framework\TestCase
 {
     public function testSimple()
     {

--- a/test/Raven/Tests/UtilTest.php
+++ b/test/Raven/Tests/UtilTest.php
@@ -14,7 +14,7 @@ class Raven_StacktraceTestObject
     private $foo = 'bar';
 }
 
-class Raven_Tests_UtilTest extends PHPUnit_Framework_TestCase
+class Raven_Tests_UtilTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetReturnsDefaultOnMissing()
     {


### PR DESCRIPTION
This PR add PHPUnit forward compatibility layer. Now all tests extend from namespaced PHPUnit `TestCase`.