### PR TITLE
[2.0] Add PHPStan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,19 @@ jobs:
         COMPOSER_OPTIONS: "--prefer-lowest"
         REMOVE_XDEBUG: "1"
       install: travis_retry composer update --no-interaction --prefer-lowest
-    - stage: Code style
-      php: 7.1
+    - stage: Code style & static analysis
+    - php: 7.1
       env: 
         CS-FIXER: true
         REMOVE_XDEBUG: "1"
       script: 
         - composer phpcs
+    - php: 7.1
+      env: 
+        PHPSTAN: true
+        REMOVE_XDEBUG: "1"
+      script: 
+        - composer phpstan
     - stage: Coverage
       php: 7.1
       env:

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
         ],
         "phpstan": [
-            "vendor/bin/phpstan.phar analyse lib tests"
+            "vendor/bin/phpstan.phar analyse lib tests -c phpstan.neon -l 0"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
         ],
         "phpstan": [
-            "vendor/bin/phpstan.phar analyse lib tests -c phpstan.neon -l 2"
+            "composer require --dev phpstan/phpstan-shim ^0.9.2",
+            "vendor/bin/phpstan.phar analyse lib tests -c phpstan.neon -l 3"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "php-http/curl-client": "^1.7.1",
         "php-http/message": "^1.5",
         "php-http/mock-client": "~1.0",
+        "phpstan/phpstan-shim": "^0.9.2",
         "phpunit/phpunit": "^5.7.27|^6.0",
         "symfony/phpunit-bridge": "^4.0"
     },
@@ -64,6 +65,9 @@
         ],
         "phpcs": [
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
+        ],
+        "phpstan": [
+            "vendor/bin/phpstan.phar analyse src tests"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
         ],
         "phpstan": [
-            "vendor/bin/phpstan.phar analyse lib tests -c phpstan.neon -l 0"
+            "vendor/bin/phpstan.phar analyse lib tests -c phpstan.neon -l 2"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
         ],
         "phpstan": [
-            "vendor/bin/phpstan.phar analyse src tests"
+            "vendor/bin/phpstan.phar analyse lib tests"
         ]
     },
     "config": {

--- a/lib/Raven/Middleware/MiddlewareStack.php
+++ b/lib/Raven/Middleware/MiddlewareStack.php
@@ -27,7 +27,7 @@ class MiddlewareStack
     private $handler;
 
     /**
-     * @var array<int, MiddlewareInterface[]> The list of middlewares
+     * @var array<int, callable[]> The list of middlewares
      */
     private $stack = [];
 

--- a/lib/Raven/TransactionStack.php
+++ b/lib/Raven/TransactionStack.php
@@ -55,7 +55,7 @@ final class TransactionStack implements \Countable
     /**
      * Pushes the given values onto the stack.
      *
-     * @param string[] $values The values to push
+     * @param array<int, string> $values The values to push
      *
      * @throws \InvalidArgumentException If any of the values is not a string
      */

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     ignoreErrors:
         - '/Constructor of class Raven\\HttpClient\\Encoding\\Base64EncodingStream has an unused parameter \$(readFilterOptions|writeFilterOptions)/'
+        - '/Call to an undefined method Raven\\ClientBuilder::methodThatDoesNotExists\(\)/'
     excludes_analyse:
         - tests/resources

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    ignoreErrors:
+        - '/Constructor of class Raven\\HttpClient\\Encoding\\Base64EncodingStream has an unused parameter \$(readFilterOptions|writeFilterOptions)/'
+    excludes_analyse:
+        - tests/resources

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -93,7 +93,7 @@ class ClientTest extends TestCase
         $reflectionProperty->setValue($client, $middlewareStack);
         $reflectionProperty->setAccessible(false);
 
-        $client->removeMiddleware($middleware, -10);
+        $client->removeMiddleware($middleware);
     }
 
     public function testAddProcessor()
@@ -287,7 +287,7 @@ class ClientTest extends TestCase
 
         Uuid::setFactory(new UuidFactory());
 
-        $this->assertEquals('ddbd643a51904ccea6ce3098506f9d33', $client->getLastEventID());
+        $this->assertEquals('ddbd643a51904ccea6ce3098506f9d33', $client->getLastEventId());
     }
 
     public function testGetUserContext()

--- a/tests/Middleware/BreadcrumbInterfaceMiddlewareTest.php
+++ b/tests/Middleware/BreadcrumbInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Breadcrumbs\Breadcrumb;

--- a/tests/Middleware/ContextInterfaceMiddlewareTest.php
+++ b/tests/Middleware/ContextInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Configuration;

--- a/tests/Middleware/ExceptionInterfaceMiddlewareTest.php
+++ b/tests/Middleware/ExceptionInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Client;

--- a/tests/Middleware/MessageInterfaceMiddlewareTest.php
+++ b/tests/Middleware/MessageInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Configuration;

--- a/tests/Middleware/ModulesMiddlewareTest.php
+++ b/tests/Middleware/ModulesMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Configuration;

--- a/tests/Middleware/RequestInterfaceMiddlewareTest.php
+++ b/tests/Middleware/RequestInterfaceMiddlewareTest.php
@@ -57,7 +57,7 @@ class RequestInterfaceMiddlewareTest extends TestCase
         }
 
         $invokationCount = 0;
-        $callback = function (Event $eventArg, ServerRequestInterface $requestArg) use ($event, $request, $expectedValue, &$invokationCount) {
+        $callback = function (Event $eventArg, ServerRequestInterface $requestArg) use ($request, $expectedValue, &$invokationCount) {
             $this->assertSame($request, $requestArg);
             $this->assertEquals($expectedValue, $eventArg->getRequest());
 

--- a/tests/Middleware/RequestInterfaceMiddlewareTest.php
+++ b/tests/Middleware/RequestInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;

--- a/tests/Middleware/SanitizerMiddlewareTest.php
+++ b/tests/Middleware/SanitizerMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Configuration;

--- a/tests/Middleware/UserInterfaceMiddlewareTest.php
+++ b/tests/Middleware/UserInterfaceMiddlewareTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Raven\Tests\Breadcrumbs;
+namespace Raven\Tests\Middleware;
 
 use PHPUnit\Framework\TestCase;
 use Raven\Configuration;


### PR DESCRIPTION
This is now easily doable in CI thanks to #618.

This adds an additional job in CI, alongside the CS check, to do static analysis of code. It requires the package using a shim with the PHAR inside, since it requires PHP 7 otherwise.