### PR TITLE
Do not truncate strings if message limit is set to zero

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -104,11 +104,11 @@ class Raven_Serializer
                 $value = mb_convert_encoding($value, 'UTF-8');
             }
 
-            if (mb_strlen($value) > $this->message_limit) {
+            if ($this->message_limit !== 0 && mb_strlen($value) > $this->message_limit) {
                 $value = mb_substr($value, 0, $this->message_limit - 10, 'UTF-8') . ' {clipped}';
             }
         } else {
-            if (strlen($value) > $this->message_limit) {
+            if ($this->message_limit !== 0 && strlen($value) > $this->message_limit) {
                 $value = substr($value, 0, $this->message_limit - 10) . ' {clipped}';
             }
         }

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -166,7 +166,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
                 }
                 $result = $serializer->serialize($input);
                 $this->assertInternalType('string', $result);
-                $this->assertLessThanOrEqual($length, strlen($result));
+                $this->assertEquals($length, strlen($result));
             }
         }
     }

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -152,6 +152,26 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Raven_Serializer::serializeString
+     */
+    public function testLongStringWithOverwrittenMessageLengthZero()
+    {
+        $serializer = new Raven_Serializer();
+        $serializer->setMessageLimit(0);
+        for ($i = 0; $i < 100; $i++) {
+            foreach (array(100, 490, 499, 500, 501, 1000, 10000) as $length) {
+                $input = '';
+                for ($j = 0; $j < $length; $j++) {
+                    $input .= chr(mt_rand(ord('a'), ord('z')));
+                }
+                $result = $serializer->serialize($input);
+                $this->assertInternalType('string', $result);
+                $this->assertLessThanOrEqual($length, strlen($result));
+            }
+        }
+    }
+
+    /**
      * @covers Raven_Serializer::serializeValue
      */
     public function testSerializeValueResource()


### PR DESCRIPTION
This pull request fixes a simple issue where we actually would like to track larger strings, if needed. Right now it does not seem to be possible.