### PR TITLE
[2.0] Merge up to 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - ...
 
+## 1.8.4 (2018-03-20)
+
+- Revert ignoring fatal errors on PHP 7+ (#571)
+- Add PHP runtime information (#564)
+- Cleanup the `site` value if it's empty (#555)
+- Add `application/json` input handling (#546)
+
 ## 1.8.3 (2018-02-07)
 
 - Serialize breadcrumbs to prevent issues with binary data (#538)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # CHANGELOG
 
-## Unreleased
+## 1.9.0 (2018-05-03)
 
-- ...
+- Fixed undefined variable (#588)
+- Fix for exceptions throwing exceptions when setting event id (#587)
+- Fix monolog handler not accepting Throwable (#586)
+- Add `excluded_exceptions` option to exclude exceptions and their extending exceptions (#583)
+- Fix `HTTP_X_FORWARDED_PROTO` header detection (#578)
+- Fix sending events async in PHP 5 (#576)
+- Avoid double reporting due to `ErrorException`s (#574)
+- Make it possible to overwrite serializer message limit of 1024 (#559)
+- Allow request data to be nested up to 5 levels deep (#554)
+- Update serializer to handle UTF-8 characters correctly (#553)
 
 ## 1.8.4 (2018-03-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- ...
+
 ## 1.9.0 (2018-05-03)
 
 - Fixed undefined variable (#588)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $ git checkout -b releases/1.9.x
 
 3. Update the hardcoded version tag in ``Client.php``:
 
-```
+```php
 class Raven_Client
 {
     const VERSION = '1.9.0';
@@ -170,7 +170,7 @@ git checkout master
 
 9. Update the version in ``Client.php``:
 
-```
+```php
 class Raven_Client
 {
     const VERSION = '1.10.x-dev';
@@ -179,7 +179,7 @@ class Raven_Client
 
 10. Lastly, update the composer version in ``composer.json``:
 
-```
+```json
     "extra": {
         "branch-alias": {
             "dev-master": "1.10.x-dev"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 # Sentry for PHP
 
 [![Build Status](https://secure.travis-ci.org/getsentry/sentry-php.png?branch=master)](http://travis-ci.org/getsentry/sentry-php)
-[![Total Downloads](https://img.shields.io/packagist/dt/sentry/sentry.svg?style=flat-square)](https://packagist.org/packages/sentry/sentry)
-[![Downloads per month](https://img.shields.io/packagist/dm/sentry/sentry.svg?style=flat-square)](https://packagist.org/packages/sentry/sentry)
-[![Latest stable version](https://img.shields.io/packagist/v/sentry/sentry.svg?style=flat-square)](https://packagist.org/packages/sentry/sentry)
-[![License](http://img.shields.io/packagist/l/sentry/sentry.svg?style=flat-square)](https://packagist.org/packages/sentry/sentry)
+[![Total Downloads](https://poser.pugx.org/sentry/sentry/downloads)](https://packagist.org/packages/sentry/sentry)
+[![Monthly Downloads](https://poser.pugx.org/sentry/sentry/d/monthly)](https://packagist.org/packages/sentry/sentry)
+[![Latest Stable Version](https://poser.pugx.org/sentry/sentry/v/stable)](https://packagist.org/packages/sentry/sentry)
+[![License](https://poser.pugx.org/sentry/sentry/license)](https://packagist.org/packages/sentry/sentry)
 [![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/getsentry/sentry-php/master.svg)](https://scrutinizer-ci.com/g/getsentry/sentry-php/)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/getsentry/sentry-php/master.svg)](https://scrutinizer-ci.com/g/getsentry/sentry-php/)
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -171,7 +171,7 @@ The following settings are available for the client:
                     'User-Agent'       => $client->getUserAgent(),
                     'X-Sentry-Auth'    => $client->getAuthHeader(),
                 ),
-                'body'    => gzipCompress(jsonEncode($data)),
+                'body'    => gzcompress(jsonEncode($data)),
             ))
         },
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -241,6 +241,26 @@ The following settings are available for the client:
                     )
         )
 
+.. describe:: timeout
+
+    The timeout for sending requests to the Sentry server in seconds, default is 2 seconds.
+
+    .. code-block:: php
+
+        'timeout' => 2,
+
+.. describe:: excluded_exceptions
+
+    Exception that should not be reported, exceptions extending exceptions in this list will also
+    be excluded, default is an empty array.
+
+    In the example below, when you exclude ``LogicException`` you will also exclude ``BadFunctionCallException``
+    since it extends ``LogicException``.
+
+    .. code-block:: php
+
+        'excluded_exceptions' => array('LogicException'),
+
 .. _sentry-php-request-context:
 
 Providing Request Context

--- a/docs/integrations/laravel.rst
+++ b/docs/integrations/laravel.rst
@@ -64,6 +64,8 @@ step is not required anymore an you can skip ahead to the next one:
 
     <?php
 
+    use Symfony\Component\HttpKernel\Exception\HttpException;
+
     class Handler extends ExceptionHandler
     {
         public function report(Exception $exception)

--- a/docs/sentry-doc-config.json
+++ b/docs/sentry-doc-config.json
@@ -16,8 +16,9 @@
       "type": "framework",
       "doc_link": "integrations/laravel/",
       "wizard": [
-        "index#installation",
-        "integrations/laravel#laravel-5-x"
+        "integrations/laravel#laravel-5-x",
+        "integrations/laravel#laravel-4-x",
+        "integrations/laravel#lumen-5-x"
       ]
     },
     "php.monolog": {
@@ -34,7 +35,6 @@
       "type": "framework",
       "doc_link": "integrations/symfony2/",
       "wizard": [
-        "index#installation",
         "integrations/symfony2#symfony-2"
       ]
     }

--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -66,14 +66,14 @@ class MonologHandler extends AbstractProcessingHandler
         }
 
         if (
-            isset($record['context']['exception']) 
+            isset($record['context']['exception'])
             && (
-                $record['context']['exception'] instanceof \Exception 
+                $record['context']['exception'] instanceof \Exception
                 || (PHP_VERSION_ID >= 70000 && $record['context']['exception'] instanceof \Throwable)
             )
         ) {
             /**
-             * @var \Exception|\Throwable $exc
+             * @var \Exception|\Throwable
              */
             $exc = $record['context']['exception'];
 

--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -65,9 +65,15 @@ class MonologHandler extends AbstractProcessingHandler
             return;
         }
 
-        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Exception) {
+        if (
+            isset($record['context']['exception']) 
+            && (
+                $record['context']['exception'] instanceof \Exception 
+                || (PHP_VERSION_ID >= 70000 && $record['context']['exception'] instanceof \Throwable)
+            )
+        ) {
             /**
-             * @var \Exception
+             * @var \Exception|\Throwable $exc
              */
             $exc = $record['context']['exception'];
 

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -33,7 +33,7 @@ use Zend\Diactoros\ServerRequestFactory;
 /**
  * Raven PHP Client.
  *
- * @doc https://docs.sentry.io/clients/php/config/
+ * @see https://docs.sentry.io/clients/php/config/
  */
 class Client
 {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -471,7 +471,7 @@ class Client
         $tagsContext = $event->getTagsContext();
 
         if (!empty($request)) {
-            $event = $event->withRequest($this->serializer->serialize($request));
+            $event = $event->withRequest($this->serializer->serialize($request, 5));
         }
         if (!empty($userContext)) {
             $event = $event->withUserContext($this->serializer->serialize($userContext, 3));

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -53,7 +53,7 @@ final class RequestInterfaceMiddleware
         if ($request->hasHeader('REMOTE_ADDR')) {
             $requestData['env']['REMOTE_ADDR'] = $request->getHeaderLine('REMOTE_ADDR');
         }
-        
+
         if (in_array('application/json', $request->getHeader('Content-Type'))) {
             $inputData = file_get_contents('php://input');
             $requestData['data'] = json_decode($inputData, true);

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -54,11 +54,6 @@ final class RequestInterfaceMiddleware
             $requestData['env']['REMOTE_ADDR'] = $request->getHeaderLine('REMOTE_ADDR');
         }
 
-        if (in_array('application/json', $request->getHeader('Content-Type'))) {
-            $inputData = file_get_contents('php://input');
-            $requestData['data'] = json_decode($inputData, true);
-        }
-
         $event = $event->withRequest($requestData);
 
         return $next($event, $request, $exception, $payload);

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -53,6 +53,11 @@ final class RequestInterfaceMiddleware
         if ($request->hasHeader('REMOTE_ADDR')) {
             $requestData['env']['REMOTE_ADDR'] = $request->getHeaderLine('REMOTE_ADDR');
         }
+        
+        if (in_array('application/json', $request->getHeader('Content-Type'))) {
+            $inputData = file_get_contents('php://input');
+            $requestData['data'] = json_decode($inputData, true);
+        }
 
         $event = $event->withRequest($requestData);
 

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -51,13 +51,23 @@ class Serializer
     protected $_all_object_serialize = false;
 
     /**
-     * @param null|string $mb_detect_order
+     * The default maximum message lengths. Longer strings will be truncated
+     * 
+     * @var int
      */
-    public function __construct($mb_detect_order = null)
+    protected $messageLimit;
+
+    /**
+     * @param null|string $mb_detect_order
+     * @param null|int    $messageLimit
+     */
+    public function __construct($mb_detect_order = null, $messageLimit = Client::MESSAGE_LIMIT)
     {
         if (null != $mb_detect_order) {
             $this->mb_detect_order = $mb_detect_order;
         }
+
+        $this->messageLimit = (int) $messageLimit;
     }
 
     /**
@@ -133,8 +143,8 @@ class Serializer
             }
         }
 
-        if (strlen($value) > 1024) {
-            $value = substr($value, 0, 1014) . ' {clipped}';
+        if (strlen($value) > $this->messageLimit) {
+            $value = substr($value, 0, $this->messageLimit - 10) . ' {clipped}';
         }
 
         return $value;
@@ -196,5 +206,21 @@ class Serializer
     public function getAllObjectSerialize()
     {
         return $this->_all_object_serialize;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMessageLimit()
+    {
+        return $this->messageLimit;
+    }
+
+    /**
+     * @param int $messageLimit
+     */
+    public function setMessageLimit($messageLimit)
+    {
+        $this->messageLimit = $messageLimit;
     }
 }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -132,19 +132,22 @@ class Serializer
     protected function serializeString($value)
     {
         $value = (string) $value;
-        if (function_exists('mb_detect_encoding')
-            && function_exists('mb_convert_encoding')
-        ) {
+
+        if (extension_loaded('mbstring')) {
             // we always guarantee this is coerced, even if we can't detect encoding
             if ($currentEncoding = mb_detect_encoding($value, $this->mb_detect_order)) {
                 $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
             } else {
                 $value = mb_convert_encoding($value, 'UTF-8');
             }
-        }
 
-        if (strlen($value) > $this->messageLimit) {
-            $value = substr($value, 0, $this->messageLimit - 10) . ' {clipped}';
+            if (mb_strlen($value) > $this->messageLimit) {
+                $value = mb_substr($value, 0, $this->messageLimit - 10, 'UTF-8') . ' {clipped}';
+            }
+        } else {
+            if (strlen($value) > $this->messageLimit) {
+                $value = substr($value, 0, $this->messageLimit - 10) . ' {clipped}';
+            }
         }
 
         return $value;

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -51,8 +51,8 @@ class Serializer
     protected $_all_object_serialize = false;
 
     /**
-     * The default maximum message lengths. Longer strings will be truncated
-     * 
+     * The default maximum message lengths. Longer strings will be truncated.
+     *
      * @var int
      */
     protected $messageLimit;

--- a/tests/Breadcrumbs/MonologHandlerTest.php
+++ b/tests/Breadcrumbs/MonologHandlerTest.php
@@ -12,6 +12,7 @@
 namespace Raven\Tests\Breadcrumbs;
 
 use Monolog\Logger;
+use ParseError;
 use PHPUnit\Framework\TestCase;
 use Raven\Breadcrumbs\Breadcrumb;
 use Raven\Breadcrumbs\MonologHandler;
@@ -44,52 +45,106 @@ EOF;
 
     public function testSimple()
     {
-        $client = $client = ClientBuilder::create([
-            'install_default_breadcrumb_handlers' => false,
-        ])->getClient();
+        $client = $this->createClient();
+        $logger = $this->createLoggerWithHandler($client);
 
-        $handler = new MonologHandler($client);
-
-        $logger = new Logger('sentry');
-        $logger->pushHandler($handler);
         $logger->addWarning('foo');
 
-        $breadcrumbsRecorder = $this->getObjectAttribute($client, 'breadcrumbRecorder');
-
-        /** @var \Raven\Breadcrumbs\Breadcrumb[] $breadcrumbs */
-        $breadcrumbs = iterator_to_array($breadcrumbsRecorder);
-
+        $breadcrumbs = $this->getBreadcrumbs($client);
         $this->assertCount(1, $breadcrumbs);
-
-        $this->assertEquals($breadcrumbs[0]->getMessage(), 'foo');
-        $this->assertEquals($breadcrumbs[0]->getLevel(), Client::LEVEL_WARNING);
-        $this->assertEquals($breadcrumbs[0]->getCategory(), 'sentry');
+        $this->assertEquals('foo', $breadcrumbs[0]->getMessage());
+        $this->assertEquals(Client::LEVEL_WARNING, $breadcrumbs[0]->getLevel());
+        $this->assertEquals('sentry', $breadcrumbs[0]->getCategory());
     }
 
     public function testErrorInMessage()
+    {
+        $client = $this->createClient();
+        $logger = $this->createLoggerWithHandler($client);
+
+        $logger->addError($this->getSampleErrorMessage());
+
+        $breadcrumbs = $this->getBreadcrumbs($client);
+        $this->assertCount(1, $breadcrumbs);
+        $this->assertEquals(Breadcrumb::TYPE_ERROR, $breadcrumbs[0]->getType());
+        $this->assertEquals(Client::LEVEL_ERROR, $breadcrumbs[0]->getLevel());
+        $this->assertEquals('sentry', $breadcrumbs[0]->getCategory());
+        $this->assertEquals('An unhandled exception', $breadcrumbs[0]->getMetadata()['value']);
+    }
+
+    public function testExceptionBeingParsed()
+    {
+        $client = $this->createClient();
+        $logger = $this->createLoggerWithHandler($client);
+
+        $logger->addError('A message', ['exception' => new \Exception('Foo bar')]);
+
+        $breadcrumbs = $this->getBreadcrumbs($client);
+        $this->assertCount(1, $breadcrumbs);
+        $this->assertEquals(Breadcrumb::TYPE_ERROR, $breadcrumbs[0]->getType());
+        $this->assertEquals('Foo bar', $breadcrumbs[0]->getMetadata()['value']);
+        $this->assertEquals('sentry', $breadcrumbs[0]->getCategory());
+        $this->assertEquals(Client::LEVEL_ERROR, $breadcrumbs[0]->getLevel());
+        $this->assertNull($breadcrumbs[0]->getMessage());
+    }
+
+    public function testThrowableBeingParsedAsException()
+    {
+        if (PHP_VERSION_ID <= 70000) {
+            $this->markTestSkipped('PHP 7.0 introduced Throwable');
+        }
+
+        $client = $this->createClient();
+        $logger = $this->createLoggerWithHandler($client);
+        $throwable = new ParseError('Foo bar');
+
+        $logger->addError('This is a throwable', ['exception' => $throwable]);
+
+        $breadcrumbs = $this->getBreadcrumbs($client);
+        $this->assertCount(1, $breadcrumbs);
+        $this->assertEquals(Breadcrumb::TYPE_ERROR, $breadcrumbs[0]->getType());
+        $this->assertEquals('Foo bar', $breadcrumbs[0]->getMetadata()['value']);
+        $this->assertEquals('sentry', $breadcrumbs[0]->getCategory());
+        $this->assertEquals(Client::LEVEL_ERROR, $breadcrumbs[0]->getLevel());
+        $this->assertNull($breadcrumbs[0]->getMessage());
+    }
+
+    /**
+     * @return Client
+     */
+    private function createClient()
     {
         $client = $client = ClientBuilder::create([
             'install_default_breadcrumb_handlers' => false,
         ])->getClient();
 
-        $handler = new MonologHandler($client);
+        return $client;
+    }
 
+    /**
+     * @param Client $client
+     * @return Logger
+     */
+    private function createLoggerWithHandler(Client $client)
+    {
+        $handler = new MonologHandler($client);
         $logger = new Logger('sentry');
         $logger->pushHandler($handler);
-        $logger->addError($this->getSampleErrorMessage());
 
+        return $logger;
+    }
+
+    /**
+     * @param Client $client
+     * @return Breadcrumb[]
+     */
+    private function getBreadcrumbs(Client $client)
+    {
         $breadcrumbsRecorder = $this->getObjectAttribute($client, 'breadcrumbRecorder');
 
-        /** @var \Raven\Breadcrumbs\Breadcrumb[] $breadcrumbs */
         $breadcrumbs = iterator_to_array($breadcrumbsRecorder);
+        $this->assertContainsOnlyInstancesOf(Breadcrumb::class, $breadcrumbs);
 
-        $this->assertCount(1, $breadcrumbs);
-
-        $metaData = $breadcrumbs[0]->getMetadata();
-
-        $this->assertEquals($breadcrumbs[0]->getType(), Breadcrumb::TYPE_ERROR);
-        $this->assertEquals($breadcrumbs[0]->getLevel(), Client::LEVEL_ERROR);
-        $this->assertEquals($breadcrumbs[0]->getCategory(), 'sentry');
-        $this->assertEquals($metaData['value'], 'An unhandled exception');
+        return $breadcrumbs;
     }
 }

--- a/tests/Breadcrumbs/MonologHandlerTest.php
+++ b/tests/Breadcrumbs/MonologHandlerTest.php
@@ -123,6 +123,7 @@ EOF;
 
     /**
      * @param Client $client
+     *
      * @return Logger
      */
     private function createLoggerWithHandler(Client $client)
@@ -136,6 +137,7 @@ EOF;
 
     /**
      * @param Client $client
+     *
      * @return Breadcrumb[]
      */
     private function getBreadcrumbs(Client $client)

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -554,7 +554,7 @@ class ClientTest extends TestCase
                             'key' => 'my other value',
                         ],
                     ],
-                ]
+                ],
             ],
             [
                 [

--- a/tests/Context/ContextTest.php
+++ b/tests/Context/ContextTest.php
@@ -106,7 +106,7 @@ class ContextTest extends TestCase
 
         // Accessing a key that does not exists in the data object should behave
         // like accessing a non-existent key of an array
-        $context['foo'];
+        @$context['foo'];
 
         $error = error_get_last();
 

--- a/tests/Fixtures/classes/CarelessException.php
+++ b/tests/Fixtures/classes/CarelessException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Raven\Tests\Fixtures\classes;
+
+class CarelessException extends \Exception
+{
+    public function __set($var, $value)
+    {
+        if ($var === 'event_id') {
+            throw new \RuntimeException('I am carelessly throwing an exception here!');
+        }
+    }
+}

--- a/tests/Fixtures/classes/CarelessException.php
+++ b/tests/Fixtures/classes/CarelessException.php
@@ -6,7 +6,7 @@ class CarelessException extends \Exception
 {
     public function __set($var, $value)
     {
-        if ($var === 'event_id') {
+        if ('event_id' === $var) {
             throw new \RuntimeException('I am carelessly throwing an exception here!');
         }
     }

--- a/tests/Middleware/RequestInterfaceMiddlewareTest.php
+++ b/tests/Middleware/RequestInterfaceMiddlewareTest.php
@@ -104,6 +104,22 @@ class RequestInterfaceMiddlewareTest extends TestCase
             ],
             [
                 [
+                    'uri' => 'http://www.example.com:123/foo',
+                    'method' => 'GET',
+                    'cookies' => [],
+                    'headers' => [],
+                ],
+                [
+                    'url' => 'http://www.example.com:123/foo',
+                    'method' => 'GET',
+                    'cookies' => [],
+                    'headers' => [
+                        'Host' => ['www.example.com:123'],
+                    ],
+                ],
+            ],
+            [
+                [
                     'uri' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',
                     'cookies' => [],

--- a/tests/Middleware/RequestInterfaceMiddlewareTest.php
+++ b/tests/Middleware/RequestInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Middleware;
+namespace Raven\Tests\Breadcrumbs;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -21,8 +21,6 @@ use Zend\Diactoros\Uri;
 
 class RequestInterfaceMiddlewareTest extends TestCase
 {
-    private static $inputData;
-
     public function testInvokeWithNoRequest()
     {
         $configuration = new Configuration();
@@ -44,7 +42,7 @@ class RequestInterfaceMiddlewareTest extends TestCase
     /**
      * @dataProvider invokeDataProvider
      */
-    public function testInvoke(array $requestData, array $expectedValue, $inputData = null)
+    public function testInvoke($requestData, $expectedValue)
     {
         $configuration = new Configuration();
         $event = new Event($configuration);
@@ -67,10 +65,6 @@ class RequestInterfaceMiddlewareTest extends TestCase
         };
 
         $middleware = new RequestInterfaceMiddleware();
-        if ($inputData) {
-            $this->mockReadFromPhpInput($inputData);
-        }
-
         $middleware($event, $callback, $request);
 
         $this->assertEquals(1, $invokationCount);
@@ -78,9 +72,6 @@ class RequestInterfaceMiddlewareTest extends TestCase
 
     public function invokeDataProvider()
     {
-        $validData = ['json_test' => 'json_data'];
-        $invalidData = '{"binary_json":"' . pack('NA3CC', 3, 'aBc', 0x0D, 0x0A) . '"}';
-
         return [
             [
                 [
@@ -142,92 +133,6 @@ class RequestInterfaceMiddlewareTest extends TestCase
                     ],
                 ],
             ],
-            [
-                [
-                    'uri' => 'http://www.example.com/foo',
-                    'method' => 'POST',
-                    'cookies' => [],
-                    'headers' => [
-                        'Content-Type' => ['application/json'],
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                    ],
-                ],
-                [
-                    'url' => 'http://www.example.com/foo',
-                    'method' => 'POST',
-                    'cookies' => [],
-                    'data' => $validData,
-                    'headers' => [
-                        'Content-Type' => ['application/json'],
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                    ],
-                    'env' => [
-                        'REMOTE_ADDR' => '127.0.0.1',
-                    ],
-                ],
-                json_encode($validData),
-            ],
-            [
-                [
-                    'uri' => 'http://www.example.com/foo',
-                    'method' => 'POST',
-                    'cookies' => [],
-                    'headers' => [
-                        'Content-Type' => ['application/json'],
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                    ],
-                ],
-                [
-                    'url' => 'http://www.example.com/foo',
-                    'method' => 'POST',
-                    'cookies' => [],
-                    'data' => null,
-                    'headers' => [
-                        'Content-Type' => ['application/json'],
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                    ],
-                    'env' => [
-                        'REMOTE_ADDR' => '127.0.0.1',
-                    ],
-                ],
-                $invalidData,
-            ],
         ];
-    }
-
-    /**
-     * @return string
-     */
-    public static function getInputData()
-    {
-        return self::$inputData;
-    }
-
-    /**
-     * @param string $inputData
-     */
-    private function mockReadFromPhpInput($inputData)
-    {
-        self::$inputData = $inputData;
-        if (function_exists('Raven\Middleware\file_get_contents')) {
-            return;
-        }
-
-        $self = \get_class($this);
-
-        eval(<<<EOPHP
-namespace Raven\Middleware;
-
-function file_get_contents()
-{
-    return \\$self::getInputData();
-}
-
-EOPHP
-        );
     }
 }

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -366,16 +366,27 @@ abstract class SerializerAbstractTest extends TestCase
         if ($serialize_all_objects) {
             $serializer->setAllObjectSerialize(true);
         }
-        for ($i = 0; $i < 100; ++$i) {
-            foreach ([100, 1000, 1010, 1024, 1050, 1100, 10000] as $length) {
-                $input = '';
-                for ($i = 0; $i < $length; ++$i) {
-                    $input .= chr(mt_rand(0, 255));
-                }
-                $result = $serializer->serialize($input);
-                $this->assertInternalType('string', $result);
-                $this->assertLessThanOrEqual(1024, strlen($result));
-            }
+
+        foreach ([100, 1000, 1010, 1024, 1050, 1100, 10000] as $length) {
+            $input = str_repeat('x', $length);
+            $result = $serializer->serialize($input);
+            $this->assertInternalType('string', $result);
+            $this->assertLessThanOrEqual(1024, strlen($result));
+        }
+    }
+
+    public function testLongStringWithOverwrittenMessageLength()
+    {
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer */
+        $serializer = new $class_name();
+        $serializer->setMessageLimit(500);
+
+        foreach (array(100, 490, 499, 500, 501, 1000, 10000) as $length) {
+            $input = str_repeat('x', $length);
+            $result = $serializer->serialize($input);
+            $this->assertInternalType('string', $result);
+            $this->assertLessThanOrEqual(500, strlen($result));
         }
     }
 

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -420,6 +420,24 @@ abstract class SerializerAbstractTest extends TestCase
         $serializer->setAllObjectSerialize(false);
         $this->assertFalse($serializer->getAllObjectSerialize());
     }
+
+    public function testClippingUTF8Characters()
+    {
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('mbstring extension is not enabled.');
+        }
+
+        $testString = 'Прекратите надеяться, что ваши пользователи будут сообщать об ошибках';
+        $class_name = static::get_test_class();
+        /** @var \Raven\Serializer $serializer */
+        $serializer = new $class_name(null, 19);
+
+        $clipped = $serializer->serialize($testString);
+
+        $this->assertEquals('Прекратит {clipped}', $clipped);
+        $this->assertNotNull(json_encode($clipped));
+        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+    }
 }
 
 /**

--- a/tests/SerializerAbstractTest.php
+++ b/tests/SerializerAbstractTest.php
@@ -382,7 +382,7 @@ abstract class SerializerAbstractTest extends TestCase
         $serializer = new $class_name();
         $serializer->setMessageLimit(500);
 
-        foreach (array(100, 490, 499, 500, 501, 1000, 10000) as $length) {
+        foreach ([100, 490, 499, 500, 501, 1000, 10000] as $length) {
             $input = str_repeat('x', $length);
             $result = $serializer->serialize($input);
             $this->assertInternalType('string', $result);


### PR DESCRIPTION
This is a continuation of the work of #526, continuosly porting all the new stuff from the master branch into the 2.0. This is the list of merged PRs on master that I've ported here (by merge order on master):

- [x] #543: docs fix
- [x] #546: adding `application/json` input handling
- [x] #547: docs fix bis
- [x] #548: fix Client PHPDoc
- [x] #551: fix syntax highlighting in the README.md
- [x] #556: docs fix ter
- [x] #557: use badge/poser in the README.md
- [x] ~~#555: Cleanup the 'site' value if it's empty~~ `site` is a deprecated field, no longer present
- [x] ~~#564: add runtime info~~ already covered by #562
- [x] #570: fix official docs definition
- [x] #572: handle non-default host port 
- [x] #573: prepare 1.8.4 release
- [x] ~~#578: Fix x-forwarded-proto detection~~ will be handled with #594
- [x] ~~#583: `exclude_exceptions` with child types~~ already handled in #487
- [x] #554: allow serialization 5 levels deep
- [x] #559: make string limit customizable
- [x] #587: avoid looping when exception throws exception
- [x] #586: Fix monolog handler not accepting Throwable
- [x] #553: fix serializer to account for non-UTF-8 chars
- [x] ~~#588: fix for undefined variable~~ not applicable, CurlHandler no longer present
- [x] #590: update for 1.9.0 release
- [x] ~~#591: prepare 1.10.x release~~ not applicable

I will handle those PHPT regression tests separately:
- [ ] #571: add regression tests for fatal handling
- [ ] #574: avoid double reporting
- [ ] #575: force send with curl_method async
- [ ] #576: more regression PHPT tests and fixes
- [ ] #589: fix regression test
