### PR TITLE
[2.0] Exclude subclasses and implementations of exceptions

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -5,7 +5,8 @@
 - The `environment` option has been renamed to `current_environment`.
 - The `http_proxy` option has been renamed to `proxy`.
 - The `processorOptions` option has been renamed to `processors_options`.
-- The `exclude` option has been renamed to `excluded_exceptions`.
+- The `exclude` option has been renamed to `excluded_exceptions`. Unlike `exclude`,
+   `excluded_exceptions` will also exclude all subclasses. 
 - The `send_callback` option has been renamed to `should_capture`.
 - The `name` option has been renamed to `server_name`.
 - The `project` option has been removed.

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -240,6 +240,11 @@ class ConfigurationTest extends TestCase
                 new \Exception(),
                 false,
             ],
+            [
+                [\Exception::class],
+                new \BadFunctionCallException(),
+                true,
+            ],
         ];
     }
 


### PR DESCRIPTION
Allows much better control over which exceptions are excluded
For example now you can exclude all `Http_Exception` subclasses

Previously if I wrote `exclude => ["Exception"]` I would still get all subclasses of exception