### PR TITLE
Fix monolog handler not accepting Throwable

### DIFF
--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -61,9 +61,9 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
             return;
         }
 
-        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
+        if (isset($record['context']['exception']) && ($record['context']['exception'] instanceof \Exception || (PHP_VERSION_ID >= 70000 && $record['context']['exception'] instanceof \Throwable))) {
             /**
-             * @var Exception $exc
+             * @var \Exception|\Throwable $exc
              */
             $exc = $record['context']['exception'];
             $crumb = array(


### PR DESCRIPTION
The monolog handler should accept a Throwable as an exception.

Fixes #561.