### PR TITLE
Apply other fix for #391

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -131,7 +131,7 @@ class Raven_Client
     /**
      * @var bool
      */
-    private $useCompression;
+    public $useCompression;
 
     public function __construct($options_or_dsn = null, $options = array())
     {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -128,6 +128,11 @@ class Raven_Client
      */
     protected $_shutdown_function_has_been_set;
 
+    /**
+     * @var bool
+     */
+    private $useCompression;
+
     public function __construct($options_or_dsn = null, $options = array())
     {
         if (is_array($options_or_dsn)) {
@@ -195,6 +200,7 @@ class Raven_Client
         $this->context = new Raven_Context();
         $this->breadcrumbs = new Raven_Breadcrumbs();
         $this->_shutdown_function_has_been_set = false;
+        $this->useCompression = function_exists('gzcompress') && extension_loaded('zip');
 
         $this->sdk = Raven_Util::get($options, 'sdk', array(
             'name' => 'sentry-php',
@@ -995,7 +1001,7 @@ class Raven_Client
             return false;
         }
 
-        if (function_exists("gzcompress")) {
+        if ($this->useCompression) {
             $message = gzcompress($message);
         }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -228,12 +228,7 @@ class Raven_Client
             $this->registerShutdownFunction();
         }
 
-        // manually trigger autoloading, as it cannot be done during error handling in some edge cases due to PHP (see #60149)
-        if (!class_exists('Raven_Stacktrace')) {
-            // @codeCoverageIgnoreStart
-            spl_autoload_call('Raven_Stacktrace');
-            // @codeCoverageIgnoreEnd
-        }
+        $this->triggerAutoload();
     }
 
     public function __destruct()
@@ -1516,5 +1511,24 @@ class Raven_Client
     public function setReprSerializer(Raven_ReprSerializer $reprSerializer)
     {
         $this->reprSerializer = $reprSerializer;
+    }
+
+    private function triggerAutoload()
+    {
+        // manually trigger autoloading, as it cannot be done during error handling in some edge cases due to PHP (see #60149)
+       
+        if (! class_exists('Raven_Stacktrace')) {
+            spl_autoload_call('Raven_Stacktrace');
+        }
+
+        if (function_exists('mb_detect_encoding')) {
+            mb_detect_encoding('string');
+        }
+        if (function_exists('mb_convert_encoding')) {
+            mb_convert_encoding('string', 'UTF8');
+        }
+        if (function_exists('mb_convert_encoding')) {
+            mb_convert_encoding('string', 'UTF8');
+        }
     }
 }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -200,7 +200,7 @@ class Raven_Client
         $this->context = new Raven_Context();
         $this->breadcrumbs = new Raven_Breadcrumbs();
         $this->_shutdown_function_has_been_set = false;
-        $this->useCompression = function_exists('gzcompress') && extension_loaded('zip');
+        $this->useCompression = function_exists('gzcompress');
 
         $this->sdk = Raven_Util::get($options, 'sdk', array(
             'name' => 'sentry-php',
@@ -1524,9 +1524,7 @@ class Raven_Client
         if (function_exists('mb_detect_encoding')) {
             mb_detect_encoding('string');
         }
-        if (function_exists('mb_convert_encoding')) {
-            mb_convert_encoding('string', 'UTF8');
-        }
+
         if (function_exists('mb_convert_encoding')) {
             mb_convert_encoding('string', 'UTF8');
         }

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -258,6 +258,11 @@ class Raven_Client
         $this->error_handler->registerExceptionHandler();
         $this->error_handler->registerErrorHandler();
         $this->error_handler->registerShutdownFunction();
+        
+        if ($this->_curl_handler) {
+            $this->_curl_handler->registerShutdownFunction();
+        }
+
         return $this;
     }
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -1516,7 +1516,7 @@ class Raven_Client
     private function triggerAutoload()
     {
         // manually trigger autoloading, as it cannot be done during error handling in some edge cases due to PHP (see #60149)
-       
+
         if (! class_exists('Raven_Stacktrace')) {
             spl_autoload_call('Raven_Stacktrace');
         }

--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -29,7 +29,7 @@ class Raven_CurlHandler
         $this->requests = array();
         $this->join_timeout = $join_timeout;
 
-        register_shutdown_function(array($this, 'join'));
+        $this->registerShutdownFunction();
     }
 
     public function __destruct()
@@ -67,6 +67,11 @@ class Raven_CurlHandler
         $this->select();
 
         return $fd;
+    }
+
+    public function registerShutdownFunction()
+    {
+        register_shutdown_function(array($this, 'join'));
     }
 
     public function join($timeout = null)

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -138,6 +138,8 @@ class Raven_ErrorHandler
                 @$error['message'], 0, @$error['type'],
                 @$error['file'], @$error['line']
             );
+            
+            $this->client->useCompression &= PHP_VERSION_ID > 70000;
             $this->handleException($e, true);
         }
     }

