### PR TITLE
default value for array should be array

### DIFF
--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -35,8 +35,8 @@ class Raven_Stacktrace
          */
         $result = array();
         for ($i = 0; $i < count($frames); $i++) {
-            $frame = isset($frames[$i]) ? $frames[$i] : null;
-            $nextframe = isset($frames[$i + 1]) ? $frames[$i + 1] : null;
+            $frame = isset($frames[$i]) ? $frames[$i] : array();
+            $nextframe = isset($frames[$i + 1]) ? $frames[$i + 1] : array();
 
             if (!array_key_exists('file', $frame)) {
                 $context = array();

--- a/lib/Raven/Stacktrace.php
+++ b/lib/Raven/Stacktrace.php
@@ -50,8 +50,10 @@ class Raven_Stacktrace
                     } catch (ReflectionException $e) {
                         // Forget it if we run into errors, it's not worth it.
                     }
-                } else {
+                } elseif (!empty($frame['function'])) {
                     $context['line'] = sprintf('%s(anonymous)', $frame['function']);
+                } else {
+                    $context['line'] = sprintf('(anonymous)');
                 }
 
                 if (empty($context['filename'])) {

--- a/test/Raven/Tests/StacktraceTest.php
+++ b/test/Raven/Tests/StacktraceTest.php
@@ -192,6 +192,20 @@ class Raven_Tests_StacktraceTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($frames[0]['in_app'], false);
     }
 
+    public function testInAppWithEmptyFrame()
+    {
+        $stack = array(
+            array(
+                "function" => "{closure}",
+            ),
+            null
+        );
+
+        $frames = Raven_Stacktrace::get_stack_info($stack, true, null, 0, null, dirname(__FILE__));
+
+        $this->assertEquals($frames[0]['in_app'], false);
+    }
+
     public function testInAppWithExclusion()
     {
         $stack = array(


### PR DESCRIPTION
Thix Fix notice  array_key_exists() expects parameter 2 to be array, null given

This fix should be added to 1.8 and 2.0 branches 