### PR TITLE
[2.0] Sortable middleware stack

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -443,7 +443,13 @@ class Client
             $payload['message'] = substr($payload['message'], 0, static::MESSAGE_LIMIT);
         }
 
-        $event = $this->middlewareStack->executeStack($event, static::isHttpRequest() ? ServerRequestFactory::fromGlobals() : null, isset($payload['exception']) ? $payload['exception'] : null, $payload);
+        $event = $this->middlewareStack->executeStack(
+            $event,
+            static::isHttpRequest() ? ServerRequestFactory::fromGlobals() : null,
+            isset($payload['exception']) ? $payload['exception'] : null,
+            $payload
+        );
+
         $event = $this->sanitize($event);
 
         $this->send($event);

--- a/lib/Raven/ClientBuilder.php
+++ b/lib/Raven/ClientBuilder.php
@@ -112,6 +112,11 @@ final class ClientBuilder implements ClientBuilderInterface
     private $httpClientPlugins = [];
 
     /**
+     * @var array List of middlewares and their priorities
+     */
+    private $middlewares = [];
+
+    /**
      * @var array List of processors and their priorities
      */
     private $processors = [];
@@ -199,6 +204,40 @@ final class ClientBuilder implements ClientBuilderInterface
         }
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addMiddleware(callable $middleware, $priority = 0)
+    {
+        $this->middlewares[] = [$middleware, $priority];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeMiddleware(callable $middleware)
+    {
+        foreach ($this->middlewares as $key => $value) {
+            if ($value[0] !== $middleware) {
+                continue;
+            }
+
+            unset($this->middlewares[$key]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMiddlewares()
+    {
+        return $this->middlewares;
     }
 
     /**

--- a/lib/Raven/ClientBuilderInterface.php
+++ b/lib/Raven/ClientBuilderInterface.php
@@ -89,6 +89,35 @@ interface ClientBuilderInterface
     public function removeHttpClientPlugin($className);
 
     /**
+     * Adds a new middleware with the given priority to the stack.
+     *
+     * @param callable $middleware The middleware instance
+     * @param int      $priority   The priority. The higher this value, the
+     *                             earlier a processor will be executed in
+     *                             the chain (defaults to 0)
+     *
+     * @return $this
+     */
+    public function addMiddleware(callable $middleware, $priority = 0);
+
+    /**
+     * Removes the given middleware from the stack.
+     *
+     * @param callable $middleware The middleware instance
+     *
+     * @return $this
+     */
+    public function removeMiddleware(callable $middleware);
+
+    /**
+     * Gets the list of middlewares that will be added to the client at the
+     * given priority.
+     *
+     * @return array
+     */
+    public function getMiddlewares();
+
+    /**
      * Adds a new processor to the processors chain with the specified priority.
      *
      * @param ProcessorInterface $processor The processor instance
@@ -110,7 +139,7 @@ interface ClientBuilderInterface
     public function removeProcessor(ProcessorInterface $processor);
 
     /**
-     * Gets a list of processors that will be added to the client at the
+     * Gets the list of processors that will be added to the client at the
      * given priority.
      *
      * @return array

--- a/lib/Raven/Middleware/BreadcrumbInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/BreadcrumbInterfaceMiddleware.php
@@ -49,7 +49,7 @@ final class BreadcrumbInterfaceMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         foreach ($this->recorder as $breadcrumb) {
             $event = $event->withBreadcrumb($breadcrumb);

--- a/lib/Raven/Middleware/BreadcrumbInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/BreadcrumbInterfaceMiddleware.php
@@ -44,7 +44,7 @@ final class BreadcrumbInterfaceMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/ContextInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ContextInterfaceMiddleware.php
@@ -51,7 +51,7 @@ final class ContextInterfaceMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/ContextInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ContextInterfaceMiddleware.php
@@ -56,7 +56,7 @@ final class ContextInterfaceMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         $context = isset($payload[$this->contextName . '_context']) ? $payload[$this->contextName . '_context'] : [];
         $context = array_merge($this->context->toArray(), $context);

--- a/lib/Raven/Middleware/ExceptionInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ExceptionInterfaceMiddleware.php
@@ -44,7 +44,7 @@ final class ExceptionInterfaceMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/ExceptionInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ExceptionInterfaceMiddleware.php
@@ -49,7 +49,7 @@ final class ExceptionInterfaceMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         // Do not override the level if it was set explicitly by the user
         if (!isset($payload['level']) && $exception instanceof \ErrorException) {

--- a/lib/Raven/Middleware/MessageInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/MessageInterfaceMiddleware.php
@@ -33,7 +33,7 @@ final class MessageInterfaceMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         $message = isset($payload['message']) ? $payload['message'] : null;
         $messageParams = isset($payload['message_params']) ? $payload['message_params'] : [];

--- a/lib/Raven/Middleware/MessageInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/MessageInterfaceMiddleware.php
@@ -28,7 +28,7 @@ final class MessageInterfaceMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/MiddlewareStack.php
+++ b/lib/Raven/Middleware/MiddlewareStack.php
@@ -1,0 +1,156 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Raven\Event;
+
+/**
+ * This class implements a stack of middlewares that can be sorted by priority.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+class MiddlewareStack
+{
+    /**
+     * @var callable The handler that will end the middleware call stack
+     */
+    private $handler;
+
+    /**
+     * @var array<int, MiddlewareInterface[]> The list of middlewares
+     */
+    private $stack = [];
+
+    /**
+     * @var callable The tip of the middleware call stack
+     */
+    private $middlewareStackTip;
+
+    /**
+     * @var bool Whether the stack of middleware callables is locked
+     */
+    private $stackLocked = false;
+
+    /**
+     * Constructor.
+     *
+     * @param callable $handler The handler that will end the middleware call stack
+     */
+    public function __construct(callable $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * Invokes the handler stack as a composed handler.
+     *
+     * @param Event                       $event     The event being processed
+     * @param ServerRequestInterface|null $request   The request, if available
+     * @param \Throwable|\Exception|null  $exception The thrown exception, if available
+     * @param array                       $payload   Additional data
+     *
+     * @return Event
+     */
+    public function executeStack(Event $event, ServerRequestInterface $request = null, $exception = null, array $payload = [])
+    {
+        $handler = $this->resolve();
+
+        $this->stackLocked = true;
+
+        $event = $handler($event, $request, $exception, $payload);
+
+        $this->stackLocked = false;
+
+        if (!$event instanceof Event) {
+            throw new \UnexpectedValueException(sprintf('Middleware must return an instance of the "%s" class.', Event::class));
+        }
+
+        return $event;
+    }
+
+    /**
+     * Adds a new middleware with the given priority to the stack.
+     *
+     * @param callable $middleware The middleware instance
+     * @param int      $priority   The priority. The higher this value, the
+     *                             earlier a processor will be executed in
+     *                             the chain (defaults to 0)
+     *
+     * @throws \RuntimeException If the method is called while the stack is dequeuing
+     */
+    public function addMiddleware(callable $middleware, $priority = 0)
+    {
+        if ($this->stackLocked) {
+            throw new \RuntimeException('Middleware can\'t be added once the stack is dequeuing.');
+        }
+
+        $this->middlewareStackTip = null;
+
+        $this->stack[$priority][] = $middleware;
+    }
+
+    /**
+     * Removes the given middleware from the stack.
+     *
+     * @param callable $middleware The middleware instance
+     *
+     * @throws \RuntimeException If the method is called while the stack is dequeuing
+     */
+    public function removeMiddleware(callable $middleware)
+    {
+        if ($this->stackLocked) {
+            throw new \RuntimeException('Middleware can\'t be removed once the stack is dequeuing.');
+        }
+
+        $this->middlewareStackTip = null;
+
+        foreach ($this->stack as $priority => $middlewares) {
+            $this->stack[$priority] = array_filter($middlewares, function ($item) use ($middleware) {
+                return $middleware !== $item;
+            });
+        }
+    }
+
+    /**
+     * Resolves the stack of middleware callables into a chain where each middleware
+     * will call the next one in order of priority.
+     *
+     * @return callable
+     */
+    private function resolve()
+    {
+        if (null === $this->middlewareStackTip) {
+            $prev = $this->handler;
+
+            ksort($this->stack);
+
+            if (!empty($this->stack)) {
+                foreach (array_merge(...$this->stack) as $middleware) {
+                    $prev = function (Event $event, ServerRequestInterface $request = null, $exception = null, array $payload = []) use ($middleware, $prev) {
+                        $event = $middleware($event, $prev, $request, $exception, $payload);
+
+                        if (!$event instanceof Event) {
+                            throw new \UnexpectedValueException(sprintf('Middleware must return an instance of the "%s" class.', Event::class));
+                        }
+
+                        return $event;
+                    };
+                }
+            }
+
+            $this->middlewareStackTip = $prev;
+        }
+
+        return $this->middlewareStackTip;
+    }
+}

--- a/lib/Raven/Middleware/ProcessorMiddleware.php
+++ b/lib/Raven/Middleware/ProcessorMiddleware.php
@@ -49,7 +49,7 @@ final class ProcessorMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         foreach ($this->processorRegistry->getProcessors() as $processor) {
             $event = $processor->process($event);

--- a/lib/Raven/Middleware/ProcessorMiddleware.php
+++ b/lib/Raven/Middleware/ProcessorMiddleware.php
@@ -44,7 +44,7 @@ final class ProcessorMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -28,7 +28,7 @@ final class RequestInterfaceMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -33,7 +33,7 @@ final class RequestInterfaceMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         if (null === $request) {
             return $next($event, $request, $exception, $payload);

--- a/lib/Raven/Middleware/UserInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/UserInterfaceMiddleware.php
@@ -27,7 +27,7 @@ final class UserInterfaceMiddleware
      * @param Event                       $event     The event being processed
      * @param callable                    $next      The next middleware to call
      * @param ServerRequestInterface|null $request   The request, if available
-     * @param \Exception|null             $exception The thrown exception, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
      * @param array                       $payload   Additional data
      *
      * @return Event

--- a/lib/Raven/Middleware/UserInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/UserInterfaceMiddleware.php
@@ -32,7 +32,7 @@ final class UserInterfaceMiddleware
      *
      * @return Event
      */
-    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, \Exception $exception = null, array $payload = [])
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         $userContext = $event->getUserContext();
 

--- a/lib/Raven/Processor/ProcessorRegistry.php
+++ b/lib/Raven/Processor/ProcessorRegistry.php
@@ -17,7 +17,7 @@ namespace Raven\Processor;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class ProcessorRegistry
+class ProcessorRegistry
 {
     /**
      * @var array List of processors sorted by priority

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -140,6 +140,32 @@ class ClientBuilderTest extends TestCase
         $this->assertSame($plugin2, reset($plugins));
     }
 
+    public function testAddMiddlewares()
+    {
+        $middleware = function () {};
+
+        $clientBuilder = new ClientBuilder();
+        $clientBuilder->addMiddleware($middleware, -10);
+
+        $this->assertEquals([[$middleware, -10]], $clientBuilder->getMiddlewares());
+    }
+
+    public function testRemoveMiddleware()
+    {
+        $middleware1 = function () {};
+        $middleware2 = function () {};
+
+        $clientBuilder = new ClientBuilder();
+        $clientBuilder->addMiddleware($middleware1, -10);
+        $clientBuilder->addMiddleware($middleware2, 10);
+
+        $this->assertEquals([[$middleware1, -10], [$middleware2, 10]], $clientBuilder->getMiddlewares());
+
+        $clientBuilder->removeMiddleware($middleware2);
+
+        $this->assertEquals([[$middleware1, -10]], $clientBuilder->getMiddlewares());
+    }
+
     public function testAddProcessor()
     {
         /** @var ProcessorInterface|\PHPUnit_Framework_MockObject_MockObject $processor */
@@ -148,7 +174,7 @@ class ClientBuilderTest extends TestCase
         $clientBuilder = new ClientBuilder();
         $clientBuilder->addProcessor($processor, -10);
 
-        $this->assertAttributeContains([$processor, -10], 'processors', $clientBuilder);
+        $this->assertContains([$processor, -10], $clientBuilder->getProcessors());
     }
 
     public function testRemoveProcessor()
@@ -160,7 +186,7 @@ class ClientBuilderTest extends TestCase
         $clientBuilder->addProcessor($processor, -10);
         $clientBuilder->removeProcessor($processor);
 
-        $this->assertAttributeNotContains([$processor, -10], 'processors', $clientBuilder);
+        $this->assertNotContains([$processor, -10], $clientBuilder->getProcessors());
     }
 
     public function testGetClient()

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -21,6 +21,9 @@ use Raven\Configuration;
 use Raven\Context\Context;
 use Raven\Context\TagsContext;
 use Raven\Event;
+use Raven\Middleware\MiddlewareStack;
+use Raven\Processor\ProcessorInterface;
+use Raven\Processor\ProcessorRegistry;
 use Raven\Serializer;
 use Raven\Transport\TransportInterface;
 
@@ -64,56 +67,84 @@ class Dummy_Raven_Client extends \Raven\Client
 
 class ClientTest extends TestCase
 {
-    public function testMiddlewareStackIsSeeded()
+    public function testAddMiddleware()
     {
+        $middleware = function () {};
+
+        /** @var MiddlewareStack|\PHPUnit_Framework_MockObject_MockObject $middlewareStack */
+        $middlewareStack = $this->createMock(MiddlewareStack::class);
+        $middlewareStack->expects($this->once())
+            ->method('addMiddleware')
+            ->with($middleware, -10);
+
         $client = ClientBuilder::create()->getClient();
 
-        $firstMiddleware = $this->getObjectAttribute($client, 'middlewareStackTip');
-        $lastMiddleware = null;
+        $reflectionProperty = new \ReflectionProperty($client, 'middlewareStack');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($client, $middlewareStack);
+        $reflectionProperty->setAccessible(false);
 
-        $client->addMiddleware(function (Event $event, callable $next) use (&$lastMiddleware) {
-            $lastMiddleware = $next;
-
-            return $event;
-        });
-
-        $client->capture([]);
-
-        $this->assertSame($firstMiddleware, $lastMiddleware);
+        $client->addMiddleware($middleware, -10);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Middleware can't be added once the stack is dequeuing
-     */
-    public function testAddMiddlewareThrowsWhileStackIsRunning()
+    public function testRemoveMiddleware()
     {
+        $middleware = function () {};
+
+        /** @var MiddlewareStack|\PHPUnit_Framework_MockObject_MockObject $middlewareStack */
+        $middlewareStack = $this->createMock(MiddlewareStack::class);
+        $middlewareStack->expects($this->once())
+            ->method('removeMiddleware')
+            ->with($middleware);
+
         $client = ClientBuilder::create()->getClient();
 
-        $client->addMiddleware(function (Event $event) use ($client) {
-            $client->addMiddleware(function () {
-                // Do nothing, it's just a middleware added to trigger the exception
-            });
+        $reflectionProperty = new \ReflectionProperty($client, 'middlewareStack');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($client, $middlewareStack);
+        $reflectionProperty->setAccessible(false);
 
-            return $event;
-        });
-
-        $client->capture([]);
+        $client->removeMiddleware($middleware, -10);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Middleware must return an instance of the "Raven\Event" class.
-     */
-    public function testMiddlewareThrowsWhenBadValueIsReturned()
+    public function testAddProcessor()
     {
+        /** @var ProcessorInterface|\PHPUnit_Framework_MockObject_MockObject $processor */
+        $processor = $this->createMock(ProcessorInterface::class);
+
+        $processorRegistry = $this->createMock(ProcessorRegistry::class);
+        $processorRegistry->expects($this->once())
+            ->method('addProcessor')
+            ->with($processor, -10);
+
         $client = ClientBuilder::create()->getClient();
 
-        $client->addMiddleware(function () {
-            // Do nothing, it's just a middleware added to trigger the exception
-        });
+        $reflectionProperty = new \ReflectionProperty($client, 'processorRegistry');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($client, $processorRegistry);
+        $reflectionProperty->setAccessible(false);
 
-        $client->capture([]);
+        $client->addProcessor($processor, -10);
+    }
+
+    public function testRemoveProcessor()
+    {
+        /** @var ProcessorInterface|\PHPUnit_Framework_MockObject_MockObject $processor */
+        $processor = $this->createMock(ProcessorInterface::class);
+
+        $processorRegistry = $this->createMock(ProcessorRegistry::class);
+        $processorRegistry->expects($this->once())
+            ->method('removeProcessor')
+            ->with($processor);
+
+        $client = ClientBuilder::create()->getClient();
+
+        $reflectionProperty = new \ReflectionProperty($client, 'processorRegistry');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue($client, $processorRegistry);
+        $reflectionProperty->setAccessible(false);
+
+        $client->removeProcessor($processor);
     }
 
     public function testCaptureMessage()

--- a/tests/Middleware/MiddlewareStackTest.php
+++ b/tests/Middleware/MiddlewareStackTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Raven\Configuration;
+use Raven\Event;
+use Raven\Middleware\MiddlewareStack;
+
+class MiddlewareStackTest extends TestCase
+{
+    public function testExecuteStack()
+    {
+        $event = new Event(new Configuration());
+
+        /** @var ServerRequestInterface|\PHPUnit_Framework_MockObject_MockObject $capturedRequest */
+        $capturedRequest = $this->createMock(ServerRequestInterface::class);
+
+        $capturedException = new \Exception();
+        $capturedPayload = ['foo' => 'bar'];
+
+        $handlerCalled = false;
+        $handler = function (Event $event, ServerRequestInterface $request = null, $exception = null, array $payload = []) use (&$handlerCalled, $capturedRequest, $capturedException, $capturedPayload) {
+            // These asserts verify that the arguments passed through all
+            // middlewares without getting lost
+            $this->assertSame($capturedRequest, $request);
+            $this->assertSame($capturedException, $exception);
+            $this->assertSame($capturedPayload, $payload);
+
+            $handlerCalled = true;
+
+            return $event;
+        };
+
+        $middlewareCalls = [false, false];
+
+        $middlewareStack = new MiddlewareStack($handler);
+        $middlewareStack->addMiddleware($this->createMiddlewareAssertingInvokation($middlewareCalls[0]));
+        $middlewareStack->addMiddleware($this->createMiddlewareAssertingInvokation($middlewareCalls[1]));
+
+        $middlewareStack->executeStack($event, $capturedRequest, $capturedException, $capturedPayload);
+
+        $this->assertTrue($handlerCalled);
+        $this->assertNotContains(false, $middlewareCalls);
+    }
+
+    public function testAddMiddleware()
+    {
+        $middlewareCalls = [];
+
+        $handler = function (Event $event) use (&$middlewareCalls) {
+            $middlewareCalls[] = 4;
+
+            return $event;
+        };
+
+        $middleware1 = function (Event $event, callable $next) use (&$middlewareCalls) {
+            $middlewareCalls[] = 1;
+
+            return $next($event);
+        };
+
+        $middleware2 = function (Event $event, callable $next) use (&$middlewareCalls) {
+            $middlewareCalls[] = 2;
+
+            return $next($event);
+        };
+
+        $middleware3 = function (Event $event, callable $next) use (&$middlewareCalls) {
+            $middlewareCalls[] = 3;
+
+            return $next($event);
+        };
+
+        $middlewareStack = new MiddlewareStack($handler);
+        $middlewareStack->addMiddleware($middleware1, -10);
+        $middlewareStack->addMiddleware($middleware2);
+        $middlewareStack->addMiddleware($middleware3, -10);
+
+        $middlewareStack->executeStack(new Event(new Configuration()));
+
+        $this->assertEquals([2, 3, 1, 4], $middlewareCalls);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Middleware can't be added once the stack is dequeuing.
+     */
+    public function testAddMiddlewareThrowsWhileStackIsRunning()
+    {
+        /** @var MiddlewareStack $middlewareStack */
+        $middlewareStack = null;
+
+        $middlewareStack = new MiddlewareStack(function () use (&$middlewareStack) {
+            $middlewareStack->addMiddleware(function () {
+                // Returning something is not important as the expected exception
+                // should be thrown before this point is ever reached
+            });
+        });
+
+        $middlewareStack->executeStack(new Event(new Configuration()));
+    }
+
+    public function testRemoveMiddleware()
+    {
+        $middlewareCalls = [];
+
+        $middleware1 = function (Event $event, callable $next) use (&$middlewareCalls) {
+            $middlewareCalls[] = 1;
+
+            return $next($event);
+        };
+
+        $middleware2 = function (Event $event, callable $next) use (&$middlewareCalls) {
+            $middlewareCalls[] = 2;
+
+            return $next($event);
+        };
+
+        $middleware3 = function (Event $event, callable $next) use (&$middlewareCalls) {
+            $middlewareCalls[] = 3;
+
+            return $next($event);
+        };
+
+        $middlewareStack = new MiddlewareStack(function (Event $event) use (&$middlewareCalls) {
+            $middlewareCalls[] = 4;
+
+            return $event;
+        });
+
+        $middlewareStack->addMiddleware($middleware1, -10);
+        $middlewareStack->addMiddleware($middleware2);
+        $middlewareStack->addMiddleware($middleware3, -10);
+        $middlewareStack->removeMiddleware($middleware3);
+
+        $middlewareStack->executeStack(new Event(new Configuration()));
+
+        $this->assertEquals([2, 1, 4], $middlewareCalls);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Middleware can't be removed once the stack is dequeuing.
+     */
+    public function testRemoveMiddlewareThrowsWhileStackIsRunning()
+    {
+        /** @var MiddlewareStack $middlewareStack */
+        $middlewareStack = null;
+
+        $middlewareStack = new MiddlewareStack(function () use (&$middlewareStack) {
+            $middlewareStack->removeMiddleware(function () {
+                // Returning something is not important as the expected exception
+                // should be thrown before this point is ever reached
+            });
+        });
+
+        $middlewareStack->executeStack(new Event(new Configuration()));
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Middleware must return an instance of the "Raven\Event" class.
+     */
+    public function testMiddlewareThrowsWhenBadValueIsReturned()
+    {
+        $event = new Event(new Configuration());
+        $middlewareStack = new MiddlewareStack(function (Event $event) {
+            return $event;
+        });
+
+        $middlewareStack->addMiddleware(function () {
+            // Return nothing so that the expected exception is triggered
+        });
+
+        $middlewareStack->executeStack($event);
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Middleware must return an instance of the "Raven\Event" class.
+     */
+    public function testMiddlewareThrowsWhenBadValueIsReturnedFromHandler()
+    {
+        $event = new Event(new Configuration());
+        $middlewareStack = new MiddlewareStack(function () {
+            // Return nothing so that the expected exception is triggered
+        });
+
+        $middlewareStack->executeStack($event);
+    }
+
+    protected function createMiddlewareAssertingInvokation(&$wasCalled)
+    {
+        return function (Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = []) use (&$wasCalled) {
+            $wasCalled = true;
+
+            return $next($event, $request, $exception, $payload);
+        };
+    }
+}

--- a/tests/Middleware/MiddlewareStackTest.php
+++ b/tests/Middleware/MiddlewareStackTest.php
@@ -139,10 +139,13 @@ class MiddlewareStackTest extends TestCase
             return $event;
         });
 
+        $this->assertFalse($middlewareStack->removeMiddleware($middleware1));
+
         $middlewareStack->addMiddleware($middleware1, -10);
         $middlewareStack->addMiddleware($middleware2);
         $middlewareStack->addMiddleware($middleware3, -10);
-        $middlewareStack->removeMiddleware($middleware3);
+
+        $this->assertTrue($middlewareStack->removeMiddleware($middleware3));
 
         $middlewareStack->executeStack(new Event(new Configuration()));
 

--- a/tests/Middleware/ProcessorMiddlewareTest.php
+++ b/tests/Middleware/ProcessorMiddlewareTest.php
@@ -21,7 +21,7 @@ class ProcessorMiddlewareTest extends TestCase
 {
     public function testInvoke()
     {
-        $client = ClientBuilder::create([])->getClient();
+        $client = ClientBuilder::create()->getClient();
         $event = new Event($client->getConfig());
         $processorRegistry = $this->getObjectAttribute($client, 'processorRegistry');
 
@@ -45,7 +45,7 @@ class ProcessorMiddlewareTest extends TestCase
      */
     public function testInvokeProcessorThatReturnsNothingThrows()
     {
-        $client = ClientBuilder::create([])->getClient();
+        $client = ClientBuilder::create()->getClient();
         $event = new Event($client->getConfig());
         $processorRegistry = $this->getObjectAttribute($client, 'processorRegistry');
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I realized that the middleware implementation that was merged with #487 has some problems, in particular:

- the middlewares cannot be added through the client builder
- the middlewares cannot be removed (not even the default ones)
- the middlewares are not sortable, so newly added middlewares will always go to the end of the chain

To solve the last one this PR implements something similar to the priority feature of the processors so that any middleware can be pushed in a specific position, be it the end of the chain, the start or the middle. Also, all the other points have been addressed