### PR TITLE
Revert ignoring fatal errors on PHP 7+

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -140,13 +140,6 @@ class Raven_ErrorHandler
 
     public function shouldCaptureFatalError($type)
     {
-        // Do not capture E_ERROR since those can be caught by userland since PHP 7.0
-        // E_ERROR should already be handled by the exception handler
-        // This prevents duplicated exceptions in PHP 7.0+
-        if (PHP_VERSION_ID >= 70000 && $type === E_ERROR) {
-            return false;
-        }
-
         return $type & $this->fatal_error_types;
     }
 

--- a/test/Raven/Tests/ErrorHandlerTest.php
+++ b/test/Raven/Tests/ErrorHandlerTest.php
@@ -207,8 +207,6 @@ class Raven_Tests_ErrorHandlerTest extends \PHPUnit\Framework\TestCase
                        ->getMock();
         $handler = new Raven_ErrorHandler($client);
 
-        $this->assertEquals($handler->shouldCaptureFatalError(E_ERROR), PHP_VERSION_ID < 70000);
-
         $this->assertEquals($handler->shouldCaptureFatalError(E_WARNING), false);
     }
 

--- a/test/Raven/phpt/fatal_reported_twice_regression.phpt
+++ b/test/Raven/phpt/fatal_reported_twice_regression.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test that, when handling a fatal, we report it once and only once
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/test/bootstrap.php';
+
+error_reporting(E_ALL);
+$client = new \Raven_Client();
+set_error_handler(function () use ($client) {
+    echo 'Previous error handler is called' . PHP_EOL;
+    echo 'Error is ' . ($client->getLastEventID() !== null ? 'reported correctly' : 'NOT reported');
+});
+
+set_exception_handler(function () {
+    echo 'This should not be called';
+});
+
+$client->install();
+
+require 'inexistent_file.php';
+?>
+--EXPECTF--
+Previous error handler is called
+Error is reported correctly
+Fatal error: %a


### PR DESCRIPTION
This PR attempts to fix #552 allowing all fatals to be captured, with no exception anymore. This is because further investigations lead to discover that the issues in double or loop reporting of fatals where due to a bug on Symfony: see the issue https://github.com/symfony/symfony/issues/26438 and the fix https://github.com/symfony/symfony/pull/26568.

Eventual double reporting should be not fixed here in the client, but on the native integrations, like in the Symfony Bundle.

This PR also adds a regression test with a PHPT test, which could be run with PHPUnit with no issues.