### PR TITLE
[2.0] Allow usage of the public DSN in the client configuration

### DIFF
--- a/lib/Raven/Configuration.php
+++ b/lib/Raven/Configuration.php
@@ -661,11 +661,11 @@ class Configuration
                 return false;
             }
 
-            if (!isset($parsed['scheme'], $parsed['user'], $parsed['pass'], $parsed['host'], $parsed['path'])) {
+            if (!isset($parsed['scheme'], $parsed['user'], $parsed['host'], $parsed['path'])) {
                 return false;
             }
 
-            if (empty($parsed['user']) || empty($parsed['pass'])) {
+            if (empty($parsed['user']) || (isset($parsed['pass']) && empty($parsed['pass']))) {
                 return false;
             }
 
@@ -700,7 +700,7 @@ class Configuration
 
             $this->server .= substr($parsed['path'], 0, strripos($parsed['path'], '/'));
             $this->publicKey = $parsed['user'];
-            $this->secretKey = $parsed['pass'];
+            $this->secretKey = isset($parsed['pass']) ? $parsed['pass'] : null;
 
             $parts = explode('/', $parsed['path']);
 

--- a/lib/Raven/HttpClient/Authentication/SentryAuth.php
+++ b/lib/Raven/HttpClient/Authentication/SentryAuth.php
@@ -44,14 +44,26 @@ final class SentryAuth implements Authentication
      */
     public function authenticate(RequestInterface $request)
     {
-        $header = sprintf(
-            'Sentry sentry_version=%s, sentry_client=%s, sentry_timestamp=%F, sentry_key=%s, sentry_secret=%s',
-            Client::PROTOCOL,
-            Client::USER_AGENT,
-            microtime(true),
-            $this->configuration->getPublicKey(),
-            $this->configuration->getSecretKey()
-        );
+        $headerKeys = array_filter([
+            'sentry_version' => Client::PROTOCOL,
+            'sentry_client' => Client::USER_AGENT,
+            'sentry_timestamp' => sprintf('%F', microtime(true)),
+            'sentry_key' => $this->configuration->getPublicKey(),
+            'sentry_secret' => $this->configuration->getSecretKey(),
+        ]);
+
+        $isFirstItem = true;
+        $header = 'Sentry ';
+
+        foreach ($headerKeys as $headerKey => $headerValue) {
+            if (!$isFirstItem) {
+                $header .= ', ';
+            }
+
+            $header .= $headerKey . '=' . $headerValue;
+
+            $isFirstItem = false;
+        }
 
         return $request->withHeader('X-Sentry-Auth', $header);
     }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -83,6 +83,15 @@ class ConfigurationTest extends TestCase
     {
         return [
             [
+                'http://public@example.com/1',
+                [
+                    'project_id' => 1,
+                    'public_key' => 'public',
+                    'secret_key' => null,
+                    'server' => 'http://example.com',
+                ],
+            ],
+            [
                 'http://public:secret@example.com/1',
                 [
                     'project_id' => 1,
@@ -156,7 +165,7 @@ class ConfigurationTest extends TestCase
             ['http://public:secret@/1'],
             ['http://public:secret@example.com'],
             ['http://:secret@example.com/1'],
-            ['http://public@example.com/1'],
+            ['http://public:@example.com'],
             ['tcp://public:secret@example.com/1'],
         ];
     }

--- a/tests/HttpClient/Authentication/SentryAuthTest.php
+++ b/tests/HttpClient/Authentication/SentryAuthTest.php
@@ -49,4 +49,32 @@ class SentryAuthTest extends TestCase
 
         $this->assertSame($newRequest, $authentication->authenticate($request));
     }
+
+    public function testAuthenticateWithNoSecretKey()
+    {
+        $configuration = new Configuration(['server' => 'http://public@example.com/']);
+        $authentication = new SentryAuth($configuration);
+
+        /** @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject $request */
+        $request = $this->getMockBuilder(RequestInterface::class)
+            ->getMock();
+
+        /** @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject $newRequest */
+        $newRequest = $this->getMockBuilder(RequestInterface::class)
+            ->getMock();
+
+        $headerValue = sprintf(
+            'Sentry sentry_version=%s, sentry_client=%s, sentry_timestamp=%F, sentry_key=public',
+            Client::PROTOCOL,
+            Client::USER_AGENT,
+            microtime(true)
+        );
+
+        $request->expects($this->once())
+            ->method('withHeader')
+            ->with('X-Sentry-Auth', $headerValue)
+            ->willReturn($newRequest);
+
+        $this->assertSame($newRequest, $authentication->authenticate($request));
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

This PR allows usage of the public DSN available since Sentry 9 in the client configuration. It's the same change introduced in #615, just ported to the `2.0` branch. I have no test machine upgraded yet to that version of the server, so my assumptions about the fact that everything works is based on the unit tests passing. If you can check in a real environment please do it before approving