### PR TITLE
Cleanup the PHP version

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -900,7 +900,7 @@ class Raven_Client
         }
 
         $existing_runtime_context = isset($data['contexts']['runtime']) ? $data['contexts']['runtime'] : array();
-        $runtime_context = array('version' => PHP_VERSION, 'name' => 'php');
+        $runtime_context = array('version' => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION, 'name' => 'php');
         $data['contexts']['runtime'] =  array_merge($runtime_context, $existing_runtime_context);
 
         if (!$this->breadcrumbs->is_empty()) {

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -261,7 +261,7 @@ class Raven_Client
         $this->error_handler->registerExceptionHandler();
         $this->error_handler->registerErrorHandler();
         $this->error_handler->registerShutdownFunction();
-        
+
         if ($this->_curl_handler) {
             $this->_curl_handler->registerShutdownFunction();
         }
@@ -900,7 +900,7 @@ class Raven_Client
         }
 
         $existing_runtime_context = isset($data['contexts']['runtime']) ? $data['contexts']['runtime'] : array();
-        $runtime_context = array('version' => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION, 'name' => 'php');
+        $runtime_context = array('version' => self::cleanup_php_version(), 'name' => 'php');
         $data['contexts']['runtime'] =  array_merge($runtime_context, $existing_runtime_context);
 
         if (!$this->breadcrumbs->is_empty()) {
@@ -1519,6 +1519,24 @@ class Raven_Client
     public function setReprSerializer(Raven_ReprSerializer $reprSerializer)
     {
         $this->reprSerializer = $reprSerializer;
+    }
+
+    /**
+     * Cleans up the PHP version string by extracting junk from the extra part of the version.
+     *
+     * @param string $extra
+     *
+     * @return string
+     */
+    public static function cleanup_php_version($extra = PHP_EXTRA_VERSION)
+    {
+        $version = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+
+        if (!empty($extra) && preg_match('{^-(?<extra>(beta|rc)-?([0-9]+)?(-dev)?)}i', $extra, $matches) === 1) {
+            $version .= '-' . $matches['extra'];
+        }
+
+        return $version;
     }
 
     private function triggerAutoload()

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -2576,7 +2576,6 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         ), $event['breadcrumbs']);
     }
 
-
     /**
      * @covers Raven_Client::capture
      */
@@ -2624,5 +2623,30 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertInternalType('resource', $reflection->getValue($raven));
         $raven->close_curl_resource();
         $this->assertNull($reflection->getValue($raven));
+    }
+
+    /** @covers Raven_Client::cleanup_php_version */
+    public function testPhpVersionCleanup()
+    {
+        $baseVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+        $phpExtraVersions = array(
+            '' => $baseVersion,
+            '-1+ubuntu17.04.1+deb.sury.org+1' => $baseVersion,
+            '-beta3-1+ubuntu17.04.1+deb.sury.org+1' => "{$baseVersion}-beta3",
+            '-beta5-dev-1+ubuntu17.04.1+deb.sury.org+1' => "{$baseVersion}-beta5-dev",
+            '-rc-9-1+ubuntu17.04.1+deb.sury.org+1' => "{$baseVersion}-rc-9",
+            '-2~ubuntu16.04.1+deb.sury.org+1' => $baseVersion,
+            '-beta1-dev' => "{$baseVersion}-beta1-dev",
+            '-rc10' => "{$baseVersion}-rc10",
+            '-RC10' => "{$baseVersion}-RC10",
+            '-rc2-dev' => "{$baseVersion}-rc2-dev",
+            '-beta-2-dev' => "{$baseVersion}-beta-2-dev",
+            '-beta2' => "{$baseVersion}-beta2",
+            '-beta-9' => "{$baseVersion}-beta-9",
+        );
+
+        foreach ($phpExtraVersions as $extraVersion => $expectedVersion) {
+            $this->assertEquals($expectedVersion, Raven_Client::cleanup_php_version($extraVersion));
+        }
     }
 }


### PR DESCRIPTION
As discussed with the SDK team (Slack) we might want to not include the extra part of the PHP version to cleanup the Sentry interface.

![image](https://user-images.githubusercontent.com/1090754/40474590-bc1f50fa-5f3f-11e8-8356-f61fc3ca45d1.png)

(working on the unknown browser)