### PR TITLE
[2.0] Implement a specialized context class for the server OS context type

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -16,6 +16,7 @@ use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Breadcrumbs\Recorder;
 use Raven\Context\Context;
 use Raven\Context\RuntimeContext;
+use Raven\Context\ServerOsContext;
 use Raven\Context\TagsContext;
 use Raven\Middleware\BreadcrumbInterfaceMiddleware;
 use Raven\Middleware\ContextInterfaceMiddleware;
@@ -125,7 +126,7 @@ class Client
     private $runtimeContext;
 
     /**
-     * @var Context The server OS context
+     * @var ServerOsContext The server OS context
      */
     private $serverOsContext;
 
@@ -159,7 +160,7 @@ class Client
         $this->userContext = new Context();
         $this->extraContext = new Context();
         $this->runtimeContext = new RuntimeContext();
-        $this->serverOsContext = new Context();
+        $this->serverOsContext = new ServerOsContext();
         $this->recorder = new Recorder();
         $this->transaction = new TransactionStack();
         $this->serializer = new Serializer($this->config->getMbDetectOrder());
@@ -436,18 +437,6 @@ class Client
             $event = $event->withLogger($payload['logger']);
         }
 
-        if (isset($payload['tags_context'])) {
-            $event = $event->withTagsContext($payload['tags_context']);
-        }
-
-        if (isset($payload['extra_context'])) {
-            $event = $event->withExtraContext($payload['extra_context']);
-        }
-
-        if (isset($payload['user_context'])) {
-            $event = $event->withUserContext($payload['user_context']);
-        }
-
         if (isset($payload['message'])) {
             $payload['message'] = substr($payload['message'], 0, static::MESSAGE_LIMIT);
         }
