### PR TITLE
Remove secret_key from required keys

### DIFF
--- a/bin/sentry
+++ b/bin/sentry
@@ -38,7 +38,7 @@ function cmd_test($dsn)
     ));
 
     $config = get_object_vars($client);
-    $required_keys = array('server', 'project', 'public_key', 'secret_key');
+    $required_keys = array('server', 'project', 'public_key');
 
     echo "Client configuration:\n";
     foreach ($required_keys as $key) {


### PR DESCRIPTION
#644 

This PR fix the issue :

```
$ bin/sentry test https://ffd1aa57b86643148bb64220496ba6a0@sentry.io/1263429 -v
Client configuration:
-> server: https://sentry.io/api/1263429/store/
-> project: 1263429
-> public_key: ffd1aa57b86643148bb64220496ba6a0

Sending a test event:
-> event ID: 34227d39711b438bbf895e092b1eec82

Done!%
```