### PR TITLE
Switch from ___DSN___ to ___PUBLIC_DSN___ for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ more about [automatic PHP error reporting with Sentry](https://sentry.io/for/php
 ```php
 // Instantiate a new client with a compatible DSN and install built-in
 // handlers
-$client = (new Raven_Client('http://public:secret@example.com/1'))->install();
+$client = (new Raven_Client('http://public@example.com/1'))->install();
 
 // Capture an exception
 $event_id = $client->captureException($ex);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,7 +41,7 @@ once and reference it from anywhere you want to interface with Sentry:
 
 .. code-block:: php
 
-    $client = new Raven_Client('___DSN___');
+    $client = new Raven_Client('___PUBLIC_DSN___');
 
 Once you have the client you can either use it manually or enable the
 automatic error and exception capturing which is recomended:

--- a/docs/integrations/laravel.rst
+++ b/docs/integrations/laravel.rst
@@ -51,7 +51,7 @@ Add your DSN to ``.env``:
 
 .. code-block:: bash
 
-    SENTRY_LARAVEL_DSN=___DSN___
+    SENTRY_LARAVEL_DSN=___PUBLIC_DSN___
 
 Finally, if you wish to wire up User Feedback, you can do so by creating a custom
 error view in `resources/views/errors/500.blade.php`.
@@ -157,7 +157,7 @@ Add your DSN to ``config/sentry.php``:
     <?php
 
     return array(
-        'dsn' => '___DSN___',
+        'dsn' => '___PUBLIC_DSN___',
 
         // ...
     );
@@ -208,7 +208,7 @@ Create the Sentry configuration file (``config/sentry.php``):
     <?php
 
     return array(
-        'dsn' => '___DSN___',
+        'dsn' => '___PUBLIC_DSN___',
 
         // capture release as git sha
         // 'release' => trim(exec('git log --pretty="%h" -n1 HEAD')),
@@ -285,7 +285,7 @@ The following settings are available for the client:
 
     .. code-block:: php
 
-        'dsn' => '___DSN___',
+        'dsn' => '___PUBLIC_DSN___',
 
 .. describe:: release
 

--- a/docs/integrations/monolog.rst
+++ b/docs/integrations/monolog.rst
@@ -8,7 +8,7 @@ Monolog supports Sentry out of the box, so you'll just need to configure a handl
 
 .. sourcecode:: php
 
-    $client = new Raven_Client('___DSN___');
+    $client = new Raven_Client('___PUBLIC_DSN___');
 
     $handler = new Monolog\Handler\RavenHandler($client);
     $handler->setFormatter(new Monolog\Formatter\LineFormatter("%message% %context% %extra%\n"));
@@ -48,7 +48,7 @@ Sentry provides a breadcrumb handler to automatically send logs along as crumbs:
 
 .. sourcecode:: php
 
-    $client = new Raven_Client('___DSN___');
+    $client = new Raven_Client('___PUBLIC_DSN___');
 
     $handler = new \Raven_Breadcrumbs_MonologHandler($client);
     $monolog->pushHandler($handler);

--- a/docs/integrations/symfony2.rst
+++ b/docs/integrations/symfony2.rst
@@ -39,4 +39,4 @@ Add your DSN to ``app/config/config.yml``:
 .. code-block:: yaml
 
     sentry:
-        dsn: "___DSN___"
+        dsn: "___PUBLIC_DSN___"

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,7 +12,7 @@ once and reference it from anywhere you want to interface with Sentry:
 
 .. code-block:: php
 
-    $sentryClient = new Raven_Client('___DSN___');
+    $sentryClient = new Raven_Client('___PUBLIC_DSN___');
 
 
 Capturing Errors
@@ -185,7 +185,7 @@ which is aware of the last event ID.
 
     <?php
 
-    $sentry = new \Raven_Client(___DSN___);
+    $sentry = new \Raven_Client(___PUBLIC_DSN___);
 
     public class App {
         function error500($exc) {
@@ -298,12 +298,11 @@ Testing Your Connection
 The PHP client includes a simple helper script to test your connection and
 credentials with the Sentry master server::
 
-    $ bin/sentry test ___DSN___
+    $ bin/sentry test ___PUBLIC_DSN___
     Client configuration:
     -> server: [___API_URL___]
     -> project: ___PROJECT_ID___
     -> public_key: ___PUBLIC_KEY___
-    -> secret_key: ___SECRET_KEY___
 
     Sending a test event:
     -> event ID: f1765c9aed4f4ceebe5a93df9eb2d34f


### PR DESCRIPTION
Since we landed public DSN support in 1.9.1 we should also update the docs to reflect that in the Sentry interface.