### PR TITLE
Force event send after fatal error with curl_method async

### DIFF
--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -82,6 +82,10 @@ class Raven_CurlHandler
             }
             usleep(10000);
         } while ($timeout !== 0 && time() - $start < $timeout);
+
+        if (!defined('RAVEN_CURL_END_REACHED')) {
+            define('RAVEN_CURL_END_REACHED', true);
+        }
     }
 
     /**

--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -82,10 +82,6 @@ class Raven_CurlHandler
             }
             usleep(10000);
         } while ($timeout !== 0 && time() - $start < $timeout);
-
-        if (!defined('RAVEN_CURL_END_REACHED')) {
-            define('RAVEN_CURL_END_REACHED', true);
-        }
     }
 
     /**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
   <testsuites>
     <testsuite name="Raven Test Suite">
       <directory>./test/Raven/</directory>
+      <directory suffix=".phpt">./test/Raven/phpt/</directory>
     </testsuite>
   </testsuites>
 

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -10,6 +10,11 @@ while (!file_exists($vendor.'/vendor')) {
 require $vendor.'/test/bootstrap.php';
 
 $client = new \Raven_Client(array('curl_method' => 'async'));
+
+$client->setSendCallback(function (array $data) {
+    echo 'Sending handled fatal error...' . PHP_EOL;
+});
+
 register_shutdown_function(function () {
     if (constant('RAVEN_CURL_END_REACHED')) {
         echo 'Raven_CurlHandler::join() was called before' . PHP_EOL;
@@ -25,4 +30,5 @@ while (TRUE) {
 ?>
 --EXPECTF--
 Fatal error: Allowed memory size %s
+Sending handled fatal error...
 Raven_CurlHandler::join() was called before

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test that, when handling a fatal with async send enabled, we force the async to avoid losing the event
+--FILE--
+<?php
+
+$vendor = __DIR__;
+while (!file_exists($vendor.'/vendor')) {
+    $vendor = dirname($vendor);
+}
+require $vendor.'/test/bootstrap.php';
+
+$client = new \Raven_Client(array('curl_method' => 'async'));
+register_shutdown_function(function () {
+    if (constant('RAVEN_CURL_END_REACHED')) {
+        echo 'Raven_CurlHandler::join() was called before' . PHP_EOL;
+    }
+});
+
+$client->install();
+
+ini_set('memory_limit', '8M');
+while (TRUE) {
+    $a[] = 'b';
+}
+?>
+--EXPECTF--
+Fatal error: Allowed memory size %s
+Raven_CurlHandler::join() was called before


### PR DESCRIPTION
This is to address #391: when using the `'curl_method' => 'async'` option, in the case of a fatal error the event is not sent to Sentry, at least in PHP < 7.

For starter, it adds a regression test that checks the order of method calls of `ErrorHandler::handleFatal()` and `Raven_CurlHandler::join()`.