--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -139,7 +139,7 @@ class Raven_ErrorHandler
                 @$error['file'], @$error['line']
             );
             
-            $this->client->useCompression &= PHP_VERSION_ID > 70000;
+            $this->client->useCompression = $this->client->useCompression && PHP_VERSION_ID > 70000;
             $this->handleException($e, true);
         }
     }

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -2072,7 +2072,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertRegExp('_^[a-zA-Z0-9/=]+$_', $value, 'Raven_Client::encode returned malformed data');
         $decoded = base64_decode($value);
         $this->assertInternalType('string', $decoded, 'Can not use base64 decode on the encoded blob');
-        if (function_exists('gzcompress') && extension_loaded('zip')) {
+        if (function_exists('gzcompress')) {
             $decoded = gzuncompress($decoded);
             $this->assertEquals($json_stringify, $decoded, 'Can not decompress compressed blob');
         } else {

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -2072,7 +2072,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertRegExp('_^[a-zA-Z0-9/=]+$_', $value, 'Raven_Client::encode returned malformed data');
         $decoded = base64_decode($value);
         $this->assertInternalType('string', $decoded, 'Can not use base64 decode on the encoded blob');
-        if (function_exists("gzcompress")) {
+        if (function_exists('gzcompress') && extension_loaded('zip')) {
             $decoded = gzuncompress($decoded);
             $this->assertEquals($json_stringify, $decoded, 'Can not decompress compressed blob');
         } else {

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -14,6 +14,7 @@ require $vendor.'/vendor/autoload.php';
 
 $dsn = 'https://user:password@sentry.test/123456';
 $client = new \Raven_Client($dsn, array('curl_method' => 'async', 'server' => 'sentry.test'));
+// doing this to avoid autoload-driver failures during the error handling
 $pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
 $curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
 $pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');
@@ -24,7 +25,11 @@ $client->setSendCallback(function () {
 
 $client->install();
 
-register_shutdown_function(function () use (&$pendingEvents, &$pendingRequests) {
+register_shutdown_function(function () use (&$client) {
+    $pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
+    $curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
+    $pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');
+
     if (! empty($pendingEvents)) {
         echo 'There are pending events inside the client';
     }

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -11,7 +11,7 @@ require $vendor.'/test/bootstrap.php';
 require $vendor.'/vendor/autoload.php';
 
 $dsn = 'https://user:password@sentry.test/123456';
-$client = new \Raven_Client($dsn, array('curl_method' => 'async'));
+$client = new \Raven_Client($dsn, array('curl_method' => 'async', 'server' => 'sentry.test'));
 $pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
 $curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
 $pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test that, when handling a fatal with async send enabled, we force the async to avoid losing the event
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 50400 && PHP_VERSION_ID < 50600) die('Skipped: this fails under PHP 5.4/5.5, we cannot fix it'); ?>
 --FILE--
 <?php
 

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -12,6 +12,9 @@ require $vendor.'/vendor/autoload.php';
 
 $dsn = 'https://user:password@sentry.test/123456';
 $client = new \Raven_Client($dsn, array('curl_method' => 'async'));
+$pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
+$curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
+$pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');
 
 $client->setSendCallback(function () {
     echo 'Sending handled fatal error...' . PHP_EOL;
@@ -19,11 +22,7 @@ $client->setSendCallback(function () {
 
 $client->install();
 
-register_shutdown_function(function () use (&$client) {
-    $pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
-    $curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
-    $pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');
-
+register_shutdown_function(function () use (&$pendingEvents, &$pendingRequests) {
     if (! empty($pendingEvents)) {
         echo 'There are pending events inside the client';
     }

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -10,10 +10,8 @@ while (!file_exists($vendor.'/vendor')) {
 require $vendor.'/test/bootstrap.php';
 require $vendor.'/vendor/autoload.php';
 
-$client = new \Raven_Client(array('curl_method' => 'async'));
-$pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
-$curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
-$pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');
+$dsn = 'https://user:password@sentry.test/123456';
+$client = new \Raven_Client($dsn, array('curl_method' => 'async'));
 
 $client->setSendCallback(function () {
     echo 'Sending handled fatal error...' . PHP_EOL;
@@ -21,7 +19,11 @@ $client->setSendCallback(function () {
 
 $client->install();
 
-register_shutdown_function(function () use ($pendingEvents, $pendingRequests) {
+register_shutdown_function(function () use (&$client) {
+    $pendingEvents = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_pending_events');
+    $curlHandler = \PHPUnit\Framework\Assert::getObjectAttribute($client, '_curl_handler');
+    $pendingRequests = \PHPUnit\Framework\Assert::getObjectAttribute($curlHandler, 'requests');
+
     if (! empty($pendingEvents)) {
         echo 'There are pending events inside the client';
     }


### PR DESCRIPTION
This implements the regression suggested in https://github.com/getsentry/sentry-php/issues/391#issuecomment-374925533 and should finally fix the issue with fatals + curl async.

Thanks again to @mfb for helping me debugging this issue.