### PR TITLE
Provide method to register async shutdown function

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -269,9 +269,8 @@ class Raven_Client
         $this->error_handler->registerErrorHandler();
         $this->error_handler->registerShutdownFunction();
 
-        if ($this->_curl_handler) {
-            $this->_curl_handler->registerShutdownFunction();
-        }
+        // Register final shutdown function to send fatal error via curl async.
+        $this->registerShutdownFunction();
 
         return $this;
     }
@@ -742,12 +741,10 @@ class Raven_Client
         $handler->install();
     }
 
-    protected function registerShutdownFunction()
+    public function registerShutdownFunction()
     {
-        if (!$this->_shutdown_function_has_been_set) {
-            $this->_shutdown_function_has_been_set = true;
-            register_shutdown_function(array($this, 'onShutdown'));
-        }
+        $this->_shutdown_function_has_been_set = true;
+        register_shutdown_function(array($this, 'onShutdown'));
     }
 
     /**


### PR DESCRIPTION
For any custom setups of the client that don't call install(), we should provide a method to register the async shutdown function (_curl_handler is protected so otherwise this can't be done).