### PR TITLE
[WIP] [2.0] Post body middleware

### DIFF
--- a/lib/Raven/Middleware/PostBodyMiddleware.php
+++ b/lib/Raven/Middleware/PostBodyMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Raven\Middleware;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Raven\Event;
+
+final class PostBodyMiddleware
+{
+    /**
+     * Collects the needed data and sets it in the given event object.
+     *
+     * @param Event                       $event     The event being processed
+     * @param callable                    $next      The next middleware to call
+     * @param ServerRequestInterface|null $request   The request, if available
+     * @param \Exception|\Throwable|null  $exception The thrown exception, if available
+     * @param array                       $payload   Additional data
+     *
+     * @return Event
+     */
+    public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
+    {
+        if ($request && $request->getBody()->getSize()) {
+            $requestData = $event->getRequest();
+            $requestData['data'] = $request->getBody();
+            $event = $event->withRequest($requestData);
+        }
+
+        return $next($event, $request, $exception, $payload);
+    }
+}

--- a/tests/Middleware/PostBodyMiddlewareTest.php
+++ b/tests/Middleware/PostBodyMiddlewareTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Raven\Tests\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Raven\Configuration;
+use Raven\Event;
+use Raven\Middleware\PostBodyMiddleware;
+use Zend\Diactoros\ServerRequest;
+
+class PostBodyMiddlewareTest extends TestCase
+{
+    public function testInvokeWithNoRequest()
+    {
+        $event = new Event($this->prophesize(Configuration::class)->reveal());
+
+        $invocationCount = 0;
+        $callback = function (Event $eventArg) use ($event, &$invocationCount) {
+            $this->assertSame($event, $eventArg);
+            $this->assertArrayNotHasKey('data', $event->getRequest());
+
+            ++$invocationCount;
+        };
+
+        $middleware = new PostBodyMiddleware();
+        $middleware($event, $callback);
+
+        $this->assertEquals(1, $invocationCount);
+    }
+
+    public function testInvokeWithNoBody()
+    {
+        $event = new Event($this->prophesize(Configuration::class)->reveal());
+        $request = $this->createRequestWithBody(null);
+
+        $invocationCount = 0;
+        $callback = function (Event $eventArg, ServerRequestInterface $requestArg) use ($event, $request, &$invocationCount) {
+            $this->assertSame($request, $requestArg);
+            $this->assertSame($event, $eventArg);
+            $this->assertArrayNotHasKey('data', $event->getRequest());
+
+            ++$invocationCount;
+        };
+
+        $middleware = new PostBodyMiddleware();
+        $middleware($event, $callback, $request);
+
+        $this->assertEquals(1, $invocationCount);
+    }
+
+    /**
+     * @dataProvider invokeDataProvider
+     */
+    public function testInvoke(array $requestData, array $expectedValue)
+    {
+        $event = new Event($this->prophesize(Configuration::class)->reveal());
+        $request = $this->createRequestWithBody($requestData['body']);
+
+        $invocationCount = 0;
+        $callback = function (Event $eventArg, ServerRequestInterface $requestArg) use ($request, $expectedValue, &$invocationCount) {
+            $this->assertSame($request, $requestArg);
+            $this->assertEquals($expectedValue, $eventArg->getRequest());
+
+            ++$invocationCount;
+        };
+
+        $middleware = new PostBodyMiddleware();
+        $middleware($event, $callback, $request);
+
+        $this->assertEquals(1, $invocationCount);
+    }
+
+    public function invokeDataProvider()
+    {
+        return [
+            [
+                [
+                    'body' => 'some-data',
+                ],
+                [
+                    'data' => 'some-data',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param string|null $body
+     *
+     * @return ServerRequest
+     */
+    private function createRequestWithBody($body)
+    {
+        $stream = $this->prophesize(StreamInterface::class);
+        $stringBody = (string) $body;
+        $stream->__toString()
+            ->willReturn($stringBody);
+        $stream->getSize()
+            ->willReturn(strlen($stringBody));
+
+        return (new ServerRequest())->withBody($stream->reveal());
+    }
+}


### PR DESCRIPTION
This stems from #592, to handle separately POST bodies.

This middleware should not be added by default, but the user could add it to get the POST body when needed. I'm thinking about adding also JSON handling, and at least some doc reference.