### PR TITLE
Support using real client IP when behind a web proxy

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -805,7 +805,9 @@ class Raven_Client
             $user = array(
                 'id' => session_id(),
             );
-            if (!empty($_SERVER['REMOTE_ADDR'])) {
+            if (!empty($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+                $user['ip_address'] = $_SERVER['HTTP_X_FORWARDED_FOR'];
+            } elseif (!empty($_SERVER['REMOTE_ADDR'])) {
                 $user['ip_address'] = $_SERVER['REMOTE_ADDR'];
             }
             if (!empty($_SESSION)) {


### PR DESCRIPTION
Support being behind a web proxy eg cloudflare and use HTTP_X_FORWARDED_FOR value as the user IP address.

Hope this resolves this issue as sentry reports the cloudflare IP as the client's IP address in the sentry issue.