### PR TITLE
Fixed undefined variable

### DIFF
--- a/lib/Raven/CurlHandler.php
+++ b/lib/Raven/CurlHandler.php
@@ -94,6 +94,8 @@ class Raven_CurlHandler
      */
     protected function select()
     {
+        $active = false;
+        
         do {
             $mrc = curl_multi_exec($this->multi_handle, $active);
         } while ($mrc == CURLM_CALL_MULTI_PERFORM);

--- a/test/Raven/phpt/fatal_reported_with_async.phpt
+++ b/test/Raven/phpt/fatal_reported_with_async.phpt
@@ -41,7 +41,7 @@ register_shutdown_function(function () use (&$client) {
     }
 });
 
-ini_set('memory_limit', '8M');
+ini_set('memory_limit', '16M');
 while (TRUE) {
     $a[] = 'b';
 }


### PR DESCRIPTION
Fixed PHP notice `Notice: Undefined variable: active in ... lib/Raven/CurlHandler.php on line 96`.

Depending on your setup, notices are converted to exceptions so you don't forget about them ;-) This notice currently causes my test environment to fail.