### PR TITLE
Use correct class name for default processor

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -221,7 +221,7 @@ The following settings are available for the client:
 .. describe:: processors
 
     An array of classes to use to process data before it is sent to
-    Sentry. By default, ``Raven_SanitizeDataProcessor`` is used
+    Sentry. By default, ``Raven_Processor_SanitizeDataProcessor`` is used
 
 .. describe:: processorOptions
 
@@ -230,12 +230,12 @@ The following settings are available for the client:
     the list of processors used by ``Raven_Client``
 
     An example of overriding the regular expressions in
-    ``Raven_SanitizeDataProcessor`` is below:
+    ``Raven_Processor_SanitizeDataProcessor`` is below:
 
     .. code-block:: php
 
         'processorOptions' => array(
-            'Raven_SanitizeDataProcessor' => array(
+            'Raven_Processor_SanitizeDataProcessor' => array(
                         'fields_re' => '/(user_password|user_token|user_secret)/i',
                         'values_re' => '/^(?:\d[ -]*?){15,16}$/'
                     )


### PR DESCRIPTION
In version 1.7.0 the default processor class changed from Raven_SanitizeDataProcessor to Raven_Processor_SanitizeDataProcessor

This means the sample config documentation would be wrong for someone who didn't customize their processors  (i.e. extra fields they were trying to sanitize would not be sanitized)