### PR TITLE
[2.0] Add RuntimeContext class to store runtime information

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -15,6 +15,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Breadcrumbs\Recorder;
 use Raven\Context\Context;
+use Raven\Context\RuntimeContext;
 use Raven\Context\TagsContext;
 use Raven\Middleware\BreadcrumbInterfaceMiddleware;
 use Raven\Middleware\ContextInterfaceMiddleware;
@@ -119,7 +120,7 @@ class Client
     private $extraContext;
 
     /**
-     * @var Context The runtime context
+     * @var RuntimeContext The runtime context
      */
     private $runtimeContext;
 
@@ -157,7 +158,7 @@ class Client
         $this->tagsContext = new TagsContext();
         $this->userContext = new Context();
         $this->extraContext = new Context();
-        $this->runtimeContext = new Context();
+        $this->runtimeContext = new RuntimeContext();
         $this->serverOsContext = new Context();
         $this->recorder = new Recorder();
         $this->transaction = new TransactionStack();
@@ -589,7 +590,7 @@ class Client
     /**
      * Gets the runtime context.
      *
-     * @return Context
+     * @return RuntimeContext
      */
     public function getRuntimeContext()
     {

--- a/lib/Raven/Configuration.php
+++ b/lib/Raven/Configuration.php
@@ -631,7 +631,7 @@ class Configuration
     }
 
     /**
-     * Configures the options for this processor.
+     * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
      *

--- a/lib/Raven/Context/RuntimeContext.php
+++ b/lib/Raven/Context/RuntimeContext.php
@@ -16,8 +16,8 @@ use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
- * This class is a specialized implementation of the {@see `Context`} class
- * that stores information about the current runtime.
+ * This class is a specialized implementation of the {@see Context} class that
+ * stores information about the current runtime.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
@@ -103,6 +103,46 @@ class RuntimeContext extends Context
         $data = $this->resolver->resolve([$offset => $value]);
 
         parent::offsetSet($offset, $data[$offset]);
+    }
+
+    /**
+     * Gets the name of the runtime.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->data['name'];
+    }
+
+    /**
+     * Sets the name of the runtime.
+     *
+     * @param string $name The name
+     */
+    public function setName($name)
+    {
+        $this->offsetSet('name', $name);
+    }
+
+    /**
+     * Gets the version of the runtime.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->data['version'];
+    }
+
+    /**
+     * Sets the version of the runtime.
+     *
+     * @param string $version The version
+     */
+    public function setVersion($version)
+    {
+        $this->offsetSet('version', $version);
     }
 
     /**

--- a/lib/Raven/Context/RuntimeContext.php
+++ b/lib/Raven/Context/RuntimeContext.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Context;
+
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * This class is a specialized implementation of the {@see `Context`} class
+ * that stores information about the current runtime.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+class RuntimeContext extends Context
+{
+    /**
+     * @var OptionsResolver The options resolver
+     */
+    private $resolver;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function __construct(array $data = [])
+    {
+        $this->resolver = new OptionsResolver();
+
+        $this->configureOptions($this->resolver);
+
+        parent::__construct($this->resolver->resolve($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function merge(array $data, $recursive = false)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::merge($data, $recursive);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function setData(array $data)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::setData($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function replaceData(array $data)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::replaceData($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function offsetSet($offset, $value)
+    {
+        $data = $this->resolver->resolve([$offset => $value]);
+
+        parent::offsetSet($offset, $data[$offset]);
+    }
+
+    /**
+     * Configures the options of the context.
+     *
+     * @param OptionsResolver $resolver The resolver for the options
+     */
+    private function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'name' => 'php',
+            'version' => PHP_VERSION,
+        ]);
+
+        $resolver->setAllowedTypes('name', 'string');
+        $resolver->setAllowedTypes('version', 'string');
+    }
+}

--- a/tests/Context/RuntimeContextTest.php
+++ b/tests/Context/RuntimeContextTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Tests\Context;
+
+use PHPUnit\Framework\TestCase;
+use Raven\Context\RuntimeContext;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
+class RuntimeContextTest extends TestCase
+{
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testConstructor($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new RuntimeContext($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testMerge($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new RuntimeContext();
+        $context->merge($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testSetData($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new RuntimeContext();
+        $context->setData($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testReplaceData($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new RuntimeContext();
+        $context->replaceData($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    public function valuesDataProvider()
+    {
+        return [
+            [
+                [],
+                [
+                    'name' => 'php',
+                    'version' => PHP_VERSION,
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'name' => 'foo',
+                ],
+                [
+                    'name' => 'foo',
+                    'version' => PHP_VERSION,
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'name' => 'foo',
+                    'version' => 'bar',
+                ],
+                [
+                    'name' => 'foo',
+                    'version' => 'bar',
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'foo' => 'bar',
+                ],
+                [],
+                UndefinedOptionsException::class,
+                'The option "foo" does not exist. Defined options are: "name", "version".',
+            ],
+            [
+                [
+                    'name' => 1,
+                ],
+                [],
+                InvalidOptionsException::class,
+                'The option "name" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                [
+                    'version' => 1,
+                ],
+                [],
+                InvalidOptionsException::class,
+                'The option "version" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider offsetSetDataProvider
+     */
+    public function testOffsetSet($key, $value, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new RuntimeContext();
+        $context[$key] = $value;
+
+        $this->assertArraySubset([$key => $value], $context->toArray());
+    }
+
+    public function offsetSetDataProvider()
+    {
+        return [
+            [
+                'name',
+                'foo',
+                null,
+                null,
+            ],
+            [
+                'name',
+                1,
+                InvalidOptionsException::class,
+                'The option "name" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                'version',
+                1,
+                InvalidOptionsException::class,
+                'The option "version" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                'foo',
+                'bar',
+                UndefinedOptionsException::class,
+                'The option "foo" does not exist. Defined options are: "name", "version".',
+            ],
+        ];
+    }
+}

--- a/tests/Context/RuntimeContextTest.php
+++ b/tests/Context/RuntimeContextTest.php
@@ -188,4 +188,31 @@ class RuntimeContextTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @dataProvider gettersAndSettersDataProvider
+     */
+    public function testGettersAndSetters($getterMethod, $setterMethod, $value)
+    {
+        $context = new RuntimeContext();
+        $context->$setterMethod($value);
+
+        $this->assertEquals($value, $context->$getterMethod());
+    }
+
+    public function gettersAndSettersDataProvider()
+    {
+        return [
+            [
+                'getName',
+                'setName',
+                'foo',
+            ],
+            [
+                'getVersion',
+                'setVersion',
+                'bar',
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR aims to fix issue #562 for the `2.x` branch by introducing a specialized `RuntimeContext` class that automatically compiles the runtime SDK interface with the PHP version for the captured events.