### PR TITLE
Runtime information

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -884,6 +884,8 @@ class Raven_Client
         if (empty($data['site'])) {
             unset($data['site']);
         }
+        $data['contexts']['runtime'] =  array('version' => phpversion(), 'name' => 'php');
+
 
         if (!$this->breadcrumbs->is_empty()) {
             $data['breadcrumbs'] = $this->breadcrumbs->fetch();

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -884,8 +884,8 @@ class Raven_Client
         if (empty($data['site'])) {
             unset($data['site']);
         }
-        $data['contexts']['runtime'] =  array('version' => phpversion(), 'name' => 'php');
 
+        $data['contexts']['runtime'] =  array('version' => PHP_VERSION, 'name' => 'php');
 
         if (!$this->breadcrumbs->is_empty()) {
             $data['breadcrumbs'] = $this->breadcrumbs->fetch();

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -885,7 +885,9 @@ class Raven_Client
             unset($data['site']);
         }
 
-        $data['contexts']['runtime'] =  array('version' => PHP_VERSION, 'name' => 'php');
+        $existing_runtime_context = isset($data['contexts']['runtime']) ? $data['contexts']['runtime'] : [];
+        $runtime_context = array('version' => PHP_VERSION, 'name' => 'php');
+        $data['contexts']['runtime'] =  array_merge($existing_runtime_context, $runtime_context);
 
         if (!$this->breadcrumbs->is_empty()) {
             $data['breadcrumbs'] = $this->breadcrumbs->fetch();

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -885,9 +885,9 @@ class Raven_Client
             unset($data['site']);
         }
 
-        $existing_runtime_context = isset($data['contexts']['runtime']) ? $data['contexts']['runtime'] : [];
+        $existing_runtime_context = isset($data['contexts']['runtime']) ? $data['contexts']['runtime'] : array();
         $runtime_context = array('version' => PHP_VERSION, 'name' => 'php');
-        $data['contexts']['runtime'] =  array_merge($existing_runtime_context, $runtime_context);
+        $data['contexts']['runtime'] =  array_merge($runtime_context, $existing_runtime_context);
 
         if (!$this->breadcrumbs->is_empty()) {
             $data['breadcrumbs'] = $this->breadcrumbs->fetch();

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1044,7 +1044,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(phpversion(), $events[0]['contexts']['runtime']['version']);
+        $this->assertEquals(PHP_VERSION, $events[0]['contexts']['runtime']['version']);
         $event = array_pop($events);
         $this->assertEquals('php', $event['contexts']['runtime']['name']);
     }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1044,8 +1044,8 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
 
         $client->captureMessage('test');
         $events = $client->getSentEvents();
-        $this->assertEquals(PHP_VERSION, $events[0]['contexts']['runtime']['version']);
         $event = array_pop($events);
+        $this->assertEquals(PHP_VERSION, $event['contexts']['runtime']['version']);
         $this->assertEquals('php', $event['contexts']['runtime']['name']);
     }
 
@@ -1071,10 +1071,38 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $client->captureMessage('test', array(), $data);
 
         $events = $client->getSentEvents();
-        $this->assertEquals(PHP_VERSION, $events[0]['contexts']['runtime']['version']);
         $event = array_pop($events);
+        $this->assertEquals(PHP_VERSION, $event['contexts']['runtime']['version']);
         $this->assertEquals('php', $event['contexts']['runtime']['name']);
         $this->assertEquals(1216, $event['contexts']['mine']['line']);
+    }
+
+    /**
+     * @covers Raven_Client::capture
+     */
+    public function testRuntimeOnExistingRuntimeContext()
+    {
+        $client = new Dummy_Raven_Client();
+
+        $data = array('contexts' => array(
+            'runtime' => array(
+                'line' => 1216,
+                'stack' => array(
+                    1, array(
+                        'foo' => 'bar',
+                        'level4' => array(array('level5', 'level5 a'), 2),
+                    ), 3
+                ),
+            ),
+        ));
+
+        $client->captureMessage('test', array(), $data);
+
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        $this->assertEquals(PHP_VERSION, $event['contexts']['runtime']['version']);
+        $this->assertEquals('php', $event['contexts']['runtime']['name']);
+        $this->assertEquals(1216, $event['contexts']['runtime']['line']);
     }
 
     /**

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1050,6 +1050,34 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Raven_Client::capture
+     */
+    public function testRuntimeOnCustomContext()
+    {
+        $client = new Dummy_Raven_Client();
+
+        $data = array('contexts' => array(
+            'mine' => array(
+                'line' => 1216,
+                'stack' => array(
+                    1, array(
+                        'foo' => 'bar',
+                        'level4' => array(array('level5', 'level5 a'), 2),
+                    ), 3
+                ),
+            ),
+        ));
+
+        $client->captureMessage('test', array(), $data);
+
+        $events = $client->getSentEvents();
+        $this->assertEquals(PHP_VERSION, $events[0]['contexts']['runtime']['version']);
+        $event = array_pop($events);
+        $this->assertEquals('php', $event['contexts']['runtime']['name']);
+        $this->assertEquals(1216, $event['contexts']['mine']['line']);
+    }
+
+    /**
      * @covers Raven_Client::captureMessage
      */
     public function testCaptureMessageWithUnserializableUserData()

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1080,6 +1080,28 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers Raven_Client::capture
      */
+    public function testRuntimeOnOverrideRuntimeItself()
+    {
+        $client = new Dummy_Raven_Client();
+
+        $data = array('contexts' => array(
+            'runtime' => array(
+                'name' => 'sentry',
+                'version' => '0.1.1-alpha.1'
+            ),
+        ));
+
+        $client->captureMessage('test', array(), $data);
+
+        $events = $client->getSentEvents();
+        $event = array_pop($events);
+        $this->assertEquals('0.1.1-alpha.1', $event['contexts']['runtime']['version']);
+        $this->assertEquals('sentry', $event['contexts']['runtime']['name']);
+    }
+
+    /**
+     * @covers Raven_Client::capture
+     */
     public function testRuntimeOnExistingRuntimeContext()
     {
         $client = new Dummy_Raven_Client();

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1049,8 +1049,6 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('php', $event['contexts']['runtime']['name']);
     }
 
-
-
     /**
      * @covers Raven_Client::captureMessage
      */

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1036,6 +1036,22 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Raven_Client::capture
+     */
+    public function testRuntimeContext()
+    {
+        $client = new Dummy_Raven_Client();
+
+        $client->captureMessage('test');
+        $events = $client->getSentEvents();
+        $this->assertEquals(phpversion(), $events[0]['contexts']['runtime']['version']);
+        $event = array_pop($events);
+        $this->assertEquals('php', $event['contexts']['runtime']['name']);
+    }
+
+
+
+    /**
      * @covers Raven_Client::captureMessage
      */
     public function testCaptureMessageWithUnserializableUserData()


### PR DESCRIPTION
as discussed here: https://github.com/getsentry/sentry-php/issues/562
this one adds a context containing the current php version.

running the `examples/vanilla/index.php`  results in a exception like this:
( i wanted to upload via github (seems to 503 right now, hope they have sentry))

https://imgur.com/Hs6FDYm



i really would appreciate if we can get this in an 1.8.* release (atleast a release in a short time) - i really would love to have this in production. let me know if you need me to backport it somewhere.





