### PR TITLE
Update docs config

### DIFF
--- a/docs/sentry-doc-config.json
+++ b/docs/sentry-doc-config.json
@@ -16,8 +16,9 @@
       "type": "framework",
       "doc_link": "integrations/laravel/",
       "wizard": [
-        "index#installation",
-        "integrations/laravel#laravel-5-x"
+        "integrations/laravel#laravel-5-x",
+        "integrations/laravel#laravel-4-x",
+        "integrations/laravel#lumen-5-x"
       ]
     },
     "php.monolog": {
@@ -34,7 +35,6 @@
       "type": "framework",
       "doc_link": "integrations/symfony2/",
       "wizard": [
-        "index#installation",
         "integrations/symfony2#symfony-2"
       ]
     }


### PR DESCRIPTION
Currently the generic php instructions are prepended on the Laravel & Symfony getting started pages in Sentry, this should not be the case since they are not needed and confusing at best.

Also added Laravel 4.x & Lumen 5.x instructions to that page.