@@ -600,7 +589,7 @@ class Client
     /**
      * Gets the server OS context.
      *
-     * @return Context
+     * @return ServerOsContext
      */
     public function getServerOsContext()
     {

--- a/lib/Raven/Context/ServerOsContext.php
+++ b/lib/Raven/Context/ServerOsContext.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Context;
+
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * This class is a specialized implementation of the {@see Context} class that
+ * stores information about the operating system of the server.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+class ServerOsContext extends Context
+{
+    /**
+     * @var OptionsResolver The options resolver
+     */
+    private $resolver;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function __construct(array $data = [])
+    {
+        $this->resolver = new OptionsResolver();
+
+        $this->configureOptions($this->resolver);
+
+        parent::__construct($this->resolver->resolve($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function merge(array $data, $recursive = false)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::merge($data, $recursive);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function setData(array $data)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::setData($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function replaceData(array $data)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::replaceData($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function offsetSet($offset, $value)
+    {
+        $data = $this->resolver->resolve([$offset => $value]);
+
+        parent::offsetSet($offset, $data[$offset]);
+    }
+
+    /**
+     * Gets the name of the operating system.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->data['name'];
+    }
+
+    /**
+     * Sets the name of the operating system.
+     *
+     * @param string $name The name
+     */
+    public function setName($name)
+    {
+        $this->offsetSet('name', $name);
+    }
+
+    /**
+     * Gets the version of the operating system.
+     *
+     * @return string
+     */
+    public function getVersion()
+    {
+        return $this->data['version'];
+    }
+
+    /**
+     * Sets the version of the operating system.
+     *
+     * @param string $version The version
+     */
+    public function setVersion($version)
+    {
+        $this->offsetSet('version', $version);
+    }
+
+    /**
+     * Gets the build of the operating system.
+     *
+     * @return string
+     */
+    public function getBuild()
+    {
+        return $this->data['build'];
+    }
+
+    /**
+     * Sets the build of the operating system.
+     *
+     * @param string $build The build
+     */
+    public function setBuild($build)
+    {
+        $this->offsetSet('build', $build);
+    }
+
+    /**
+     * Gets the version of the kernel of the operating system.
+     *
+     * @return string
+     */
+    public function getKernelVersion()
+    {
+        return $this->data['kernel_version'];
+    }
+
+    /**
+     * Sets the version of the kernel of the operating system.
+     *
+     * @param string $kernelVersion The kernel version
+     */
+    public function setKernelVersion($kernelVersion)
+    {
+        $this->offsetSet('kernel_version', $kernelVersion);
+    }
+
+    /**
+     * Configures the options of the context.
+     *
+     * @param OptionsResolver $resolver The resolver for the options
+     */
+    private function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'name' => php_uname('s'),
+            'version' => php_uname('r'),
+            'build' => php_uname('v'),
+            'kernel_version' => php_uname('a'),
+        ]);
+
+        $resolver->setAllowedTypes('name', 'string');
+        $resolver->setAllowedTypes('version', 'string');
+        $resolver->setAllowedTypes('build', 'string');
+        $resolver->setAllowedTypes('kernel_version', 'string');
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -19,6 +19,8 @@ use Raven\Client;
 use Raven\ClientBuilder;
 use Raven\Configuration;
 use Raven\Context\Context;
+use Raven\Context\RuntimeContext;
+use Raven\Context\ServerOsContext;
 use Raven\Context\TagsContext;
 use Raven\Event;
 use Raven\Serializer;
@@ -295,14 +297,14 @@ class ClientTest extends TestCase
     {
         $client = ClientBuilder::create()->getClient();
 
-        $this->assertInstanceOf(Context::class, $client->getRuntimeContext());
+        $this->assertInstanceOf(RuntimeContext::class, $client->getRuntimeContext());
     }
 
     public function testGetServerOsContext()
     {
         $client = ClientBuilder::create()->getClient();
 
-        $this->assertInstanceOf(Context::class, $client->getServerOsContext());
+        $this->assertInstanceOf(ServerOsContext::class, $client->getServerOsContext());
     }
 
     public function testAppPathLinux()

--- a/tests/Context/ServerOsContextTest.php
+++ b/tests/Context/ServerOsContextTest.php
@@ -1,0 +1,305 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Tests\Context;
+
+use PHPUnit\Framework\TestCase;
+use Raven\Context\ServerOsContext;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+
+class ServerOsContextTest extends TestCase
+{
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testConstructor($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new ServerOsContext($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testMerge($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new ServerOsContext();
+        $context->merge($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testSetData($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new ServerOsContext();
+        $context->setData($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    /**
+     * @dataProvider valuesDataProvider
+     */
+    public function testReplaceData($initialData, $expectedData, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new ServerOsContext();
+        $context->replaceData($initialData);
+
+        $this->assertEquals($expectedData, $context->toArray());
+    }
+
+    public function valuesDataProvider()
+    {
+        return [
+            [
+                [],
+                [
+                    'name' => php_uname('s'),
+                    'version' => php_uname('r'),
+                    'build' => php_uname('v'),
+                    'kernel_version' => php_uname('a'),
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'name' => 'foo',
+                ],
+                [
+                    'name' => 'foo',
+                    'version' => php_uname('r'),
+                    'build' => php_uname('v'),
+                    'kernel_version' => php_uname('a'),
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'version' => 'bar',
+                ],
+                [
+                    'name' => php_uname('s'),
+                    'version' => 'bar',
+                    'build' => php_uname('v'),
+                    'kernel_version' => php_uname('a'),
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'build' => 'baz',
+                ],
+                [
+                    'name' => php_uname('s'),
+                    'version' => php_uname('r'),
+                    'build' => 'baz',
+                    'kernel_version' => php_uname('a'),
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'kernel_version' => 'foobarbaz',
+                ],
+                [
+                    'name' => php_uname('s'),
+                    'version' => php_uname('r'),
+                    'build' => php_uname('v'),
+                    'kernel_version' => 'foobarbaz',
+                ],
+                null,
+                null,
+            ],
+            [
+                [
+                    'foo' => 'bar',
+                ],
+                [],
+                UndefinedOptionsException::class,
+                'The option "foo" does not exist. Defined options are: "build", "kernel_version", "name", "version".',
+            ],
+            [
+                [
+                    'name' => 1,
+                ],
+                [],
+                InvalidOptionsException::class,
+                'The option "name" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                [
+                    'version' => 1,
+                ],
+                [],
+                InvalidOptionsException::class,
+                'The option "version" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                [
+                    'build' => 1,
+                ],
+                [],
+                InvalidOptionsException::class,
+                'The option "build" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                [
+                    'kernel_version' => 1,
+                ],
+                [],
+                InvalidOptionsException::class,
+                'The option "kernel_version" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider offsetSetDataProvider
+     */
+    public function testOffsetSet($key, $value, $expectedExceptionClass, $expectedExceptionMessage)
+    {
+        if (null !== $expectedExceptionClass) {
+            $this->expectException($expectedExceptionClass);
+            $this->expectExceptionMessage($expectedExceptionMessage);
+        }
+
+        $context = new ServerOsContext();
+        $context[$key] = $value;
+
+        $this->assertArraySubset([$key => $value], $context->toArray());
+    }
+
+    public function offsetSetDataProvider()
+    {
+        return [
+            [
+                'name',
+                'foo',
+                null,
+                null,
+            ],
+            [
+                'name',
+                1,
+                InvalidOptionsException::class,
+                'The option "name" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                'version',
+                'foo',
+                null,
+                null,
+            ],
+            [
+                'version',
+                1,
+                InvalidOptionsException::class,
+                'The option "version" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                'build',
+                'foo',
+                null,
+                null,
+            ],
+            [
+                'build',
+                1,
+                InvalidOptionsException::class,
+                'The option "build" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                'kernel_version',
+                'foobarbaz',
+                null,
+                null,
+            ],
+            [
+                'kernel_version',
+                1,
+                InvalidOptionsException::class,
+                'The option "kernel_version" with value 1 is expected to be of type "string", but is of type "integer".',
+            ],
+            [
+                'foo',
+                'bar',
+                UndefinedOptionsException::class,
+                'The option "foo" does not exist. Defined options are: "build", "kernel_version", "name", "version".',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider gettersAndSettersDataProvider
+     */
+    public function testGettersAndSetters($getterMethod, $setterMethod, $value)
+    {
+        $context = new ServerOsContext();
+        $context->$setterMethod($value);
+
+        $this->assertEquals($value, $context->$getterMethod());
+    }
+
+    public function gettersAndSettersDataProvider()
+    {
+        return [
+            [
+                'getName',
+                'setName',
+                'foo',
+            ],
+            [
+                'getVersion',
+                'setVersion',
+                'bar',
+            ],
+            [
+                'getBuild',
+                'setBuild',
+                'baz',
+            ],
+            [
+                'getKernelVersion',
+                'setKernelVersion',
+                'foobarbaz',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Following the lines of the PR that implemented a `RuntimeContext` class, this one introduces a specialized version of the `Context` class that handles the context type representing the operating system. These are the information printed in Sentry

| Property Name | Value |
| ------------- | ------------- |
Version | build 16299 (Windows 10) (10.0)
Kernel Version | Windows NT DESKTOP-XXXXXXX 10.0 build 16299 (Windows 10) AMD64
