### PR TITLE
[2.0] Drop the trust_x_forwarded_proto configuration option

### DIFF
--- a/lib/Raven/ClientBuilder.php
+++ b/lib/Raven/ClientBuilder.php
@@ -41,8 +41,6 @@ use Raven\Transport\TransportInterface;
  *
  * @method int getSendAttempts()
  * @method setSendAttempts(int $attemptsCount)
- * @method bool isTrustXForwardedProto()
- * @method setIsTrustXForwardedProto(bool $value)
  * @method string[] getPrefixes()
  * @method setPrefixes(array $prefixes)
  * @method bool getSerializeAllObjects()

--- a/lib/Raven/Configuration.php
+++ b/lib/Raven/Configuration.php
@@ -88,28 +88,6 @@ class Configuration
     }
 
     /**
-     * Checks whether the X-FORWARDED-PROTO header should be trusted.
-     *
-     * @return bool
-     */
-    public function isTrustXForwardedProto()
-    {
-        return $this->options['trust_x_forwarded_proto'];
-    }
-
-    /**
-     * Sets whether the X-FORWARDED-PROTO header should be trusted.
-     *
-     * @param bool $value The value of the option
-     */
-    public function setIsTrustXForwardedProto($value)
-    {
-        $options = array_merge($this->options, ['trust_x_forwarded_proto' => $value]);
-
-        $this->options = $this->resolver->resolve($options);
-    }
-
-    /**
      * Gets the prefixes which should be stripped from filenames to create
      * relative paths.
      *
@@ -642,7 +620,6 @@ class Configuration
     {
         $resolver->setDefaults([
             'send_attempts' => 6,
-            'trust_x_forwarded_proto' => false,
             'prefixes' => explode(PATH_SEPARATOR, get_include_path()),
             'serialize_all_object' => false,
             'sample_rate' => 1,
@@ -667,7 +644,6 @@ class Configuration
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
-        $resolver->setAllowedTypes('trust_x_forwarded_proto', 'bool');
         $resolver->setAllowedTypes('prefixes', 'array');
         $resolver->setAllowedTypes('serialize_all_object', 'bool');
         $resolver->setAllowedTypes('sample_rate', ['int', 'float']);

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -242,7 +242,6 @@ class ClientBuilderTest extends TestCase
     public function optionsDataProvider()
     {
         return [
-            ['setIsTrustXForwardedProto', true],
             ['setPrefixes', ['foo', 'bar']],
             ['setSerializeAllObjects', false],
             ['setSampleRate', 0.5],

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -45,7 +45,6 @@ class ConfigurationTest extends TestCase
     {
         return [
             ['send_attempts', 1, 'getSendAttempts', 'setSendAttempts'],
-            ['trust_x_forwarded_proto', false, 'isTrustXForwardedProto', 'setIsTrustXForwardedProto'],
             ['prefixes', ['foo', 'bar'], 'getPrefixes', 'setPrefixes'],
             ['serialize_all_object', false, 'getSerializeAllObjects', 'setSerializeAllObjects'],
             ['sample_rate', 0.5, 'getSampleRate', 'setSampleRate'],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR fixes issue #594 by dropping the `trust_x_forwared_proto` configuration option, which was unused anyway