### PR TITLE
Adding application/json input handling.

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -284,6 +284,10 @@ class Raven_Client
      */
     protected static function getInputStream()
     {
+        if (PHP_VERSION_ID < 50600) {
+            return null;
+        }
+
         return file_get_contents('php://input');
     }
 


### PR DESCRIPTION
References #531
- Added additional unit test for json data.
- PHP input is sanitized through json_decode
- If there is binary or invalid data in the json input the entire payload will be discarded. Could run input through sanitize first?