### PR TITLE
[2.0] Support modules attribute of the event by logging Composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php": "^5.6|^7.0",
         "ext-mbstring": "*",
-        "composer/composer": "^1.6",
         "php-http/async-client-implementation": "~1.0",
         "php-http/client-common": "~1.5",
         "php-http/discovery": "~1.2",
@@ -25,6 +24,7 @@
         "zendframework/zend-diactoros": "~1.4"
     },
     "require-dev": {
+        "composer/composer": "^1.6",
         "friendsofphp/php-cs-fixer": "~2.1",
         "monolog/monolog": "~1.0",
         "php-http/curl-client": "~1.7",

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": "^5.6|^7.0",
-        "ext-json": "*",
         "ext-mbstring": "*",
+        "composer/composer": "^1.6",
         "php-http/async-client-implementation": "~1.0",
         "php-http/client-common": "~1.5",
         "php-http/discovery": "~1.2",

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -22,6 +22,7 @@ use Raven\Middleware\BreadcrumbInterfaceMiddleware;
 use Raven\Middleware\ContextInterfaceMiddleware;
 use Raven\Middleware\ExceptionInterfaceMiddleware;
 use Raven\Middleware\MessageInterfaceMiddleware;
+use Raven\Middleware\ModulesMiddleware;
 use Raven\Middleware\ProcessorMiddleware;
 use Raven\Middleware\RequestInterfaceMiddleware;
 use Raven\Middleware\UserInterfaceMiddleware;
@@ -170,6 +171,7 @@ class Client
         };
 
         $this->addMiddleware(new ProcessorMiddleware($this->processorRegistry));
+        $this->addMiddleware(new ModulesMiddleware($this->config));
         $this->addMiddleware(new MessageInterfaceMiddleware());
         $this->addMiddleware(new RequestInterfaceMiddleware());
         $this->addMiddleware(new UserInterfaceMiddleware());

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -22,7 +22,6 @@ use Raven\Middleware\BreadcrumbInterfaceMiddleware;
 use Raven\Middleware\ContextInterfaceMiddleware;
 use Raven\Middleware\ExceptionInterfaceMiddleware;
 use Raven\Middleware\MessageInterfaceMiddleware;
-use Raven\Middleware\ModulesMiddleware;
 use Raven\Middleware\ProcessorMiddleware;
 use Raven\Middleware\RequestInterfaceMiddleware;
 use Raven\Middleware\UserInterfaceMiddleware;
@@ -171,7 +170,6 @@ class Client
         };
 
         $this->addMiddleware(new ProcessorMiddleware($this->processorRegistry));
-        $this->addMiddleware(new ModulesMiddleware($this->config));
         $this->addMiddleware(new MessageInterfaceMiddleware());
         $this->addMiddleware(new RequestInterfaceMiddleware());
         $this->addMiddleware(new UserInterfaceMiddleware());

