### PR TITLE
Include object string representation in stacktraces if supported.

### DIFF
--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -29,7 +29,11 @@ class Raven_ReprSerializer extends Raven_Serializer
         } elseif (is_integer($value) || is_float($value)) {
             return (string) $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-            return 'Object '.get_class($value);
+            $name = 'Object '.get_class($value);
+            if (method_exists($value, '__toString')) {
+                $name .= ': ' . $value;
+            }
+            return $name;
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {

--- a/test/Raven/Tests/ReprSerializerTest.php
+++ b/test/Raven/Tests/ReprSerializerTest.php
@@ -27,6 +27,13 @@ class Raven_Tests_ReprSerializerTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Object Raven_StacktraceTestObject', $result);
     }
 
+    public function testObjectsAreStringsIncludingOwnRepresentation() {
+        $serializer = new Raven_ReprSerializer();
+        $input = new Raven_StacktraceTestObjectWithStringConversion();
+        $result = $serializer->serialize($input);
+        $this->assertEquals('Object Raven_StacktraceTestObjectWithStringConversion: no foo without a bar', $result);
+    }
+
     public function testIntsAreInts()
     {
         $serializer = new Raven_ReprSerializer();

--- a/test/Raven/Tests/UtilTest.php
+++ b/test/Raven/Tests/UtilTest.php
@@ -14,6 +14,15 @@ class Raven_StacktraceTestObject
     private $foo = 'bar';
 }
 
+class Raven_StacktraceTestObjectWithStringConversion
+{
+    private $foo = 'bar';
+
+    public function __toString() {
+        return 'no foo without a ' . $this->foo;
+    }
+}
+
 class Raven_Tests_UtilTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetReturnsDefaultOnMissing()


### PR DESCRIPTION
This allows more insight into problems, because the class name alone may not suffice.