### PR TITLE
Fix gzipCompress function name

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -171,7 +171,7 @@ The following settings are available for the client:
                     'User-Agent'       => $client->getUserAgent(),
                     'X-Sentry-Auth'    => $client->getAuthHeader(),
                 ),
-                'body'    => gzipCompress(jsonEncode($data)),
+                'body'    => gzcompress(jsonEncode($data)),
             ))
         },
 


### PR DESCRIPTION
PHP doesn't have `gzipCompress` function, use `gzcompress` instead
http://php.net/manual/en/function.gzcompress.php