### PR TITLE
Use configured message limit when creating serializers

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -210,8 +210,8 @@ class Raven_Client
             'name' => 'sentry-php',
             'version' => self::VERSION,
         ));
-        $this->serializer = new Raven_Serializer($this->mb_detect_order);
-        $this->reprSerializer = new Raven_ReprSerializer($this->mb_detect_order);
+        $this->serializer = new Raven_Serializer($this->mb_detect_order, $this->message_limit);
+        $this->reprSerializer = new Raven_ReprSerializer($this->mb_detect_order, $this->message_limit);
 
         if ($this->curl_method == 'async') {
             $this->_curl_handler = new Raven_CurlHandler($this->get_curl_options());


### PR DESCRIPTION
When `message_limit` is set in Raven client options, serializers should use this value instead of default message limit from `RAVEN_Client::MESSAGE_LIMIT`.