### PR TITLE
Do not capture E_ERROR type as fatal error

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -561,10 +561,10 @@ class Raven_Client
     /**
      * Log an exception to sentry
      *
-     * @param Exception $exception The Exception object.
-     * @param array     $data      Additional attributes to pass with this event (see Sentry docs).
-     * @param mixed     $logger
-     * @param mixed     $vars
+     * @param \Throwable|\Exception $exception The Throwable/Exception object.
+     * @param array                 $data      Additional attributes to pass with this event (see Sentry docs).
+     * @param mixed                 $logger
+     * @param mixed                 $vars
      * @return string|null
      */
     public function captureException($exception, $data = null, $logger = null, $vars = null)

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -569,7 +569,7 @@ class Raven_Client
      */
     public function captureException($exception, $data = null, $logger = null, $vars = null)
     {
-        $has_chained_exceptions = version_compare(PHP_VERSION, '5.3.0', '>=');
+        $has_chained_exceptions = PHP_VERSION_ID >= 50300;
 
         if (in_array(get_class($exception), $this->exclude)) {
             return null;
@@ -1328,7 +1328,7 @@ class Raven_Client
             case E_STRICT:             return Raven_Client::INFO;
             case E_RECOVERABLE_ERROR:  return Raven_Client::ERROR;
         }
-        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+        if (PHP_VERSION_ID >= 50300) {
             switch ($severity) {
             case E_DEPRECATED:         return Raven_Client::WARN;
             case E_USER_DEPRECATED:    return Raven_Client::WARN;

--- a/lib/Raven/Compat.php
+++ b/lib/Raven/Compat.php
@@ -81,9 +81,9 @@ class Raven_Compat
     public static function json_encode($value, $options = 0, $depth = 512)
     {
         if (function_exists('json_encode')) {
-            if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+            if (PHP_VERSION_ID < 50300) {
                 return json_encode($value);
-            } elseif (version_compare(PHP_VERSION, '5.5.0', '<')) {
+            } elseif (PHP_VERSION_ID < 50500) {
                 return json_encode($value, $options);
             } else {
                 return json_encode($value, $options, $depth);

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -140,6 +140,13 @@ class Raven_ErrorHandler
 
     public function shouldCaptureFatalError($type)
     {
+        // Do not capture E_ERROR since those can be caught by userland since PHP 7.0
+        // E_ERROR should already be handled by the exception handler
+        // This prevents duplicated exceptions in PHP 7.0+
+        if (version_compare(phpversion(), '7.0', '>=') && $type === E_ERROR) {
+            return false;
+        }
+
         return $type & $this->fatal_error_types;
     }
 

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -143,7 +143,7 @@ class Raven_ErrorHandler
         // Do not capture E_ERROR since those can be caught by userland since PHP 7.0
         // E_ERROR should already be handled by the exception handler
         // This prevents duplicated exceptions in PHP 7.0+
-        if (version_compare(phpversion(), '7.0', '>=') && $type === E_ERROR) {
+        if (PHP_VERSION_ID >= 70000 && $type === E_ERROR) {
             return false;
         }
 

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -586,7 +586,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testCaptureExceptionChainedException()
     {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+        if (PHP_VERSION_ID < 50300) {
             $this->markTestSkipped('PHP 5.3 required for chained exceptions.');
         }
 
@@ -610,7 +610,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testCaptureExceptionDifferentLevelsInChainedExceptionsBug()
     {
-        if (version_compare(PHP_VERSION, '5.3.0', '<')) {
+        if (PHP_VERSION_ID < 50300) {
             $this->markTestSkipped('PHP 5.3 required for chained exceptions.');
         }
 
@@ -1600,7 +1600,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $predefined = array(E_ERROR, E_WARNING, E_PARSE, E_NOTICE, E_CORE_ERROR, E_CORE_WARNING,
                        E_COMPILE_ERROR, E_COMPILE_WARNING, E_USER_ERROR, E_USER_WARNING,
                        E_USER_NOTICE, E_STRICT, E_RECOVERABLE_ERROR, );
-        if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
+        if (PHP_VERSION_ID >= 50300) {
             $predefined[] = E_DEPRECATED;
             $predefined[] = E_USER_DEPRECATED;
         }
@@ -1769,7 +1769,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
             $data_broken = array($data_broken);
         }
         $value = $client->encode($data_broken);
-        if (!function_exists('json_encode') or version_compare(PHP_VERSION, '5.5.0', '>=')) {
+        if (!function_exists('json_encode') or PHP_VERSION_ID >= 50500) {
             $this->assertFalse($value, 'Broken data encoded successfully with '.
                 (function_exists('json_encode') ? 'native method' : 'Raven_Compat::_json_encode'));
         } else {
@@ -1817,11 +1817,9 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $debug_backtrace = $this->_debug_backtrace;
         set_error_handler($previous, E_ALL);
         $this->assertTrue($u);
-        if (isset($debug_backtrace[1]['function']) and ($debug_backtrace[1]['function'] == 'call_user_func')
-            and version_compare(PHP_VERSION, '7.0', '>=')
-        ) {
+        if (isset($debug_backtrace[1]['function']) and ($debug_backtrace[1]['function'] == 'call_user_func') and PHP_VERSION_ID >= 70000) {
             $offset = 2;
-        } elseif (version_compare(PHP_VERSION, '7.0', '>=')) {
+        } elseif (PHP_VERSION_ID >= 70000) {
             $offset = 1;
         } else {
             $offset = 2;
@@ -2048,7 +2046,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
      */
     public function testGet_user_data_step2()
     {
-        if (version_compare(PHP_VERSION, '7.1.999', '>')) {
+        if (PHP_VERSION_ID >= 70200) {
             /**
              * @doc https://3v4l.org/OVbja
              * @doc https://3v4l.org/uT00O

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -207,7 +207,7 @@ class Raven_Tests_ErrorHandlerTest extends \PHPUnit\Framework\TestCase
                        ->getMock();
         $handler = new Raven_ErrorHandler($client);
 
-        $this->assertEquals($handler->shouldCaptureFatalError(E_ERROR), true);
+        $this->assertEquals($handler->shouldCaptureFatalError(E_ERROR), !version_compare(phpversion(), '7.0', '>='));
 
         $this->assertEquals($handler->shouldCaptureFatalError(E_WARNING), false);
     }

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -207,7 +207,7 @@ class Raven_Tests_ErrorHandlerTest extends \PHPUnit\Framework\TestCase
                        ->getMock();
         $handler = new Raven_ErrorHandler($client);
 
-        $this->assertEquals($handler->shouldCaptureFatalError(E_ERROR), !version_compare(phpversion(), '7.0', '>='));
+        $this->assertEquals($handler->shouldCaptureFatalError(E_ERROR), PHP_VERSION_ID < 70000);
 
         $this->assertEquals($handler->shouldCaptureFatalError(E_WARNING), false);
     }

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -124,7 +124,7 @@ class Raven_Tests_StacktraceTest extends \PHPUnit\Framework\TestCase
         // just grab the last few frames
         $frames = array_slice($frames, -6);
         $skip_call_user_func_fix = false;
-        if (version_compare(PHP_VERSION, '7.0', '>=')) {
+        if (PHP_VERSION_ID >= 70000) {
             $skip_call_user_func_fix = true;
             foreach ($frames as &$frame) {
                 if (isset($frame['function']) and ($frame['function'] == 'call_user_func')) {


### PR DESCRIPTION
This should fix #408, can you guys please test it and and let me know if this is the way we should handle this or an alternative. 

IMO this gist is that we should ignore E_ERROR exceptions as fatal in PHP 7.0+ since they can be captured by userland and are thus going through the regular exception handler before entering the fatal error handler thus creating duplicated exceptions.

This PR as a side effect also unifies the way the PHP version is checked.