--- a/lib/Raven/Configuration.php
+++ b/lib/Raven/Configuration.php
@@ -435,7 +435,7 @@ class Configuration
     /**
      * Gets the project which the authenticated user is bound to.
      *
-     * @return string
+     * @return string|null
      */
     public function getProjectRoot()
     {
@@ -445,7 +445,7 @@ class Configuration
     /**
      * Sets the project which the authenticated user is bound to.
      *
-     * @param string $path The path to the project root
+     * @param string|null $path The path to the project root
      */
     public function setProjectRoot($path)
     {

--- a/lib/Raven/Middleware/ModulesMiddleware.php
+++ b/lib/Raven/Middleware/ModulesMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace Raven\Middleware;
 
+use Composer\Composer;
 use Composer\Factory;
 use Composer\IO\NullIO;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,6 +29,10 @@ final class ModulesMiddleware
      */
     public function __construct(Configuration $config)
     {
+        if (!class_exists(Composer::class)) {
+            throw new \LogicException('You need the "composer/composer" package in order to use this middleware.');
+        }
+
         $this->config = $config;
     }
 

--- a/lib/Raven/Middleware/ModulesMiddleware.php
+++ b/lib/Raven/Middleware/ModulesMiddleware.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Raven\Middleware;
+
+use Composer\Factory;
+use Composer\IO\NullIO;
+use Psr\Http\Message\ServerRequestInterface;
+use Raven\Configuration;
+use Raven\Event;
+
+/**
+ * This middleware logs with the event details all the versions of the packages
+ * installed with Composer, if any.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class ModulesMiddleware
+{
+    /**
+     * @var Configuration The Raven client configuration
+     */
+    private $config;
+
+    /**
+     * Constructor.
+     *
+     * @param Configuration $config The Raven client configuration
+     */
+    public function __construct(Configuration $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Collects the needed data and sets it in the given event object.
+     *
+     * @param Event                       $event     The event being processed
+     * @param callable                    $next      The next middleware to call
+     * @param ServerRequestInterface|null $request   The request, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
+     * @param array                       $payload   Additional data
+     *
+     * @return Event
+     */
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
+    {
+        $composerFilePath = $this->config->getProjectRoot() . DIRECTORY_SEPARATOR . 'composer.json';
+
+        if (file_exists($composerFilePath)) {
+            $composer = Factory::create(new NullIO(), $composerFilePath, true);
+            $locker = $composer->getLocker();
+
+            if ($locker->isLocked()) {
+                $modules = [];
+
+                foreach ($locker->getLockedRepository()->getPackages() as $package) {
+                    $modules[$package->getName()] = $package->getVersion();
+                }
+
+                $event = $event->withModules($modules);
+            }
+        }
+
+        return $next($event, $request, $exception, $payload);
+    }
+}

--- a/tests/Fixtures/composer.json
+++ b/tests/Fixtures/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "vendor-name/project-name",
+    "type": "library",
+    "require": {
+        "foo/bar": "1.2.3",
+        "foo/baz": "4.5.6"
+    }
+}

--- a/tests/Fixtures/composer.lock
+++ b/tests/Fixtures/composer.lock
@@ -1,0 +1,18 @@
+{
+    "packages": [
+        {
+            "name": "foo/bar",
+            "version": "1.2.3"
+        },
+        {
+            "name": "foo/baz",
+            "version": "4.5.6"
+        }
+    ],
+    "packages-dev": null,
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false
+}

--- a/tests/Middleware/ModulesMiddlewareTest.php
+++ b/tests/Middleware/ModulesMiddlewareTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of Raven.
+ *
+ * (c) Sentry Team
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Raven\Tests\Breadcrumbs;
+
+use PHPUnit\Framework\TestCase;
+use Raven\Configuration;
+use Raven\Event;
+use Raven\Middleware\ModulesMiddleware;
+
+class ModulesMiddlewareTest extends TestCase
+{
+    public function testInvoke()
+    {
+        $configuration = new Configuration(['project_root' => __DIR__ . '/../Fixtures']);
+        $event = new Event($configuration);
+
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use ($event, &$callbackInvoked) {
+            $this->assertNotSame($event, $eventArg);
+            $this->assertEquals(['foo/bar' => '1.2.3.0', 'foo/baz' => '4.5.6.0'], $eventArg->getModules());
+
+            $callbackInvoked = true;
+        };
+
+        $middleware = new ModulesMiddleware($configuration);
+        $middleware($event, $callback);
+
+        $this->assertTrue($callbackInvoked);
+    }
+
+    public function testInvokeDoesNothingWhenNoComposerLockFileExists()
+    {
+        $configuration = new Configuration(['project_root' => __DIR__]);
+        $event = new Event($configuration);
+
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use ($event, &$callbackInvoked) {
+            $this->assertSame($event, $eventArg);
+
+            $callbackInvoked = true;
+        };
+
+        $middleware = new ModulesMiddleware($configuration);
+        $middleware($event, $callback);
+
+        $this->assertTrue($callbackInvoked);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

A long standing issue (#175) is open to request the implementation of the support for the `modules` attribute of the event. In Sentry this means that the name and versions of the Composer packages used by the project where the SDK is used would be logged and displayed. This PR adds support for this feature