### PR TITLE
[2.0] Use jobs in Travis build

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,7 +5,7 @@ tools:
     php_code_coverage: true
     external_code_coverage:
         timeout: 2400 # There can be another pull request in progress
-        runs: 4 # PHP 5.6 + PHP 7.0 + PHP 7.1 + PHP 7.2
+        runs: 1
 
 build:
     environment:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,17 +22,29 @@ cache:
 
 before_install:
   - if [ "$REMOVE_XDEBUG" = "1" ]; then phpenv config-rm xdebug.ini; fi
-  - composer self-update
 
 install: travis_retry composer install --no-interaction
 
 script:
-  - composer phpcs
-  - composer tests-travis
+  - composer tests
 
-after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - if [ $(phpenv version-name) = "5.6" ] && [ "$REMOVE_XDEBUG" = "0" ]; then php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT; fi
-  - if [ $(phpenv version-name) = "7.0" ] && [ "$REMOVE_XDEBUG" = "0" ]; then php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT; fi
-  - if [ $(phpenv version-name) = "7.1" ] && [ "$REMOVE_XDEBUG" = "0" ]; then php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT; fi
-  - if [ $(phpenv version-name) = "7.2" ] && [ "$REMOVE_XDEBUG" = "0" ]; then php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT; fi
+jobs:
+  include:
+    - stage: Test
+      php: 5.6
+      env: 
+        COMPOSER_OPTIONS: "--prefer-lowest"
+        REMOVE_XDEBUG: "1"
+      install: travis_retry composer install --no-interaction --prefer-lowest
+    - stage: Code style
+    - script: 
+        - composer phpcs
+      env: 
+        CS-FIXER: true
+        REMOVE_XDEBUG: "1"
+    - stage: Coverage
+      script: 
+        - phpdbg -qrr vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-clover tests/clover.xml
+      after_success:
+        - wget https://scrutinizer-ci.com/ocular.phar
+        - php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,18 @@ jobs:
         REMOVE_XDEBUG: "1"
       install: travis_retry composer update --no-interaction --prefer-lowest
     - stage: Code style
-      php: 7.2
+      php: 7.1
       env: 
         CS-FIXER: true
         REMOVE_XDEBUG: "1"
       script: 
         - composer phpcs
     - stage: Coverage
+      php: 7.1
+      env:
+        REMOVE_XDEBUG: "0"
       script:
-        - phpdbg -qrr vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-clover tests/clover.xml
+        - vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-clover tests/clover.xml
       after_success:
         - wget https://scrutinizer-ci.com/ocular.phar
         - php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       env: 
         COMPOSER_OPTIONS: "--prefer-lowest"
         REMOVE_XDEBUG: "1"
-      install: travis_retry composer install --no-interaction --prefer-lowest
+      install: travis_retry composer update --no-interaction --prefer-lowest
     - stage: Code style
       php: 7.2
       env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,14 @@ jobs:
         REMOVE_XDEBUG: "1"
       install: travis_retry composer install --no-interaction --prefer-lowest
     - stage: Code style
-    - script: 
-        - composer phpcs
+      php: 7.2
       env: 
         CS-FIXER: true
         REMOVE_XDEBUG: "1"
-    - stage: Coverage
       script: 
+        - composer phpcs
+    - stage: Coverage
+      script:
         - phpdbg -qrr vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-clover tests/clover.xml
       after_success:
         - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
         "monolog/monolog": "~1.0",
         "php-http/curl-client": "~1.7",
         "php-http/mock-client": "~1.0",
