### PR TITLE
Allow $data['request'] to be 5 levels deep

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -929,7 +929,7 @@ class Raven_Client
     {
         // attempt to sanitize any user provided data
         if (!empty($data['request'])) {
-            $data['request'] = $this->serializer->serialize($data['request']);
+            $data['request'] = $this->serializer->serialize($data['request'], 5);
         }
         if (!empty($data['user'])) {
             $data['user'] = $this->serializer->serialize($data['user'], 3);

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1335,21 +1335,42 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     public function testSanitizeRequest()
     {
         $client = new Dummy_Raven_Client();
-        $data = array('request' => array(
-            'context' => array(
-                'line' => 1216,
-                'stack' => array(
-                    1, array(2), 3
+
+        // Typical content of $_POST in PHP
+        $post = array(
+            '_method' => 'POST',
+            'data' => array(
+                'MyModel' => array(
+                    'flatField' => 'my value',
+                    'nestedField' => array(
+                        'key' => 'my other value',
+                    ),
                 ),
             ),
+        );
+
+        $data = array('request' => array(
+            'method' => 'POST',
+            'url' => 'https://example.com/something',
+            'query_string' => '',
+            'data' => $post,
         ));
+
         $client->sanitize($data);
 
         $this->assertEquals(array('request' => array(
-            'context' => array(
-                'line' => 1216,
-                'stack' => array(
-                    1, 'Array of length 1', 3
+            'method' => 'POST',
+            'url' => 'https://example.com/something',
+            'query_string' => '',
+            'data' => array(
+                '_method' => 'POST',
+                'data' => array(
+                    'MyModel' => array(
+                        'flatField' => 'my value',
+                        'nestedField' => array(
+                            'key' => 'my other value',
+                        ),
+                    ),
                 ),
             ),
         )), $data);

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1379,6 +1379,52 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Raven_Client::sanitize
      */
+    public function testSanitizeDeepRequest()
+    {
+        $client = new Dummy_Raven_Client();
+
+        $post = array(
+            '_method' => 'POST',
+            'data' => array(
+                'Level 1' => array(
+                    'Level 2' => array(
+                        'Level 3' => array(
+                            'Level 4' => 'something',
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $data = array('request' => array(
+            'method' => 'POST',
+            'url' => 'https://example.com/something',
+            'query_string' => '',
+            'data' => $post,
+        ));
+
+        $client->sanitize($data);
+
+        $this->assertEquals(array('request' => array(
+            'method' => 'POST',
+            'url' => 'https://example.com/something',
+            'query_string' => '',
+            'data' => array(
+                '_method' => 'POST',
+                'data' => array(
+                    'Level 1' => array(
+                        'Level 2' => array(
+                            'Level 3' => 'Array of length 1',
+                        ),
+                    ),
+                ),
+            ),
+        )), $data);
+    }
+
+    /**
+     * @covers Raven_Client::sanitize
+     */
     public function testSanitizeContexts()
     {
         $client = new Dummy_Raven_Client();


### PR DESCRIPTION
A normal POST request in a PHP application can be up to 3 levels deep. In `$data['request']` there are 2 additional arrays wrapped around it, so that the serializer removes most of the data. (I added a screenshot to show how that looks in the UI). 

This pull request raises the `max_depth` for the request data to 5. 
I also adjusted the test to use more realistic data so that it's better understandable. 
I added another test so that the truncation is still covered by a test. 

![screenshot from 2018-02-21 21-57-31](https://user-images.githubusercontent.com/1061218/36504892-3f36690a-1752-11e8-99cc-9d5223161308.png)
