### PR TITLE
Add option to ignore SERVER_PORT getting added to url.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -261,6 +261,17 @@ The following settings are available for the client:
 
         'excluded_exceptions' => array('LogicException'),
 
+.. describe:: ignore_server_port
+
+    By default the server port will be added to the logged URL when it is a non
+    standard port (80, 443).
+    Setting this to ``true`` will ignore the server port altogether and will
+    result in the server port never getting appended to the logged URL.
+
+    .. code-block:: php
+
+        'ignore_server_port' => true,
+
 .. _sentry-php-request-context:
 
 Providing Request Context

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -91,6 +91,7 @@ class Raven_Client
     public $exclude;
     public $excluded_exceptions;
     public $http_proxy;
+    public $ignore_server_port;
     protected $send_callback;
     public $curl_method;
     public $curl_path;
@@ -173,6 +174,7 @@ class Raven_Client
         $this->excluded_exceptions = Raven_Util::get($options, 'excluded_exceptions', array());
         $this->severity_map = null;
         $this->http_proxy = Raven_Util::get($options, 'http_proxy');
+        $this->ignore_server_port = Raven_Util::get($options, 'ignore_server_port', false);
         $this->extra_data = Raven_Util::get($options, 'extra', array());
         $this->send_callback = Raven_Util::get($options, 'send_callback', null);
         $this->curl_method = Raven_Util::get($options, 'curl_method', 'sync');
@@ -1311,9 +1313,11 @@ class Raven_Client
             : (!empty($_SERVER['LOCAL_ADDR'])  ? $_SERVER['LOCAL_ADDR']
             : (!empty($_SERVER['SERVER_ADDR']) ? $_SERVER['SERVER_ADDR'] : '')));
 
-        $hasNonDefaultPort = !empty($_SERVER['SERVER_PORT']) && !in_array((int)$_SERVER['SERVER_PORT'], array(80, 443));
-        if ($hasNonDefaultPort && !preg_match('#:[0-9]*$#', $host)) {
-            $host .= ':' . $_SERVER['SERVER_PORT'];
+        if (!$this->ignore_server_port) {
+            $hasNonDefaultPort = !empty($_SERVER['SERVER_PORT']) && !in_array((int)$_SERVER['SERVER_PORT'], array(80, 443));
+            if ($hasNonDefaultPort && !preg_match('#:[0-9]*$#', $host)) {
+                $host .= ':' . $_SERVER['SERVER_PORT'];
+            }
         }
 
         $httpS = $this->isHttps() ? 's' : '';

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1803,6 +1803,16 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 array(),
                 'http://example.com:81/',
                 'Port is not appended'
+            ),
+            array(
+                array(
+                    'REQUEST_URI' => '/',
+                    'HTTP_HOST' => 'example.com',
+                    'SERVER_PORT' => 81
+                ),
+                array('ignore_server_port' => true),
+                'http://example.com/',
+                'Port is appended'
             )
         );
     }


### PR DESCRIPTION
Nowadays, running a site behind a reverse proxy is extremely common. When you are behind a reverse proxy, you **cannot** be sure that whatever is serving PHP is on a standard port (80 or 443, see #572). It can easily be 8080 or whatever is available/suitable for the hoster.

Blindly appending the port to the url in that case is annoying for developers when going through the logs.

An option to ignore the server port would help out immensly, so this pull request proposes to add `ignore_server_port` as an option defaulting to _false_ to keep the current behavior.