### PR TITLE
Incrase serialize default max depth

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -76,7 +76,7 @@ class Raven_Serializer
      * @param int   $_depth
      * @return string|bool|double|int|null|object|array
      */
-    public function serialize($value, $max_depth = 3, $_depth = 0)
+    public function serialize($value, $max_depth = 10, $_depth = 0)
     {
         $className = is_object($value) ? get_class($value) : null;
         $toArray = is_array($value) || $className === 'stdClass';


### PR DESCRIPTION
Can we have this max depth increased? The extra attributes from data variable in Client::sanitiz doesn't pass any values and I feel default value should be increased. Or we can have some static configuration for this.