### PR TITLE
Make it possible to overwrite message limit of 1024

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -46,12 +46,24 @@ class Raven_Serializer
     protected $mb_detect_order = self::DEFAULT_MB_DETECT_ORDER;
 
     /**
-     * @param null|string $mb_detect_order
+     * The default maximum message lengths. Longer strings will be truncated
+     *
+     * @var int
      */
-    public function __construct($mb_detect_order = null)
+    protected $message_limit = Raven_Client::MESSAGE_LIMIT;
+
+    /**
+     * @param null|string $mb_detect_order
+     * @param null|int    $message_limit
+     */
+    public function __construct($mb_detect_order = null, $message_limit = null)
     {
         if ($mb_detect_order != null) {
             $this->mb_detect_order = $mb_detect_order;
+        }
+
+        if ($message_limit != null) {
+            $this->message_limit = (int) $message_limit;
         }
     }
 
@@ -93,8 +105,8 @@ class Raven_Serializer
             }
         }
 
-        if (strlen($value) > 1024) {
-            $value = substr($value, 0, 1014) . ' {clipped}';
+        if (strlen($value) > $this->message_limit) {
+            $value = substr($value, 0, $this->message_limit - 10) . ' {clipped}';
         }
 
         return $value;
@@ -140,5 +152,23 @@ class Raven_Serializer
         $this->mb_detect_order = $mb_detect_order;
 
         return $this;
+    }
+
+    /**
+     * @return int
+     * @codeCoverageIgnore
+     */
+    public function getMessageLimit()
+    {
+        return $this->message_limit;
+    }
+
+    /**
+     * @param int $message_limit
+     * @codeCoverageIgnore
+     */
+    public function setMessageLimit($message_limit)
+    {
+        $this->message_limit = (int)$message_limit;
     }
 }

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -132,6 +132,26 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Raven_Serializer::serializeString
+     */
+    public function testLongStringWithOverwrittenMessageLength()
+    {
+        $serializer = new Raven_Serializer();
+        $serializer->setMessageLimit(500);
+        for ($i = 0; $i < 100; $i++) {
+            foreach (array(100, 490, 499, 500, 501, 1000, 10000) as $length) {
+                $input = '';
+                for ($i = 0; $i < $length; $i++) {
+                    $input .= chr(mt_rand(0, 255));
+                }
+                $result = $serializer->serialize($input);
+                $this->assertInternalType('string', $result);
+                $this->assertLessThanOrEqual(500, strlen($result));
+            }
+        }
+    }
+
+    /**
      * @covers Raven_Serializer::serializeValue
      */
     public function testSerializeValueResource()


### PR DESCRIPTION
Currently the message length limit is fixed to 1024 in the Serializer. 
In the Client it's possible to change the value (if needed), but not in serializer context. I just added the possibility to pass higher/lower values. 