### PR TITLE
remove suggestion of : immobiliare/sentry-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "ext-hash": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "immobiliare/sentry-php": "Fork that fixes support for PHP 5.2",
         "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
     },
     "conflict": {


### PR DESCRIPTION
Hello,

so basically, if we managed to install via composer require, means we have PHP >= 5.3
then we don't need to suggest installing this?

Or am I missing something obvious