### PR TITLE
feat: explicit culprit -> transaction

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -832,7 +832,7 @@ class Raven_Client
             'tags' => $this->tags,
             'platform' => 'php',
             'sdk' => $this->sdk,
-            'culprit' => $this->transaction->peek(),
+            'transaction' => $this->transaction->peek(),
         );
     }
 

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -680,11 +680,11 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
     {
         $client = new Dummy_Raven_Client();
         $ex = $this->create_exception();
-        $client->captureException($ex, array('culprit' => 'test'));
+        $client->captureException($ex, array('transaction' => 'test'));
         $events = $client->getSentEvents();
         $this->assertEquals(1, count($events));
         $event = array_pop($events);
-        $this->assertEquals('test', $event['culprit']);
+        $this->assertEquals('test', $event['transaction']);
     }
 
     /**
@@ -828,7 +828,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 'name' => 'sentry-php',
                 'version' => $client::VERSION,
             ),
-            'culprit' => 'test',
+            'transaction' => 'test',
         );
         $this->assertEquals($expected, $client->get_default_data());
     }


### PR DESCRIPTION
This emits transaction culprits as the actual transaction as intended
by the protocol.