### PR TITLE
[2.0] Make the behaviour of the RemoveCookiesProcessor configurable

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -350,3 +350,9 @@
 
   $client = ClientBuilder::create([...])->getClient();
   ```
+
+### Processors
+
+- The `RemoveCookiesProessor` class has been renamed to `SanitizeCookiesProcessor` to
+  better reflect its purpose. The constructor accepts an array of options to make the
+  behaviour of which cookies to sanitize configurable.

--- a/lib/Raven/ClientBuilder.php
+++ b/lib/Raven/ClientBuilder.php
@@ -26,8 +26,8 @@ use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Raven\HttpClient\Authentication\SentryAuth;
 use Raven\Processor\ProcessorInterface;
-use Raven\Processor\RemoveCookiesProcessor;
 use Raven\Processor\RemoveHttpBodyProcessor;
+use Raven\Processor\SanitizeCookiesProcessor;
 use Raven\Processor\SanitizeDataProcessor;
 use Raven\Processor\SanitizeHttpHeadersProcessor;
 
@@ -287,7 +287,7 @@ final class ClientBuilder implements ClientBuilderInterface
     private static function getDefaultProcessors()
     {
         return [
-            [new RemoveCookiesProcessor(), 0],
+            [new SanitizeCookiesProcessor(), 0],
             [new RemoveHttpBodyProcessor(), 0],
             [new SanitizeHttpHeadersProcessor(), 0],
             [new SanitizeDataProcessor(), -255],

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -43,6 +43,7 @@ class RequestInterfaceMiddleware
             'url' => (string) $request->getUri(),
             'method' => $request->getMethod(),
             'headers' => $request->getHeaders(),
+            'cookies' => $request->getCookieParams(),
         ];
 
         if ('' !== $request->getUri()->getQuery()) {

--- a/lib/Raven/Processor/RemoveCookiesProcessor.php
+++ b/lib/Raven/Processor/RemoveCookiesProcessor.php
@@ -12,6 +12,7 @@
 namespace Raven\Processor;
 
 use Raven\Event;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * This processor removes all the cookies from the request to ensure no sensitive
@@ -22,6 +23,25 @@ use Raven\Event;
 final class RemoveCookiesProcessor implements ProcessorInterface
 {
     /**
+     * @var array The configuration options
+     */
+    private $options;
+
+    /**
+     * Class constructor.
+     *
+     * @param array $options An optional array of configuration options
+     */
+    public function __construct(array $options = [])
+    {
+        $resolver = new OptionsResolver();
+
+        $this->configureOptions($resolver);
+
+        $this->options = $resolver->resolve($options);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function process(Event $event)
@@ -29,13 +49,29 @@ final class RemoveCookiesProcessor implements ProcessorInterface
         $request = $event->getRequest();
 
         if (isset($request['cookies'])) {
-            $request['cookies'] = self::STRING_MASK;
+            foreach ($request['cookies'] as $name => $value) {
+                $request['cookies'][$name] = self::STRING_MASK;
+            }
         }
 
-        if (isset($request['headers'], $request['headers']['cookie'])) {
-            $request['headers']['cookie'] = self::STRING_MASK;
-        }
+        unset($request['headers']['cookie']);
 
         return $event->withRequest($request);
+    }
+
+    /**
+     * Configures the options for this processor.
+     *
+     * @param OptionsResolver $resolver The resolver for the options
+     */
+    private function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'include' => [],
+            'exclude' => [],
+        ]);
+
+        $resolver->setAllowedTypes('include', 'array');
+        $resolver->setAllowedTypes('exclude', 'array');
     }
 }

--- a/lib/Raven/Processor/SanitizeCookiesProcessor.php
+++ b/lib/Raven/Processor/SanitizeCookiesProcessor.php
@@ -16,12 +16,12 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * This processor removes all the cookies from the request to ensure no sensitive
- * informations are sent to the server.
+ * This processor sanitizes the cookies to ensure no sensitive information are
+ * sent to the server.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class RemoveCookiesProcessor implements ProcessorInterface
+final class SanitizeCookiesProcessor implements ProcessorInterface
 {
     /**
      * @var array The configuration options

--- a/tests/Middleware/RequestInterfaceMiddlewareTest.php
+++ b/tests/Middleware/RequestInterfaceMiddlewareTest.php
@@ -50,6 +50,7 @@ class RequestInterfaceMiddlewareTest extends TestCase
         $request = new ServerRequest();
         $request = $request->withUri(new Uri($requestData['uri']));
         $request = $request->withMethod($requestData['method']);
+        $request = $request->withCookieParams($requestData['cookies']);
 
         foreach ($requestData['headers'] as $name => $value) {
             $request = $request->withHeader($name, $value);
@@ -76,11 +77,17 @@ class RequestInterfaceMiddlewareTest extends TestCase
                 [
                     'uri' => 'http://www.example.com/foo',
                     'method' => 'GET',
+                    'cookies' => [
+                        'foo' => 'bar',
+                    ],
                     'headers' => [],
                 ],
                 [
                     'url' => 'http://www.example.com/foo',
                     'method' => 'GET',
+                    'cookies' => [
+                        'foo' => 'bar',
+                    ],
                     'headers' => [
                         'Host' => ['www.example.com'],
                     ],
@@ -90,6 +97,7 @@ class RequestInterfaceMiddlewareTest extends TestCase
                 [
                     'uri' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',
+                    'cookies' => [],
                     'headers' => [
                         'Host' => ['www.example.com'],
                         'REMOTE_ADDR' => ['127.0.0.1'],
@@ -99,6 +107,7 @@ class RequestInterfaceMiddlewareTest extends TestCase
                     'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',
                     'query_string' => 'foo=bar&bar=baz',
+                    'cookies' => [],
                     'headers' => [
                         'Host' => ['www.example.com'],
                         'REMOTE_ADDR' => ['127.0.0.1'],

--- a/tests/Processor/RemoveCookiesProcessorTest.php
+++ b/tests/Processor/RemoveCookiesProcessorTest.php
@@ -54,7 +54,9 @@ class RemoveCookiesProcessorTest extends TestCase
             [
                 [
                     'foo' => 'bar',
-                    'cookies' => 'baz',
+                    'cookies' => [
+                        'foo' => 'bar',
+                    ],
                     'headers' => [
                         'cookie' => 'bar',
                         'another-header' => 'foo',
@@ -62,9 +64,10 @@ class RemoveCookiesProcessorTest extends TestCase
                 ],
                 [
                     'foo' => 'bar',
-                    'cookies' => RemoveCookiesProcessor::STRING_MASK,
+                    'cookies' => [
+                        'foo' => RemoveCookiesProcessor::STRING_MASK,
+                    ],
                     'headers' => [
-                        'cookie' => RemoveCookiesProcessor::STRING_MASK,
                         'another-header' => 'foo',
                     ],
                 ],

--- a/tests/Processor/SanitizeCookiesProcessorTest.php
+++ b/tests/Processor/SanitizeCookiesProcessorTest.php
@@ -15,9 +15,9 @@ use PHPUnit\Framework\TestCase;
 use Raven\Client;
 use Raven\ClientBuilder;
 use Raven\Event;
-use Raven\Processor\RemoveCookiesProcessor;
+use Raven\Processor\SanitizeCookiesProcessor;
 
-class RemoveCookiesProcessorTest extends TestCase
+class SanitizeCookiesProcessorTest extends TestCase
 {
     /**
      * @var Client
@@ -35,7 +35,7 @@ class RemoveCookiesProcessorTest extends TestCase
      */
     public function testConstructorThrowsIfBothOnlyAndExceptOptionsAreSet()
     {
-        new RemoveCookiesProcessor([
+        new SanitizeCookiesProcessor([
             'only' => ['foo'],
             'except' => ['bar'],
         ]);
@@ -59,10 +59,13 @@ class RemoveCookiesProcessorTest extends TestCase
             ],
         ]);
 
-        $processor = new RemoveCookiesProcessor($options);
+        $processor = new SanitizeCookiesProcessor($options);
         $event = $processor->process($event);
 
-        $this->assertArraySubset($expectedData, $event->getRequest());
+        $requestData = $event->getRequest();
+
+        $this->assertArraySubset($expectedData, $requestData);
+        $this->assertArrayNotHasKey('cookie', $requestData['headers']);
     }
 
     public function processDataProvider()
@@ -73,8 +76,8 @@ class RemoveCookiesProcessorTest extends TestCase
                 [
                     'foo' => 'bar',
                     'cookies' => [
-                        'foo' => RemoveCookiesProcessor::STRING_MASK,
-                        'bar' => RemoveCookiesProcessor::STRING_MASK,
+                        'foo' => SanitizeCookiesProcessor::STRING_MASK,
+                        'bar' => SanitizeCookiesProcessor::STRING_MASK,
                     ],
                     'headers' => [
                         'another-header' => 'foo',
@@ -88,7 +91,7 @@ class RemoveCookiesProcessorTest extends TestCase
                 [
                     'foo' => 'bar',
                     'cookies' => [
-                        'foo' => RemoveCookiesProcessor::STRING_MASK,
+                        'foo' => SanitizeCookiesProcessor::STRING_MASK,
                         'bar' => 'foo',
                     ],
                     'headers' => [
@@ -104,7 +107,7 @@ class RemoveCookiesProcessorTest extends TestCase
                     'foo' => 'bar',
                     'cookies' => [
                         'foo' => 'bar',
-                        'bar' => RemoveCookiesProcessor::STRING_MASK,
+                        'bar' => SanitizeCookiesProcessor::STRING_MASK,
                     ],
                     'headers' => [
                         'another-header' => 'foo',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

In PR #406 a processor to sanitize all cookies by replacing their values with a set of asterisks was added. Apart from the naming that I've changed to better reflect what this class really does (it does not remove any cookie, it just sanitizes them), The current result that is shown when looking at an issue in Sentry is something along these lines in Sentry:

Cookie Name | Cookie Value
| ------------- | -------------
******** |

Not really useful, uh? This PR makes the processor configurable a bit. By default it still works as before, but two new options named `only` and `except` are now available and you can't use both of them at the same time. The first one let users choose which cookies should be sanitized while the second one let users choose which cookies should not. To better explain the concept you can find below some examples

- **`only` option and `except` option both configured to `[]` (default behavior)**

  Cookie Name | Cookie Value
  | ------------- | -------------
  foo | ********
  bar | ********

- **`only` option configured to `['foo']`**

  Cookie Name | Cookie Value
  | ------------- | -------------
  foo | ********
  bar | baz

- **`except` option configured to `['foo']`**

  Cookie Name | Cookie Value
  | ------------- | -------------
  foo | baz
  bar | ********