### PR TITLE
Add excluded_exceptions that is compatible with 2.0

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -89,6 +89,7 @@ class Raven_Client
     public $timeout;
     public $message_limit;
     public $exclude;
+    public $excluded_exceptions;
     public $http_proxy;
     protected $send_callback;
     public $curl_method;
@@ -164,6 +165,7 @@ class Raven_Client
         $this->timeout = Raven_Util::get($options, 'timeout', 2);
         $this->message_limit = Raven_Util::get($options, 'message_limit', self::MESSAGE_LIMIT);
         $this->exclude = Raven_Util::get($options, 'exclude', array());
+        $this->excluded_exceptions = Raven_Util::get($options, 'excluded_exceptions', array());
         $this->severity_map = null;
         $this->http_proxy = Raven_Util::get($options, 'http_proxy');
         $this->extra_data = Raven_Util::get($options, 'extra', array());
@@ -612,6 +614,12 @@ class Raven_Client
 
         if (in_array(get_class($exception), $this->exclude)) {
             return null;
+        }
+
+        foreach ($this->excluded_exceptions as $exclude) {
+            if ($exception instanceof $exclude) {
+                return null;
+            }
         }
 
         if ($data === null) {

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -216,6 +216,13 @@ class Dummy_Raven_CurlHandler extends Raven_CurlHandler
     }
 }
 
+interface Dummy_Exception_Interface
+{
+}
+class Dummy_Exception extends Exception implements Dummy_Exception_Interface
+{
+}
+
 class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
@@ -689,6 +696,34 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
             'exclude' => array('Exception'),
         ));
         $ex = $this->create_exception();
+        $client->captureException($ex, 'test');
+        $events = $client->getSentEvents();
+        $this->assertEquals(0, count($events));
+    }
+
+    /**
+     * @covers Raven_Client::captureException
+     */
+    public function testCaptureExceptionHandlesExcludeSubclassOption()
+    {
+        $client = new Dummy_Raven_Client(array(
+            'excluded_exceptions' => array('Exception'),
+        ));
+        $ex = new Dummy_Exception();
+        $client->captureException($ex, 'test');
+        $events = $client->getSentEvents();
+        $this->assertEquals(0, count($events));
+    }
+
+    /**
+     * @covers Raven_Client::captureException
+     */
+    public function testCaptureExceptionHandlesExcludeInterfaceOption()
+    {
+        $client = new Dummy_Raven_Client(array(
+            'excluded_exceptions' => array('Dummy_Exception_Interface'),
+        ));
+        $ex = new Dummy_Exception();
         $client->captureException($ex, 'test');
         $events = $client->getSentEvents();
         $this->assertEquals(0, count($events));


### PR DESCRIPTION
So, given that I'm sticking with 1.x for the moment, I have made this solution, and I thought I'd share it as it might be interesting to you. I'm probably going to be deploying this on my server now.

Basically, instead of changing how `exclude` works, I've added a new option, `excluded_exceptions` that works just like it does in 2.0, and how I need it to work, excluding all subclasses.

As a bonus might make upgrade path simpler for people as they can start using `excluded_exceptions` in 1.X