### PR TITLE
Fix POST data from http request for non-multipart/form-data enctype o…

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -746,8 +746,13 @@ class Raven_Client
 
         // dont set this as an empty array as PHP will treat it as a numeric array
         // instead of a mapping which goes against the defined Sentry spec
-        if (!empty($_POST)) {
+        if (PHP_VERSION_ID < 50600 && !empty($_POST)) {
             $result['data'] = $_POST;
+        } else {
+            $result['data'] = file_get_contents("php://input");
+            if (!empty($_POST)) {
+                $result['POST'] = $_POST;
+            }
         }
         if (!empty($_COOKIE)) {
             $result['cookies'] = $_COOKIE;

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -824,8 +824,8 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         );
 
         if (PHP_VERSION_ID < 50600) {
-             $expected['request']['data'] = $expected['request']['POST'];
-             unset($expected['request']['POST']);
+            $expected['request']['data'] = $expected['request']['POST'];
+            unset($expected['request']['POST']);
         }
 
         $client = new Dummy_Raven_Client();

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -805,9 +805,10 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 'method' => 'PATCH',
                 'url' => 'https://getsentry.com/welcome/',
                 'query_string' => 'q=bitch&l=en',
-                'data' => array(
+                'POST' => array(
                     'stamp'           => '1c',
                 ),
+                'data' => '',
                 'cookies' => array(
                     'donut'           => 'chocolat',
                 ),
@@ -821,6 +822,11 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 ),
             )
         );
+
+        if (PHP_VERSION_ID < 50600) {
+             $expected['request']['data'] = $expected['request']['POST'];
+             unset($expected['request']['POST']);
+        }
 
         $client = new Dummy_Raven_Client();
         $this->assertEquals($expected, $client->get_http_data());


### PR DESCRIPTION
POST data is broken if logging non-multipart/formdata requests , because PHP try to parse it as multipart/formdata
To fix this issue we need to pass raw POST data to sentry. But php://input is readable only once at PHP<5.6, so we need to write a condition for this case