### PR TITLE
Avoid double reporting due to ErrorExceptions

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
   <testsuites>
     <testsuite name="Raven Test Suite">
       <directory>./test/Raven/</directory>
+      <directory suffix=".phpt">./test/Raven/phpt/</directory>
     </testsuite>
   </testsuites>
 

--- a/test/Raven/phpt/error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/error_reported_twice_regression.phpt
@@ -38,4 +38,4 @@ Fatal error: Uncaught TypeError: Argument 1 passed to iAcceptOnlyArrays() must b
 Stack trace:
 #0 %s
 #1 {main}
-  thrown in - on line %s
+  thrown in %s

--- a/test/Raven/phpt/error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/error_reported_twice_regression.phpt
@@ -22,12 +22,12 @@ $client->setSendCallback(function (array $data) {
 });
 $client->install();
 
-function thisiswrong(): float
+function iAcceptOnlyArrays(array $array)
 {
-    return 'not a float';
+    return false;
 }
 
-thisiswrong();
+iAcceptOnlyArrays('not an array');
 
 ?>
 --EXPECTF--

--- a/test/Raven/phpt/error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/error_reported_twice_regression.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test that, when handling a fatal, we report it once and only once
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('This test makes sense only under PHP 7+'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('Skipped: this test makes sense only under PHP 7+'); ?>
 --FILE--
 <?php
 
@@ -31,10 +31,10 @@ iAcceptOnlyArrays('not an array');
 
 ?>
 --EXPECTF--
-Sending message: Return value of thisiswrong() must be of the type float, string returned
-Sending message of type: TypeError
+Sending message: Argument 1 passed to iAcceptOnlyArrays() must be of the type array, string given%s
+Sending message of type: %s
 
-Fatal error: Uncaught TypeError: Return value of thisiswrong() must be of the type float, string returned in %a
+Fatal error: Uncaught TypeError: Argument 1 passed to iAcceptOnlyArrays() must be of the type array, string given%s
 Stack trace:
 #0 %s
 #1 {main}

--- a/test/Raven/phpt/error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/error_reported_twice_regression.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test that, when handling a fatal, we report it once and only once
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('This test makes sense only under PHP 7+'); ?>
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (! file_exists($vendor . '/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor . '/test/bootstrap.php';
+
+error_reporting(E_ALL);
+$client = new \Raven_Client();
+
+$client->setSendCallback(function (array $data) {
+    echo 'Sending message: ' . $data['exception']['values'][0]['value'] . PHP_EOL;
+    echo 'Sending message of type: ' . $data['exception']['values'][0]['type'] . PHP_EOL;
+
+    return false;
+});
+$client->install();
+
+function thisiswrong(): float
+{
+    return 'not a float';
+}
+
+thisiswrong();
+
+?>
+--EXPECTF--
+Sending message: Return value of thisiswrong() must be of the type float, string returned
+Sending message of type: TypeError
+
+Fatal error: Uncaught TypeError: Return value of thisiswrong() must be of the type float, string returned in %a
+Stack trace:
+#0 %s
+#1 {main}
+  thrown in - on line %s

--- a/test/Raven/phpt/parse_error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/parse_error_reported_twice_regression.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test that, when handling a fatal, we report it once and only once
+--SKIPIF--
+<?php if (PHP_VERSION_ID < 70000) die('This test makes sense only under PHP 7+'); ?>
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (! file_exists($vendor . '/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor . '/test/bootstrap.php';
+
+error_reporting(E_ALL);
+$client = new \Raven_Client();
+
+$client->setSendCallback(function (array $data) {
+    echo 'Sending message: ' . $data['exception']['values'][0]['value'] . PHP_EOL;
+    echo 'Sending message of type: ' . $data['exception']['values'][0]['type'] . PHP_EOL;
+
+    return false;
+});
+$client->install();
+
+include __DIR__ . '/resources/parseError.php';
+
+?>
+--EXPECTF--
+Sending message: syntax error, unexpected 'error' (T_STRING)
+Sending message of type: ParseError
+
+Parse error: syntax error, unexpected 'error' (T_STRING) in /home/jean/workspace/sentry-php/test/Raven/phpt/resources/parseError.php on line 3
+
+Fatal error: Exception thrown without a stack frame in Unknown on line 0

--- a/test/Raven/phpt/parse_error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/parse_error_reported_twice_regression.phpt
@@ -29,6 +29,6 @@ include __DIR__ . '/resources/parseError.php';
 Sending message: syntax error, unexpected 'error' (T_STRING)
 Sending message of type: ParseError
 
-Parse error: syntax error, unexpected 'error' (T_STRING) in /home/jean/workspace/sentry-php/test/Raven/phpt/resources/parseError.php on line 3
+Parse error: syntax error, unexpected 'error' (T_STRING) in %s/test/Raven/phpt/resources/parseError.php on line 3
 
 Fatal error: Exception thrown without a stack frame in Unknown on line 0

--- a/test/Raven/phpt/parse_error_reported_twice_regression.phpt
+++ b/test/Raven/phpt/parse_error_reported_twice_regression.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test that, when handling a fatal, we report it once and only once
 --SKIPIF--
-<?php if (PHP_VERSION_ID < 70000) die('This test makes sense only under PHP 7+'); ?>
+<?php if (PHP_VERSION_ID < 70000) die('Skipped: this test makes sense only under PHP 7+'); ?>
 --FILE--
 <?php
 

--- a/test/Raven/phpt/resources/parseError.php
+++ b/test/Raven/phpt/resources/parseError.php
@@ -1,0 +1,3 @@
+<?php
+
+parse error


### PR DESCRIPTION
This PR adds two regression PHPT tests to solve the issue of double-reporting errors under PHP 7+, due to the rethrowing of `E_ERROR` as an `ErrorException`

I'm not sure how to solve this issue, but at least this is a start. Thanks to @mfb for giving me the repro scripts in https://github.com/getsentry/sentry-php/issues/552#issuecomment-374665871