### PR TITLE
[2.0] Rename the "server" configuration option to "dsn"

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -42,6 +42,7 @@
   object instances should be serialized.
 - The `context_lines` option has been added to configure the number of lines of
   code context to capture.
+- The `server` option has been renamed to `dsn`.
 
 ### Client
 
@@ -176,7 +177,7 @@
   $client->getConfig()->setShouldCapture(...);
 
 - The method `Raven_Client::getServerEndpoint` has been removed. You should use
-  `Configuration::getServer` instead.
+  `Configuration::getDsn` instead.
 
   Before:
 

--- a/lib/Raven/ClientBuilder.php
+++ b/lib/Raven/ClientBuilder.php
@@ -69,7 +69,7 @@ use Raven\Transport\TransportInterface;
  * @method setLogger(string $logger)
  * @method string getRelease()
  * @method setRelease(string $release)
- * @method string getServer()
+ * @method string getDsn()
  * @method string getServerName()
  * @method setServerName(string $serverName)
  * @method string[] getTags()
@@ -317,8 +317,8 @@ final class ClientBuilder implements ClientBuilderInterface
      */
     private function createHttpClientInstance()
     {
-        if (null !== $this->configuration->getServer()) {
-            $this->addHttpClientPlugin(new BaseUriPlugin($this->uriFactory->createUri($this->configuration->getServer())));
+        if (null !== $this->configuration->getDsn()) {
+            $this->addHttpClientPlugin(new BaseUriPlugin($this->uriFactory->createUri($this->configuration->getDsn())));
         }
 
         $this->addHttpClientPlugin(new HeaderSetPlugin(['User-Agent' => Client::USER_AGENT]));
@@ -340,7 +340,7 @@ final class ClientBuilder implements ClientBuilderInterface
             return $this->transport;
         }
 
-        if (null !== $this->configuration->getServer()) {
+        if (null !== $this->configuration->getDsn()) {
             return new HttpTransport($this->configuration, $this->createHttpClientInstance(), $this->messageFactory);
         }
 

--- a/lib/Raven/Configuration.php
+++ b/lib/Raven/Configuration.php
@@ -29,7 +29,7 @@ class Configuration
     /**
      * @var string|null A simple server string, set to the DSN found on your Sentry settings
      */
-    private $server;
+    private $dsn;
 
     /**
      * @var string The project ID number to send to the Sentry server
@@ -479,9 +479,9 @@ class Configuration
      *
      * @return string
      */
-    public function getServer()
+    public function getDsn()
     {
-        return $this->server;
+        return $this->dsn;
     }
 
     /**
@@ -613,7 +613,7 @@ class Configuration
             'project_root' => null,
             'logger' => 'php',
             'release' => null,
-            'server' => isset($_SERVER['SENTRY_DSN']) ? $_SERVER['SENTRY_DSN'] : null,
+            'dsn' => isset($_SERVER['SENTRY_DSN']) ? $_SERVER['SENTRY_DSN'] : null,
             'server_name' => gethostname(),
             'should_capture' => null,
             'tags' => [],
@@ -636,14 +636,14 @@ class Configuration
         $resolver->setAllowedTypes('project_root', ['null', 'string']);
         $resolver->setAllowedTypes('logger', 'string');
         $resolver->setAllowedTypes('release', ['null', 'string']);
-        $resolver->setAllowedTypes('server', ['null', 'boolean', 'string']);
+        $resolver->setAllowedTypes('dsn', ['null', 'boolean', 'string']);
         $resolver->setAllowedTypes('server_name', 'string');
         $resolver->setAllowedTypes('should_capture', ['null', 'callable']);
         $resolver->setAllowedTypes('tags', 'array');
         $resolver->setAllowedTypes('error_types', ['null', 'int']);
 
         $resolver->setAllowedValues('encoding', ['gzip', 'json']);
-        $resolver->setAllowedValues('server', function ($value) {
+        $resolver->setAllowedValues('dsn', function ($value) {
             switch (strtolower($value)) {
                 case '':
                 case 'false':
@@ -676,7 +676,7 @@ class Configuration
             return true;
         });
 
-        $resolver->setNormalizer('server', function (Options $options, $value) {
+        $resolver->setNormalizer('dsn', function (Options $options, $value) {
             switch (strtolower($value)) {
                 case '':
                 case 'false':
@@ -685,20 +685,20 @@ class Configuration
                 case '(empty)':
                 case 'null':
                 case '(null)':
-                    $this->server = null;
+                    $this->dsn = null;
 
                     return null;
             }
 
             $parsed = @parse_url($value);
 
-            $this->server = $parsed['scheme'] . '://' . $parsed['host'];
+            $this->dsn = $parsed['scheme'] . '://' . $parsed['host'];
 
             if (isset($parsed['port']) && ((80 !== $parsed['port'] && 'http' === $parsed['scheme']) || (443 !== $parsed['port'] && 'https' === $parsed['scheme']))) {
-                $this->server .= ':' . $parsed['port'];
+                $this->dsn .= ':' . $parsed['port'];
             }
 
-            $this->server .= substr($parsed['path'], 0, strripos($parsed['path'], '/'));
+            $this->dsn .= substr($parsed['path'], 0, strripos($parsed['path'], '/'));
             $this->publicKey = $parsed['user'];
             $this->secretKey = isset($parsed['pass']) ? $parsed['pass'] : null;
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -37,7 +37,7 @@ class ClientBuilderTest extends TestCase
 
     public function testHttpTransportIsUsedWhenServeIsConfigured()
     {
-        $clientBuilder = new ClientBuilder(['server' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
 
         $transport = $this->getObjectAttribute($clientBuilder->getClient(), 'transport');
 
@@ -58,7 +58,7 @@ class ClientBuilderTest extends TestCase
         /** @var UriFactory|\PHPUnit_Framework_MockObject_MockObject $uriFactory */
         $uriFactory = $this->createMock(UriFactory::class);
 
-        $clientBuilder = new ClientBuilder(['server' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $clientBuilder->setUriFactory($uriFactory);
 
         $this->assertAttributeSame($uriFactory, 'uriFactory', $clientBuilder);
@@ -69,7 +69,7 @@ class ClientBuilderTest extends TestCase
         /** @var MessageFactory|\PHPUnit_Framework_MockObject_MockObject $messageFactory */
         $messageFactory = $this->createMock(MessageFactory::class);
 
-        $clientBuilder = new ClientBuilder(['server' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $clientBuilder->setMessageFactory($messageFactory);
 
         $this->assertAttributeSame($messageFactory, 'messageFactory', $clientBuilder);
@@ -84,7 +84,7 @@ class ClientBuilderTest extends TestCase
         /** @var TransportInterface|\PHPUnit_Framework_MockObject_MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
 
-        $clientBuilder = new ClientBuilder(['server' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $clientBuilder->setTransport($transport);
 
         $this->assertAttributeSame($transport, 'transport', $clientBuilder);
@@ -96,7 +96,7 @@ class ClientBuilderTest extends TestCase
         /** @var HttpAsyncClient|\PHPUnit_Framework_MockObject_MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
 
-        $clientBuilder = new ClientBuilder(['server' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $clientBuilder->setHttpClient($httpClient);
 
         $this->assertAttributeSame($httpClient, 'httpClient', $clientBuilder);
@@ -191,7 +191,7 @@ class ClientBuilderTest extends TestCase
 
     public function testGetClient()
     {
-        $clientBuilder = new ClientBuilder(['server' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $client = $clientBuilder->getClient();
 
         $this->assertInstanceOf(Client::class, $client);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -225,7 +225,7 @@ class ClientTest extends TestCase
         $transport->expects($this->once())
             ->method('send');
 
-        $client = ClientBuilder::create(['server' => 'http://public:secret@example.com/1'])
+        $client = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/1'])
             ->setTransport($transport)
             ->getClient();
 
@@ -421,7 +421,7 @@ class ClientTest extends TestCase
         $shouldCaptureCalled = false;
 
         $client = ClientBuilder::create([
-            'server' => 'http://public:secret@example.com/1',
+            'dsn' => 'http://public:secret@example.com/1',
             'should_capture' => function () use (&$shouldCaptureCalled) {
                 $shouldCaptureCalled = true;
 
@@ -464,13 +464,13 @@ class ClientTest extends TestCase
         return [
             [
                 [
-                    'server' => 'http://public:secret@example.com/1',
+                    'dsn' => 'http://public:secret@example.com/1',
                     'sample_rate' => 0,
                 ],
             ],
             [
                 [
-                    'server' => 'http://public:secret@example.com/1',
+                    'dsn' => 'http://public:secret@example.com/1',
                     'sample_rate' => 1,
                 ],
             ],

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -71,12 +71,12 @@ class ConfigurationTest extends TestCase
      */
     public function testServerOption($dsn, $options)
     {
-        $configuration = new Configuration(['server' => $dsn]);
+        $configuration = new Configuration(['dsn' => $dsn]);
 
         $this->assertEquals($options['project_id'], $configuration->getProjectId());
         $this->assertEquals($options['public_key'], $configuration->getPublicKey());
         $this->assertEquals($options['secret_key'], $configuration->getSecretKey());
-        $this->assertEquals($options['server'], $configuration->getServer());
+        $this->assertEquals($options['server'], $configuration->getDsn());
     }
 
     public function serverOptionDataProvider()
@@ -152,11 +152,11 @@ class ConfigurationTest extends TestCase
      * @dataProvider invalidServerOptionDataProvider
      *
      * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
-     * @expectedExceptionMessageRegExp /^The option "server" with value "(.*)" is invalid.$/
+     * @expectedExceptionMessageRegExp /^The option "dsn" with value "(.*)" is invalid.$/
      */
     public function testServerOptionsWithInvalidServer($dsn)
     {
-        new Configuration(['server' => $dsn]);
+        new Configuration(['dsn' => $dsn]);
     }
 
     public function invalidServerOptionDataProvider()
@@ -175,12 +175,12 @@ class ConfigurationTest extends TestCase
      */
     public function testParseDSNWithDisabledValue($dsn)
     {
-        $configuration = new Configuration(['server' => $dsn]);
+        $configuration = new Configuration(['dsn' => $dsn]);
 
         $this->assertNull($configuration->getProjectId());
         $this->assertNull($configuration->getPublicKey());
         $this->assertNull($configuration->getSecretKey());
-        $this->assertNull($configuration->getServer());
+        $this->assertNull($configuration->getDsn());
     }
 
     public function disabledDsnProvider()

--- a/tests/HttpClient/Authentication/SentryAuthTest.php
+++ b/tests/HttpClient/Authentication/SentryAuthTest.php
@@ -24,7 +24,7 @@ class SentryAuthTest extends TestCase
 {
     public function testAuthenticate()
     {
-        $configuration = new Configuration(['server' => 'http://public:secret@example.com/']);
+        $configuration = new Configuration(['dsn' => 'http://public:secret@example.com/']);
         $authentication = new SentryAuth($configuration);
 
         /** @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject $request */
@@ -52,7 +52,7 @@ class SentryAuthTest extends TestCase
 
     public function testAuthenticateWithNoSecretKey()
     {
-        $configuration = new Configuration(['server' => 'http://public@example.com/']);
+        $configuration = new Configuration(['dsn' => 'http://public@example.com/']);
         $authentication = new SentryAuth($configuration);
 
         /** @var RequestInterface|\PHPUnit_Framework_MockObject_MockObject $request */

--- a/tests/phpt/fatal_error.phpt
+++ b/tests/phpt/fatal_error.phpt
@@ -18,7 +18,7 @@ while (!file_exists($vendor . '/vendor')) {
 require $vendor . '/vendor/autoload.php';
 
 $client = ClientBuilder::create([
-    'server' => 'http://public:secret@local.host/1',
+    'dsn' => 'http://public:secret@local.host/1',
     'send_attempts' => 1,
 ])->getClient();
 

--- a/tests/phpt/out_of_memory.phpt
+++ b/tests/phpt/out_of_memory.phpt
@@ -20,7 +20,7 @@ while (!file_exists($vendor . '/vendor')) {
 require $vendor . '/vendor/autoload.php';
 
 $client = ClientBuilder::create([
-    'server' => 'http://public:secret@local.host/1',
+    'dsn' => 'http://public:secret@local.host/1',
     'send_attempts' => 1,
 ])->getClient();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

As suggested by @stayallive I renamed the `server` configuration option to `dsn`. I chose to not alias it as I think there is no need to introduce a deprecated thing in a major new version.