### PR TITLE
[2.0] Refactor the TransactionStack class

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -453,33 +453,10 @@
   $client->getTransactionStack()->push('foo', 'bar');
   ```
 
-- The method `TransactionStack::peek` used to return `null` when the stack was
-  empty. The behaviour has changed and an exception is now thrown.
-
-  Before:
-
-  ```php
-  $client->transaction->clear();
-
-  $value = $client->transaction->peek(); // $value is null
-  ```
-
-  After:
-
-  ```php
-  $client->getTransactionStack()->clear();
-
-  try {
-      $value = $client->getTransactionStack()->peek();
-  } catch (\UnderflowException $exception) {
-      // handle the exception here
-  }
-
 - The method `TransactionStack::pop` has changed its signature by removing the
   `$context` argument. Consequently the behaviour of the method in regards to
   the returned value changed as well: it's not possible anymore to pop all values
-  up to one that equals the value of `$context` and an exception is thrown if the
-  stack is empty while calling this method.
+  up to one that equals the value of `$context`.
 
   Before:
 
@@ -500,9 +477,5 @@
       $value = $client->getTransactionStack()->pop(); // $value is 'baz', then 'bar', then 'foo'
   }
 
-  try {
-      $value = $client->getTransactionStack()->pop();
-  } catch (\UnderflowException $exception) {
-      // handle the exception here
-  }
+  $value = $client->getTransactionStack()->pop(); // $value is null
   ```

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -430,7 +430,7 @@ class Client
 
         if (isset($payload['culprit'])) {
             $event = $event->withCulprit($payload['culprit']);
-        } elseif (!$this->transactionStack->isEmpty()) {
+        } else {
             $event = $event->withCulprit($this->transactionStack->peek());
         }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -56,19 +56,9 @@ class Client
     const MESSAGE_LIMIT = 1024;
 
     /**
-     * @var Recorder The breadcrumbs recorder
-     */
-    protected $recorder;
-
-    /**
      * This constant defines the client's user-agent string.
      */
     const USER_AGENT = 'sentry-php/' . self::VERSION;
-
-    /**
-     * @var TransactionStack The transaction stack
-     */
-    public $transaction;
 
     /**
      * @var string[]|null
@@ -94,6 +84,16 @@ class Client
      * @var Configuration The client configuration
      */
     protected $config;
+
+    /**
+     * @var Recorder The breadcrumbs recorder
+     */
+    private $breadcrumbRecorder;
+
+    /**
+     * @var TransactionStack The transaction stack
+     */
+    private $transactionStack;
 
     /**
      * @var TransportInterface The transport
@@ -156,28 +156,31 @@ class Client
         $this->extraContext = new Context();
         $this->runtimeContext = new RuntimeContext();
         $this->serverOsContext = new ServerOsContext();
-        $this->recorder = new Recorder();
-        $this->transaction = new TransactionStack();
+        $this->breadcrumbRecorder = new Recorder();
+        $this->transactionStack = new TransactionStack();
         $this->serializer = new Serializer($this->config->getMbDetectOrder());
         $this->reprSerializer = new ReprSerializer($this->config->getMbDetectOrder());
         $this->middlewareStack = new MiddlewareStack(function (Event $event) {
             return $event;
         });
 
-        $this->middlewareStack->addMiddleware(new ProcessorMiddleware($this->processorRegistry), -255);
-        $this->middlewareStack->addMiddleware(new MessageInterfaceMiddleware());
-        $this->middlewareStack->addMiddleware(new RequestInterfaceMiddleware());
-        $this->middlewareStack->addMiddleware(new UserInterfaceMiddleware());
-        $this->middlewareStack->addMiddleware(new ContextInterfaceMiddleware($this->tagsContext, Context::CONTEXT_TAGS));
-        $this->middlewareStack->addMiddleware(new ContextInterfaceMiddleware($this->userContext, Context::CONTEXT_USER));
-        $this->middlewareStack->addMiddleware(new ContextInterfaceMiddleware($this->extraContext, Context::CONTEXT_EXTRA));
-        $this->middlewareStack->addMiddleware(new ContextInterfaceMiddleware($this->runtimeContext, Context::CONTEXT_RUNTIME));
-        $this->middlewareStack->addMiddleware(new ContextInterfaceMiddleware($this->serverOsContext, Context::CONTEXT_SERVER_OS));
-        $this->middlewareStack->addMiddleware(new BreadcrumbInterfaceMiddleware($this->recorder));
-        $this->middlewareStack->addMiddleware(new ExceptionInterfaceMiddleware($this));
+        $this->addMiddleware(new ProcessorMiddleware($this->processorRegistry), -255);
+        $this->addMiddleware(new MessageInterfaceMiddleware());
+        $this->addMiddleware(new RequestInterfaceMiddleware());
+        $this->addMiddleware(new UserInterfaceMiddleware());
+        $this->addMiddleware(new ContextInterfaceMiddleware($this->tagsContext, Context::CONTEXT_TAGS));
+        $this->addMiddleware(new ContextInterfaceMiddleware($this->userContext, Context::CONTEXT_USER));
+        $this->addMiddleware(new ContextInterfaceMiddleware($this->extraContext, Context::CONTEXT_EXTRA));
+        $this->addMiddleware(new ContextInterfaceMiddleware($this->runtimeContext, Context::CONTEXT_RUNTIME));
+        $this->addMiddleware(new ContextInterfaceMiddleware($this->serverOsContext, Context::CONTEXT_SERVER_OS));
+        $this->addMiddleware(new BreadcrumbInterfaceMiddleware($this->breadcrumbRecorder));
+        $this->addMiddleware(new ExceptionInterfaceMiddleware($this));
 
-        if (static::isHttpRequest() && isset($_SERVER['PATH_INFO'])) {
-            $this->transaction->push($_SERVER['PATH_INFO']);
+        $request = ServerRequestFactory::fromGlobals();
+        $serverParams = $request->getServerParams();
+
+        if (isset($serverParams['PATH_INFO'])) {
+            $this->transactionStack->push($serverParams['PATH_INFO']);
         }
 
         if ($this->config->getSerializeAllObjects()) {
@@ -196,7 +199,7 @@ class Client
      */
     public function leaveBreadcrumb(Breadcrumb $breadcrumb)
     {
-        $this->recorder->record($breadcrumb);
+        $this->breadcrumbRecorder->record($breadcrumb);
     }
 
     /**
@@ -204,7 +207,7 @@ class Client
      */
     public function clearBreadcrumbs()
     {
-        $this->recorder->clear();
+        $this->breadcrumbRecorder->clear();
     }
 
     /**
@@ -215,6 +218,16 @@ class Client
     public function getConfig()
     {
         return $this->config;
+    }
+
+    /**
+     * Gets the transaction stack.
+     *
+     * @return TransactionStack
+     */
+    public function getTransactionStack()
+    {
+        return $this->transactionStack;
     }
 
     /**
@@ -417,8 +430,8 @@ class Client
 
         if (isset($payload['culprit'])) {
             $event = $event->withCulprit($payload['culprit']);
-        } else {
-            $event = $event->withCulprit($this->transaction->peek());
+        } elseif (!$this->transactionStack->isEmpty()) {
+            $event = $event->withCulprit($this->transactionStack->peek());
         }
 
         if (isset($payload['level'])) {

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Raven.
  *
@@ -10,55 +11,102 @@
 
 namespace Raven;
 
-class TransactionStack
+/**
+ * This class is a LIFO collection that only allows access to the value at the
+ * top of the stack.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class TransactionStack implements \Countable
 {
     /**
-     * @var array
+     * @var string[] The transaction stack
      */
-    public $stack;
+    private $transactions = [];
 
-    public function __construct()
+    /**
+     * Class constructor.
+     *
+     * @param array $values An array of initial values
+     */
+    public function __construct(array $values = [])
     {
-        $this->stack = [];
+        $this->push(...$values);
     }
 
+    /**
+     * Clears the stack by removing all values.
+     */
     public function clear()
     {
-        $this->stack = [];
+        $this->transactions = [];
     }
 
+    /**
+     * Checks whether the stack is empty.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->transactions);
+    }
+
+    /**
+     * Pushes the given values onto the stack.
+     *
+     * @param string[] $values The values to push
+     *
+     * @throws \InvalidArgumentException If any of the values is not a string
+     */
+    public function push(...$values)
+    {
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                throw new \InvalidArgumentException(sprintf('The $values argument must contain string values only.'));
+            }
+
+            $this->transactions[] = $value;
+        }
+    }
+
+    /**
+     * Gets the value at the top of the stack without removing it.
+     *
+     * @return string
+     *
+     * @throws \UnderflowException If the stack is empty
+     */
     public function peek()
     {
-        $len = count($this->stack);
-        if (0 === $len) {
-            return null;
+        if (empty($this->transactions)) {
+            throw new \UnderflowException('Peeking an empty stack is not allowed.');
         }
 
-        return $this->stack[$len - 1];
+        return $this->transactions[count($this->transactions) - 1];
     }
 
-    public function push($context)
-    {
-        $this->stack[] = $context;
-    }
-
-    /** @noinspection PhpInconsistentReturnPointsInspection
-     * @param string|null $context
+    /**
+     * Removes and returns the value at the top of the stack.
      *
-     * @return mixed
+     * @return string
+     *
+     * @throws \UnderflowException If the stack is empty
      */
-    public function pop($context = null)
+    public function pop()
     {
-        if (!$context) {
-            return array_pop($this->stack);
+        if (empty($this->transactions)) {
+            throw new \UnderflowException('Popping an empty stack is not allowed.');
         }
-        while (!empty($this->stack)) {
-            if (array_pop($this->stack) === $context) {
-                return $context;
-            }
-        }
-        // @codeCoverageIgnoreStart
+
+        return array_pop($this->transactions);
     }
 
-    // @codeCoverageIgnoreEnd
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->transactions);
+    }
 }

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -73,14 +73,12 @@ final class TransactionStack implements \Countable
     /**
      * Gets the value at the top of the stack without removing it.
      *
-     * @return string
-     *
-     * @throws \UnderflowException If the stack is empty
+     * @return string|null
      */
     public function peek()
     {
         if (empty($this->transactions)) {
-            throw new \UnderflowException('Peeking an empty stack is not allowed.');
+            return null;
         }
 
         return $this->transactions[count($this->transactions) - 1];
@@ -89,14 +87,12 @@ final class TransactionStack implements \Countable
     /**
      * Removes and returns the value at the top of the stack.
      *
-     * @return string
-     *
-     * @throws \UnderflowException If the stack is empty
+     * @return string|null
      */
     public function pop()
     {
         if (empty($this->transactions)) {
-            throw new \UnderflowException('Popping an empty stack is not allowed.');
+            return null;
         }
 
         return array_pop($this->transactions);

--- a/tests/Breadcrumbs/ErrorHandlerTest.php
+++ b/tests/Breadcrumbs/ErrorHandlerTest.php
@@ -27,7 +27,7 @@ class ErrorHandlerTest extends TestCase
         $handler = new ErrorHandler($client);
         $handler->handleError(E_WARNING, 'message');
 
-        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'recorder');
+        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'breadcrumbRecorder');
 
         /** @var \Raven\Breadcrumbs\Breadcrumb[] $breadcrumbs */
         $breadcrumbs = iterator_to_array($breadcrumbsRecorder);

--- a/tests/Breadcrumbs/MonologHandlerTest.php
+++ b/tests/Breadcrumbs/MonologHandlerTest.php
@@ -54,7 +54,7 @@ EOF;
         $logger->pushHandler($handler);
         $logger->addWarning('foo');
 
-        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'recorder');
+        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'breadcrumbRecorder');
 
         /** @var \Raven\Breadcrumbs\Breadcrumb[] $breadcrumbs */
         $breadcrumbs = iterator_to_array($breadcrumbsRecorder);
@@ -78,7 +78,7 @@ EOF;
         $logger->pushHandler($handler);
         $logger->addError($this->getSampleErrorMessage());
 
-        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'recorder');
+        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'breadcrumbRecorder');
 
         /** @var \Raven\Breadcrumbs\Breadcrumb[] $breadcrumbs */
         $breadcrumbs = iterator_to_array($breadcrumbsRecorder);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -69,33 +69,23 @@ class Dummy_Raven_Client extends \Raven\Client
 
 class ClientTest extends TestCase
 {
-    /**
-     * @dataProvider constructorInitializesTransactionStackDataProvider
-     */
-    public function testConstructorInitializesTransactionStack($isHttpRequest)
+    public function testConstructorInitializesTransactionStack()
     {
-        if ($isHttpRequest) {
-            $_SERVER['PATH_INFO'] = '/foo';
-            $_SERVER['REQUEST_METHOD'] = 'GET';
-        }
+        $_SERVER['PATH_INFO'] = '/foo';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
 
         $client = ClientBuilder::create()->getClient();
         $transactionStack = $client->getTransactionStack();
 
-        if ($isHttpRequest) {
-            $this->assertCount(1, $transactionStack);
-            $this->assertEquals('/foo', $transactionStack->peek());
-        } else {
-            $this->assertCount(0, $transactionStack);
-        }
+        $this->assertNotEmpty($transactionStack);
+        $this->assertEquals('/foo', $transactionStack->peek());
     }
 
-    public function constructorInitializesTransactionStackDataProvider()
+    public function testConstructorInitializesTransactionStackInCli()
     {
-        return [
-            [true],
-            [false],
-        ];
+        $client = ClientBuilder::create()->getClient();
+
+        $this->assertEmpty($client->getTransactionStack());
     }
 
     public function testGetTransactionStack()
@@ -105,7 +95,7 @@ class ClientTest extends TestCase
         $this->assertAttributeSame($client->getTransactionStack(), 'transactionStack', $client);
     }
 
-    public function testMiddlewareStackIsSeeded()
+    public function testAddMiddleware()
     {
         $middleware = function () {};
 

--- a/tests/TransactionStackTest.php
+++ b/tests/TransactionStackTest.php
@@ -12,27 +12,155 @@
 namespace Raven\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Raven\TransactionStack;
 
 class TransactionStackTest extends TestCase
 {
-    public function testSimple()
+    public function testConstructor()
     {
-        $stack = new \Raven\TransactionStack();
-        $stack->push('hello');
-        /** @noinspection PhpVoidFunctionResultUsedInspection */
-        /** @noinspection PhpUnusedLocalVariableInspection */
-        $foo = $stack->push('foo');
-        $stack->push('bar');
-        $stack->push('world');
-        $this->assertEquals($stack->peek(), 'world');
-        $this->assertEquals($stack->pop(), 'world');
-        $this->assertEquals($stack->pop('foo'), 'foo');
-        $this->assertEquals($stack->peek(), 'hello');
-        $this->assertEquals($stack->pop(), 'hello');
-        $this->assertEquals($stack->peek(), null);
+        $stack = new TransactionStack(['a', 'b']);
+
+        $this->assertAttributeEquals(['a', 'b'], 'transactions', $stack);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The $values argument must contain string values only.
+     */
+    public function testConstructorThrowsIfValuesAreNotAllStrings()
+    {
+        new TransactionStack(['a', 1]);
+    }
+
+    public function testClear()
+    {
+        $stack = new TransactionStack();
+
+        $this->assertAttributeEmpty('transactions', $stack);
+
+        $stack->push('a', 'b');
+
+        $this->assertAttributeEquals(['a', 'b'], 'transactions', $stack);
 
         $stack->clear();
-        $this->assertInternalType('array', $stack->stack);
-        $this->assertEquals(0, count($stack->stack));
+
+        $this->assertAttributeEmpty('transactions', $stack);
+    }
+
+    public function testIsEmpty()
+    {
+        $stack = new TransactionStack();
+
+        $this->assertEmpty($stack);
+        $this->assertTrue($stack->isEmpty());
+
+        $stack->push('a');
+
+        $this->assertNotEmpty($stack);
+        $this->assertFalse($stack->isEmpty());
+    }
+
+    public function testPush()
+    {
+        $stack = new TransactionStack();
+
+        $this->assertAttributeEmpty('transactions', $stack);
+
+        $stack->push('a');
+
+        $this->assertAttributeEquals(['a'], 'transactions', $stack);
+
+        $stack->push('b', 'c');
+
+        $this->assertAttributeEquals(['a', 'b', 'c'], 'transactions', $stack);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The $values argument must contain string values only.
+     */
+    public function testPushThrowsIfValuesAreNotAllStrings()
+    {
+        $stack = new TransactionStack();
+
+        $this->assertAttributeEmpty('transactions', $stack);
+
+        $stack->push('a', 1);
+    }
+
+    /**
+     * @dataProvider peekDataProvider
+     */
+    public function testPeek($initialData, $expectedData, $expectedExceptionThrow)
+    {
+        if ($expectedExceptionThrow) {
+            $this->expectException(\UnderflowException::class);
+            $this->expectExceptionMessage('Peeking an empty stack is not allowed.');
+        }
+
+        $stack = new TransactionStack($initialData);
+
+        $this->assertEquals($expectedData, $stack->peek());
+    }
+
+    public function peekDataProvider()
+    {
+        return [
+            [
+                ['a', 'b'],
+                'b',
+                false,
+            ],
+            [
+                [],
+                null,
+                true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider popDataProvider
+     */
+    public function testPop($initialData, $expectedData, $expectedRemainingData, $expectedExceptionThrow)
+    {
+        if ($expectedExceptionThrow) {
+            $this->expectException(\UnderflowException::class);
+            $this->expectExceptionMessage('Popping an empty stack is not allowed.');
+        }
+
+        $stack = new TransactionStack($initialData);
+
+        $this->assertEquals($expectedData, $stack->pop());
+        $this->assertAttributeEquals($expectedRemainingData, 'transactions', $stack);
+    }
+
+    public function popDataProvider()
+    {
+        return [
+            [
+                ['a', 'b'],
+                'b',
+                ['a'],
+                false,
+            ],
+            [
+                [],
+                null,
+                [],
+                true,
+            ],
+        ];
+    }
+
+    public function testCount()
+    {
+        $stack = new TransactionStack();
+
+        $this->assertCount(0, $stack);
+
+        $stack->push('a');
+
+        $this->assertCount(1, $stack);
     }
 }

--- a/tests/TransactionStackTest.php
+++ b/tests/TransactionStackTest.php
@@ -34,17 +34,13 @@ class TransactionStackTest extends TestCase
 
     public function testClear()
     {
-        $stack = new TransactionStack();
-
-        $this->assertAttributeEmpty('transactions', $stack);
-
-        $stack->push('a', 'b');
+        $stack = new TransactionStack(['a', 'b']);
 
         $this->assertAttributeEquals(['a', 'b'], 'transactions', $stack);
 
         $stack->clear();
 
-        $this->assertAttributeEmpty('transactions', $stack);
+        $this->assertEmpty($stack);
     }
 
     public function testIsEmpty()
@@ -63,9 +59,6 @@ class TransactionStackTest extends TestCase
     public function testPush()
     {
         $stack = new TransactionStack();
-
-        $this->assertAttributeEmpty('transactions', $stack);
-
         $stack->push('a');
 
         $this->assertAttributeEquals(['a'], 'transactions', $stack);
@@ -83,7 +76,7 @@ class TransactionStackTest extends TestCase
     {
         $stack = new TransactionStack();
 
-        $this->assertAttributeEmpty('transactions', $stack);
+        $this->assertEmpty($stack);
 
         $stack->push('a', 1);
     }
@@ -91,16 +84,12 @@ class TransactionStackTest extends TestCase
     /**
      * @dataProvider peekDataProvider
      */
-    public function testPeek($initialData, $expectedData, $expectedExceptionThrow)
+    public function testPeek($initialData, $expectedData, $expectedRemainingData)
     {
-        if ($expectedExceptionThrow) {
-            $this->expectException(\UnderflowException::class);
-            $this->expectExceptionMessage('Peeking an empty stack is not allowed.');
-        }
-
         $stack = new TransactionStack($initialData);
 
         $this->assertEquals($expectedData, $stack->peek());
+        $this->assertAttributeEquals($expectedRemainingData, 'transactions', $stack);
     }
 
     public function peekDataProvider()
@@ -109,12 +98,12 @@ class TransactionStackTest extends TestCase
             [
                 ['a', 'b'],
                 'b',
-                false,
+                ['a', 'b'],
             ],
             [
                 [],
                 null,
-                true,
+                [],
             ],
         ];
     }
@@ -122,13 +111,8 @@ class TransactionStackTest extends TestCase
     /**
      * @dataProvider popDataProvider
      */
-    public function testPop($initialData, $expectedData, $expectedRemainingData, $expectedExceptionThrow)
+    public function testPop($initialData, $expectedData, $expectedRemainingData)
     {
-        if ($expectedExceptionThrow) {
-            $this->expectException(\UnderflowException::class);
-            $this->expectExceptionMessage('Popping an empty stack is not allowed.');
-        }
-
         $stack = new TransactionStack($initialData);
 
         $this->assertEquals($expectedData, $stack->pop());
@@ -142,13 +126,11 @@ class TransactionStackTest extends TestCase
                 ['a', 'b'],
                 'b',
                 ['a'],
-                false,
             ],
             [
                 [],
                 null,
                 [],
-                true,
             ],
         ];
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This is a small refactoring of the `TransactionStack` class. I introduced some BC breaks, but I think they are worth it as they make the code prettier and clearer. The following changes have been introduced:

- The stack is now a private member of the `Client` class and a getter has been added to access it
- The `isEmpty` function has been added and the [`Countable`](http://php.net/manual/en/class.countable.php) interface implemented
- Exceptions are thrown if an user tries to peek or pop from an empty stack instead of silently returning a `null` value
- Validation is done for the pushed entries so that only strings are allowed

Everything should BTW be documented in the `UPGRADE.md` file, please check it and tell me if something is missing. I noticed that I often forget to write the upgrade changes there