### PR TITLE
Proper case in Raven_Util class name usage

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -444,7 +444,7 @@ class Raven_Client
     public function setProcessorsFromOptions($options)
     {
         $processors = array();
-        foreach (Raven_util::get($options, 'processors', static::getDefaultProcessors()) as $processor) {
+        foreach (Raven_Util::get($options, 'processors', static::getDefaultProcessors()) as $processor) {
             /**
              * @var Raven_Processor        $new_processor
              * @var Raven_Processor|string $processor


### PR DESCRIPTION
This was causing Psalm (static analysis tool) to complain that `Raven_Util` class does not exist.