### PR TITLE
[2.0][rebased] Prevent segmentation fault in Reflection->getParameters()

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -364,8 +364,10 @@ class Stacktrace implements \JsonSerializable
                 } else {
                     $reflection = new \ReflectionMethod($frame['class'], '__call');
                 }
-            } else {
+            } elseif (function_exists($frame['function'])) {
                 $reflection = new \ReflectionFunction($frame['function']);
+            } else {
+                return self::getFrameArgumentsValues($frame, $maxValueLength);
             }
         } catch (\ReflectionException $ex) {
             return self::getFrameArgumentsValues($frame, $maxValueLength);


### PR DESCRIPTION
This is the rebased version of #505, which is te porting of #504 to the 2.0 branch.