-        "phpunit/phpunit": "^5.7|^6.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0"
+        "phpunit/phpunit": "^5.7.27|^6.0",
+        "symfony/phpunit-bridge": "^4.0"
     },
     "suggest": {
         "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "composer/composer": "^1.6",
         "friendsofphp/php-cs-fixer": "~2.1",
         "monolog/monolog": "^1.3",
-        "php-http/curl-client": "~1.7",
+        "php-http/curl-client": "^1.7.1",
         "php-http/message": "^1.5",
         "php-http/mock-client": "~1.0",
         "phpunit/phpunit": "^5.7.27|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "friendsofphp/php-cs-fixer": "~2.1",
         "monolog/monolog": "^1.3",
         "php-http/curl-client": "~1.7",
+        "php-http/message": "^1.5",
         "php-http/mock-client": "~1.0",
         "phpunit/phpunit": "^5.7.27|^6.0",
         "symfony/phpunit-bridge": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -58,9 +58,6 @@
         "tests": [
             "vendor/bin/phpunit --verbose"
         ],
-        "tests-travis": [
-            "vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-clover tests/clover.xml"
-        ],
         "tests-report": [
             "vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-html tests/html-report"
         ],

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "composer/composer": "^1.6",
         "friendsofphp/php-cs-fixer": "~2.1",
-        "monolog/monolog": "~1.0",
+        "monolog/monolog": "^1.3",
         "php-http/curl-client": "~1.7",
         "php-http/mock-client": "~1.0",
         "phpunit/phpunit": "^5.7.27|^6.0",

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -197,6 +197,8 @@ class ClientTest extends TestCase
         @trigger_error('foo', E_USER_NOTICE);
 
         $client->captureLastError();
+
+        $this->clearLastError();
     }
 
     public function testCaptureLastErrorDoesNothingWhenThereIsNoError()
@@ -204,11 +206,13 @@ class ClientTest extends TestCase
         /** @var Client|\PHPUnit_Framework_MockObject_MockObject $client */
         $client = $this->getMockBuilder(Client::class)
             ->disableOriginalConstructor()
-            ->setMethodsExcept(['captureException'])
+            ->setMethodsExcept(['captureLastError'])
             ->getMock();
 
         $client->expects($this->never())
-            ->method('capture');
+            ->method('captureException');
+
+        $this->clearLastError();
 
         $client->captureLastError();
     }
@@ -546,5 +550,17 @@ class ClientTest extends TestCase
         } catch (\Exception $ex) {
             return $ex;
         }
+    }
+
+    /**
+     * @see https://github.com/symfony/polyfill/blob/52332f49d18c413699d2dccf465234356f8e0b2c/src/Php70/Php70.php#L52-L61
+     */
+    private function clearLastError()
+    {
+        $handler = function() { return false; };
+
+        set_error_handler($handler);
+        @trigger_error('');
+        restore_error_handler();
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -209,7 +209,7 @@ class ClientTest extends TestCase
 
         $client->expects($this->never())
             ->method('capture');
-        
+
         $client->captureLastError();
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -197,8 +197,6 @@ class ClientTest extends TestCase
         @trigger_error('foo', E_USER_NOTICE);
 
         $client->captureLastError();
-
-        error_clear_last();
     }
 
     public function testCaptureLastErrorDoesNothingWhenThereIsNoError()
@@ -211,9 +209,7 @@ class ClientTest extends TestCase
 
         $client->expects($this->never())
             ->method('capture');
-
-        error_clear_last();
-
+        
         $client->captureLastError();
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -557,7 +557,7 @@ class ClientTest extends TestCase
      */
     private function clearLastError()
     {
-        $handler = function() { return false; };
+        $handler = function () { return false; };
 
         set_error_handler($handler);
         @trigger_error('');

--- a/tests/Context/ContextTest.php
+++ b/tests/Context/ContextTest.php
@@ -113,8 +113,6 @@ class ContextTest extends TestCase
         $this->assertInternalType('array', $error);
         $this->assertEquals('Undefined index: foo', $error['message']);
 
-        error_clear_last();
-
         $context['foo'] = 'bar';
 
         $this->assertAttributeEquals(['foo' => 'bar'], 'data', $context);


### PR DESCRIPTION
This PR stems from https://github.com/getsentry/sentry-php/pull/614#issuecomment-397888515.

 - use Travis new Job feature to split tests from other checks like CS
 - add `--prefer-lowest` job
 - report coverage only once, in the last job, using PHPDBG for faster execution