### PR TITLE
Fix SENTRY_DSN handling with nullable values

### DIFF
--- a/bin/sentry
+++ b/bin/sentry
@@ -21,13 +21,11 @@ function raven_cli_test($command, $args)
 
 function cmd_test($dsn)
 {
-    if (empty($dsn)) {
-        exit('ERROR: Missing DSN value');
-    }
-
     // Parse DSN as a test
     try {
-        $parsed = Raven_Client::parseDSN($dsn);
+        if (empty(Raven_Client::parseDSN($dsn))) {
+            exit('ERROR: Missing DSN value');
+        }
     } catch (InvalidArgumentException $ex) {
         exit("ERROR: There was an error parsing your DSN:\n  " . $ex->getMessage());
     }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -137,7 +137,7 @@ class Raven_Client
         if (!is_array($options_or_dsn) && !empty($options_or_dsn)) {
             $dsn = $options_or_dsn;
         } elseif (!empty($_SERVER['SENTRY_DSN'])) {
-                $dsn = @$_SERVER['SENTRY_DSN'];
+            $dsn = @$_SERVER['SENTRY_DSN'];
         } elseif (!empty($options['dsn'])) {
             $dsn = $options['dsn'];
         } else {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -137,11 +137,7 @@ class Raven_Client
         if (!is_array($options_or_dsn) && !empty($options_or_dsn)) {
             $dsn = $options_or_dsn;
         } elseif (!empty($_SERVER['SENTRY_DSN'])) {
-            if (strtolower($_SERVER['SENTRY_DSN']) == 'false' || strtolower($_SERVER['SENTRY_DSN']) == 'null') {
-                $dsn = null;
-            } else {
                 $dsn = @$_SERVER['SENTRY_DSN'];
-            }
         } elseif (!empty($options['dsn'])) {
             $dsn = $options['dsn'];
         } else {
@@ -445,6 +441,17 @@ class Raven_Client
      */
     public static function parseDSN($dsn)
     {
+        switch (strtolower($dsn)) {
+            case '':
+            case 'false':
+            case '(false)':
+            case 'empty':
+            case '(empty)':
+            case 'null':
+            case '(null)':
+                return array();
+        }
+
         $url = parse_url($dsn);
         $scheme = (isset($url['scheme']) ? $url['scheme'] : '');
         if (!in_array($scheme, array('http', 'https'))) {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -137,7 +137,12 @@ class Raven_Client
         if (!is_array($options_or_dsn) && !empty($options_or_dsn)) {
             $dsn = $options_or_dsn;
         } elseif (!empty($_SERVER['SENTRY_DSN'])) {
-            $dsn = @$_SERVER['SENTRY_DSN'];
+            if (strtolower($_SERVER['SENTRY_DSN']) == 'false' || strtolower($_SERVER['SENTRY_DSN']) == 'null' ) {
+                $dsn = null;
+            }
+            else {
+                $dsn = @$_SERVER['SENTRY_DSN'];
+            }
         } elseif (!empty($options['dsn'])) {
             $dsn = $options['dsn'];
         } else {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -137,10 +137,9 @@ class Raven_Client
         if (!is_array($options_or_dsn) && !empty($options_or_dsn)) {
             $dsn = $options_or_dsn;
         } elseif (!empty($_SERVER['SENTRY_DSN'])) {
-            if (strtolower($_SERVER['SENTRY_DSN']) == 'false' || strtolower($_SERVER['SENTRY_DSN']) == 'null' ) {
+            if (strtolower($_SERVER['SENTRY_DSN']) == 'false' || strtolower($_SERVER['SENTRY_DSN']) == 'null') {
                 $dsn = null;
-            }
-            else {
+            } else {
                 $dsn = @$_SERVER['SENTRY_DSN'];
             }
         } elseif (!empty($options['dsn'])) {

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -237,40 +237,25 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function testParseDSNWithNull()
+    /**
+     * @dataProvider disabledDsnProvider
+     */
+    public function testParseDSNWithDisabledValue($dsn)
     {
-        $result = Raven_Client::parseDSN(null);
+        $result = Raven_Client::parseDSN($dsn);
         $this->assertEmpty($result);
     }
 
-    public function testParseDSNWithNullAsString()
+    public function disabledDsnProvider()
     {
-        $result = Raven_Client::parseDSN("null");
-        $this->assertEmpty($result);
-    }
-
-    public function testParseDSNWithFalse()
-    {
-        $result = Raven_Client::parseDSN(false);
-        $this->assertEmpty($result);
-    }
-
-    public function testParseDSNWithFalseAsString()
-    {
-        $result = Raven_Client::parseDSN("false");
-        $this->assertEmpty($result);
-    }
-
-    public function testParseDSNWithEmptyString()
-    {
-        $result = Raven_Client::parseDSN("");
-        $this->assertEmpty($result);
-    }
-
-    public function testParseDSNWithEmptyAsString()
-    {
-        $result = Raven_Client::parseDSN("empty");
-        $this->assertEmpty($result);
+        return array(
+            array(null),
+            array('null'),
+            array(false),
+            array('false'),
+            array(''),
+            array('empty'),
+        );
     }
 
     public function testParseDSNHttp()

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -237,6 +237,42 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         }
     }
 
+    public function testParseDSNWithNull()
+    {
+        $result = Raven_Client::parseDSN(null);
+        $this->assertEmpty($result);
+    }
+
+    public function testParseDSNWithNullAsString()
+    {
+        $result = Raven_Client::parseDSN("null");
+        $this->assertEmpty($result);
+    }
+
+    public function testParseDSNWithFalse()
+    {
+        $result = Raven_Client::parseDSN(false);
+        $this->assertEmpty($result);
+    }
+
+    public function testParseDSNWithFalseAsString()
+    {
+        $result = Raven_Client::parseDSN("false");
+        $this->assertEmpty($result);
+    }
+
+    public function testParseDSNWithEmptyString()
+    {
+        $result = Raven_Client::parseDSN("");
+        $this->assertEmpty($result);
+    }
+
+    public function testParseDSNWithEmptyAsString()
+    {
+        $result = Raven_Client::parseDSN("empty");
+        $this->assertEmpty($result);
+    }
+
     public function testParseDSNHttp()
     {
         $result = Raven_Client::ParseDSN('http://public:secret@example.com/1');


### PR DESCRIPTION
I will assume that when reading options for `Raven\Client` you want `$_SERVER` variable to overwrite any settings from config for example.

In laravel's case, we have a small issue. When reading the `.env` file laravel puts anything it finds there in `$_SERVER` as `strings`

If i write a proper `SENTRY_DSN` in `.env` file or if i leave it empty, everything is fine. But if i write `SENTRY_DSN=false` or `SENTRY_DSN=null`  in the .env file, my app will crash.

`$options` has dsn with a correct value of `null` or `false`, however it's overwritten by `$_SERVER['SENTRY_DSN']` which is `"false"` or `"null"` (as strings). This causes the `Raven_Client::parseDSN($dsn)`; to fail

In this PR before assigning `$dsn = @$_SERVER['SENTRY_DSN]` i check if `$_SERVER['SENTRY_DSN]` contains `"false"` or `"null"` and if so, i assign `$dsn = null`.

This makes laravel not crash anymore.
