### PR TITLE
Fix x-forwarded-proto detection

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -1322,8 +1322,8 @@ class Raven_Client
         }
 
         if (!empty($this->trust_x_forwarded_proto) &&
-            !empty($_SERVER['X-FORWARDED-PROTO']) &&
-            $_SERVER['X-FORWARDED-PROTO'] === 'https') {
+            !empty($_SERVER['HTTP_X_FORWARDED_PROTO']) &&
+            $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https') {
             return true;
         }
 

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1650,7 +1650,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 array(
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
-                    'X-FORWARDED-PROTO' => 'https'
+                    'HTTP_X_FORWARDED_PROTO' => 'https'
                 ),
                 array(),
                 'http://example.com/',
@@ -1660,7 +1660,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 array(
                     'REQUEST_URI' => '/',
                     'HTTP_HOST' => 'example.com',
-                    'X-FORWARDED-PROTO' => 'https'
+                    'HTTP_X_FORWARDED_PROTO' => 'https'
                 ),
                 array('trust_x_forwarded_proto' => true),
                 'https://example.com/',


### PR DESCRIPTION
Forwarded-proto detection is currently looking for headers that aren't set - because:

 * HTTP headers have the prefix HTTP_
 * php's env variables are underscored, not hyphenated

Related: https://github.com/getsentry/sentry-php/pull/251