### PR TITLE
Make it possible to changeable default_max_depth in Raven_Serializer

### DIFF
--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -53,6 +53,13 @@ class Raven_Serializer
     protected $message_limit = Raven_Client::MESSAGE_LIMIT;
 
     /**
+     * The default max depth.
+     *
+     * @var int
+     */
+    protected $default_max_depth = 3;
+
+    /**
      * @param null|string $mb_detect_order
      * @param null|int    $message_limit
      */
@@ -71,14 +78,17 @@ class Raven_Serializer
      * Serialize an object (recursively) into something safe for data
      * sanitization and encoding.
      *
-     * @param mixed $value
-     * @param int   $max_depth
-     * @param int   $_depth
+     * @param mixed    $value
+     * @param int|null $max_depth
+     * @param int      $_depth
      * @return string|bool|double|int|null|object|array
      */
-    public function serialize($value, $max_depth = 3, $_depth = 0)
+    public function serialize($value, $max_depth = null, $_depth = 0)
     {
         $className = is_object($value) ? get_class($value) : null;
+        if (is_null($max_depth)) {
+            $max_depth = $this->default_max_depth;
+        }
         $toArray = is_array($value) || $className === 'stdClass';
         if ($toArray && $_depth < $max_depth) {
             $new = array();
@@ -174,5 +184,23 @@ class Raven_Serializer
     public function setMessageLimit($message_limit)
     {
         $this->message_limit = (int)$message_limit;
+    }
+
+    /**
+     * @return int
+     * @codeCoverageIgnore
+     */
+    public function getDefaultMaxDepth()
+    {
+        return $this->default_max_depth;
+    }
+
+    /**
+     * @param int $max_depth
+     * @codeCoverageIgnore
+     */
+    public function setDefaultMaxDepth($max_depth)
+    {
+        $this->default_max_depth = (int)$max_depth;
     }
 }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -87,7 +87,7 @@ class Raven_Serializer
     {
         $className = is_object($value) ? get_class($value) : null;
         if (is_null($max_depth)) {
-            $max_depth = $this->default_max_depth;
+            $max_depth = $this->getDefaultMaxDepth();
         }
         $toArray = is_array($value) || $className === 'stdClass';
         if ($toArray && $_depth < $max_depth) {

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -188,7 +188,6 @@ class Raven_Serializer
 
     /**
      * @return int
-     * @codeCoverageIgnore
      */
     public function getDefaultMaxDepth()
     {
@@ -197,7 +196,6 @@ class Raven_Serializer
 
     /**
      * @param int $max_depth
-     * @codeCoverageIgnore
      */
     public function setDefaultMaxDepth($max_depth)
     {

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -201,4 +201,49 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals(JSON_ERROR_NONE, json_last_error());
     }
+
+    /**
+     * @covers Raven_Serializer::getDefaultMaxDepth
+     * @covers Raven_Serializer::setDefaultMaxDepth
+     */
+    public function testChangeDefaultMaxDepth()
+    {
+        $serializer = new Raven_Serializer();
+        $input = array(
+            1 => array(
+                2 => array(
+                    3 => array(
+                        4 => array(
+                            5 => 6
+                        )
+                    )
+                )
+            )
+        );
+        $expectedDefaultResult = array(
+            1 => array(
+                2 => array(
+                    3 => 'Array of length 1'
+                )
+            )
+        );
+        $this->assertSame(
+            $expectedDefaultResult,
+            $serializer->serialize($input)
+        );
+        $expectedChangedResult = array(
+            1 => array(
+                2 => array(
+                    3 => array(
+                        4 => 'Array of length 1'
+                    )
+                )
+            )
+        );
+        $serializer->setDefaultMaxDepth(4);
+        $this->assertSame(
+            $expectedChangedResult,
+            $serializer->serialize($input)
+        );
+    }
 }


### PR DESCRIPTION
I'd like to refer to the complicated nested JSON request in Sentry.