### PR TITLE
[2.0] Fix build cs namespaced constants

### DIFF
--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -69,7 +69,7 @@ class MonologHandler extends AbstractProcessingHandler
             isset($record['context']['exception'])
             && (
                 $record['context']['exception'] instanceof \Exception
-                || (PHP_VERSION_ID >= 70000 && $record['context']['exception'] instanceof \Throwable)
+                || (\PHP_VERSION_ID >= 70000 && $record['context']['exception'] instanceof \Throwable)
             )
         ) {
             /**

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -396,7 +396,7 @@ class Client
 
         $event = $this->middlewareStack->executeStack(
             $event,
-            isset($_SERVER['REQUEST_METHOD']) && PHP_SAPI !== 'cli' ? ServerRequestFactory::fromGlobals() : null,
+            isset($_SERVER['REQUEST_METHOD']) && \PHP_SAPI !== 'cli' ? ServerRequestFactory::fromGlobals() : null,
             isset($payload['exception']) ? $payload['exception'] : null,
             $payload
         );

--- a/lib/Raven/Configuration.php
+++ b/lib/Raven/Configuration.php
@@ -742,11 +742,11 @@ class Configuration
         }
 
         if (
-            DIRECTORY_SEPARATOR === substr($path, 0, 1)
-            && DIRECTORY_SEPARATOR !== substr($path, -1)
+            \DIRECTORY_SEPARATOR === substr($path, 0, 1)
+            && \DIRECTORY_SEPARATOR !== substr($path, -1)
             && '.php' !== substr($path, -4)
         ) {
-            $path .= DIRECTORY_SEPARATOR;
+            $path .= \DIRECTORY_SEPARATOR;
         }
 
         return $path;

--- a/lib/Raven/Middleware/ModulesMiddleware.php
+++ b/lib/Raven/Middleware/ModulesMiddleware.php
@@ -49,7 +49,7 @@ final class ModulesMiddleware
      */
     public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
-        $composerFilePath = $this->config->getProjectRoot() . DIRECTORY_SEPARATOR . 'composer.json';
+        $composerFilePath = $this->config->getProjectRoot() . \DIRECTORY_SEPARATOR . 'composer.json';
 
         if (file_exists($composerFilePath)) {
             $composer = Factory::create(new NullIO(), $composerFilePath, true);

--- a/tests/Breadcrumbs/MonologHandlerTest.php
+++ b/tests/Breadcrumbs/MonologHandlerTest.php
@@ -90,7 +90,7 @@ EOF;
 
     public function testThrowableBeingParsedAsException()
     {
-        if (PHP_VERSION_ID <= 70000) {
+        if (\PHP_VERSION_ID <= 70000) {
             $this->markTestSkipped('PHP 7.0 introduced Throwable');
         }
 

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -289,7 +289,7 @@ class StacktraceTest extends TestCase
 
     protected function getFixturePath($file)
     {
-        return realpath(__DIR__ . DIRECTORY_SEPARATOR . 'Fixtures' . DIRECTORY_SEPARATOR . $file);
+        return realpath(__DIR__ . \DIRECTORY_SEPARATOR . 'Fixtures' . \DIRECTORY_SEPARATOR . $file);
     }
 
     protected function getFixture($file)


### PR DESCRIPTION
Due to a new rule in PHPCSFixer (see https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3127), the 2.0 build was failing in recent PRs like #608 #609 #610 #611. This should fix them all.