### PR TITLE
Cleanup the 'site' value if it's empty

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -881,6 +881,9 @@ class Raven_Client
         if (empty($data['request'])) {
             unset($data['request']);
         }
+        if (empty($data['site'])) {
+            unset($data['site']);
+        }
 
         if (!$this->breadcrumbs->is_empty()) {
             $data['breadcrumbs'] = $this->breadcrumbs->fetch();

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -760,6 +760,21 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Raven_Client::capture
+     */
+    public function testEmptySiteGetsRemoved()
+    {
+        $client = new Dummy_Raven_Client();
+        $client->site = '';
+
+        $client->captureMessage("My message");
+        $events = $client->getSentEvents();
+        $this->assertSame(1, count($events));
+        $event = array_pop($events);
+        $this->assertFalse(array_key_exists('site', $event));
+    }
+
+  /**
      * @covers Raven_Client::__construct
      * @covers Raven_Client::get_default_data
      */


### PR DESCRIPTION
The values `extra`, `tags`, `user`, and `request` get removed if they are empty. 
This pull request does the same for the `site` value. 

I added a screenshot to show how this affects users in the UI:
![screenshot from 2018-02-21 22-16-32](https://user-images.githubusercontent.com/1061218/36505817-f36c0446-1754-11e8-800d-f57ed2e405f4.png)