### PR TITLE
[2.0] Use the Context classes inside the event object

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -353,13 +353,13 @@ class Client implements ClientInterface
         $event = new Event($this->config);
 
         if (isset($payload['transaction'])) {
-            $event = $event->withTransaction($payload['transaction']);
+            $event->setTransaction($payload['transaction']);
         } else {
-            $event = $event->withTransaction($this->transactionStack->peek());
+            $event->setTransaction($this->transactionStack->peek());
         }
 
         if (isset($payload['logger'])) {
-            $event = $event->withLogger($payload['logger']);
+            $event->setLogger($payload['logger']);
         }
 
         $event = $this->middlewareStack->executeStack(

--- a/lib/Raven/Event.php
+++ b/lib/Raven/Event.php
@@ -191,16 +191,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withLevel($level)
+    public function setLevel($level)
     {
-        if ($level === $this->level) {
-            return $this;
-        }
+        $this->level = $level;
 
-        $new = clone $this;
-        $new->level = $level;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -220,16 +215,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withLogger($logger)
+    public function setLogger($logger)
     {
-        if ($logger === $this->logger) {
-            return $this;
-        }
+        $this->logger = $logger;
 
-        $new = clone $this;
-        $new->logger = $logger;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -248,19 +238,10 @@ final class Event implements \JsonSerializable
      * exception.
      *
      * @param string $transaction The transaction name
-     *
-     * @return static
      */
-    public function withTransaction($transaction)
+    public function setTransaction($transaction)
     {
-        if ($transaction === $this->transaction) {
-            return $this;
-        }
-
-        $new = clone $this;
-        $new->transaction = $transaction;
-
-        return $new;
+        $this->transaction = $transaction;
     }
 
     /**
@@ -280,16 +261,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withServerName($serverName)
+    public function setServerName($serverName)
     {
-        if ($serverName === $this->serverName) {
-            return $this;
-        }
+        $this->serverName = $serverName;
 
-        $new = clone $this;
-        $new->serverName = $serverName;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -309,16 +285,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withRelease($release)
+    public function setRelease($release)
     {
-        if ($release === $this->release) {
-            return $this;
-        }
+        $this->release = $release;
 
-        $new = clone $this;
-        $new->release = $release;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -349,17 +320,12 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withMessage($message, array $params = [])
+    public function setMessage($message, array $params = [])
     {
-        if ($message === $this->message && $params === $this->messageParams) {
-            return $this;
-        }
+        $this->message = $message;
+        $this->messageParams = $params;
 
-        $new = clone $this;
-        $new->message = $message;
-        $new->messageParams = $params;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -379,16 +345,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withModules(array $modules)
+    public function setModules(array $modules)
     {
-        if ($modules === $this->modules) {
-            return $this;
-        }
+        $this->modules = $modules;
 
-        $new = clone $this;
-        $new->modules = $modules;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -408,16 +369,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withRequest(array $request)
+    public function setRequest(array $request)
     {
-        if ($request === $this->request) {
-            return $this;
-        }
+        $this->request = $request;
 
-        $new = clone $this;
-        $new->request = $request;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -438,16 +394,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withExtraContext(array $extraContext, $replace = true)
+    public function setExtraContext(array $extraContext, $replace = true)
     {
-        if ($extraContext === $this->extraContext) {
-            return $this;
-        }
+        $this->extraContext = $replace ? $extraContext : array_merge($this->extraContext, $extraContext);
 
-        $new = clone $this;
-        $new->extraContext = $replace ? $extraContext : array_merge($this->extraContext, $extraContext);
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -468,16 +419,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withTagsContext(array $tagsContext, $replace = true)
+    public function setTagsContext(array $tagsContext, $replace = true)
     {
-        if ($tagsContext === $this->tagsContext) {
-            return $this;
-        }
+        $this->tagsContext = $replace ? $tagsContext : array_merge($this->tagsContext, $tagsContext);
 
-        $new = clone $this;
-        $new->tagsContext = $replace ? $tagsContext : array_merge($this->tagsContext, $tagsContext);
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -498,16 +444,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withUserContext(array $userContext, $replace = true)
+    public function setUserContext(array $userContext, $replace = true)
     {
-        if ($userContext === $this->userContext) {
-            return $this;
-        }
+        $this->userContext = $replace ? $userContext : array_merge($this->userContext, $userContext);
 
-        $new = clone $this;
-        $new->userContext = $replace ? $userContext : array_merge($this->userContext, $userContext);
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -528,16 +469,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withServerOsContext(array $serverOsContext, $replace = true)
+    public function setServerOsContext(array $serverOsContext, $replace = true)
     {
-        if ($serverOsContext === $this->serverOsContext) {
-            return $this;
-        }
+        $this->serverOsContext = $replace ? $serverOsContext : array_merge($this->serverOsContext, $serverOsContext);
 
-        $new = clone $this;
-        $new->serverOsContext = $replace ? $serverOsContext : array_merge($this->serverOsContext, $serverOsContext);
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -558,16 +494,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withRuntimeContext(array $runtimeContext, $replace = true)
+    public function setRuntimeContext(array $runtimeContext, $replace = true)
     {
-        if ($runtimeContext === $this->runtimeContext) {
-            return $this;
-        }
+        $this->runtimeContext = $replace ? $runtimeContext : array_merge($this->runtimeContext, $runtimeContext);
 
-        $new = clone $this;
-        $new->runtimeContext = $replace ? $runtimeContext : array_merge($this->runtimeContext, $runtimeContext);
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -589,16 +520,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withFingerprint(array $fingerprint)
+    public function setFingerprint(array $fingerprint)
     {
-        if ($fingerprint === $this->fingerprint) {
-            return $this;
-        }
+        $this->fingerprint = $fingerprint;
 
-        $new = clone $this;
-        $new->fingerprint = $fingerprint;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -618,16 +544,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withEnvironment($environment)
+    public function setEnvironment($environment)
     {
-        if ($environment === $this->environment) {
-            return $this;
-        }
+        $this->environment = $environment;
 
-        $new = clone $this;
-        $new->environment = $environment;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -647,12 +568,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withBreadcrumb(Breadcrumb $breadcrumb)
+    public function setBreadcrumb(Breadcrumb $breadcrumb)
     {
-        $new = clone $this;
-        $new->breadcrumbs[] = $breadcrumb;
+        $this->breadcrumbs[] = $breadcrumb;
 
-        return $new;
+        return $this;
     }
 
     /**
@@ -672,16 +592,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withException(array $exception)
+    public function setException(array $exception)
     {
-        if ($exception === $this->exception) {
-            return $this;
-        }
+        $this->exception = $exception;
 
-        $new = clone $this;
-        $new->exception = $exception;
-
-        return $new;
+        return $this;
     }
 
     /**
@@ -701,16 +616,11 @@ final class Event implements \JsonSerializable
      *
      * @return static
      */
-    public function withStacktrace(Stacktrace $stacktrace)
+    public function setStacktrace(Stacktrace $stacktrace)
     {
-        if ($stacktrace === $this->stacktrace) {
-            return $this;
-        }
+        $this->stacktrace = $stacktrace;
 
-        $new = clone $this;
-        $new->stacktrace = $stacktrace;
-
-        return $new;
+        return $this;
     }
 
     /**

--- a/lib/Raven/Event.php
+++ b/lib/Raven/Event.php
@@ -14,6 +14,10 @@ namespace Raven;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
 use Raven\Breadcrumbs\Breadcrumb;
+use Raven\Context\Context;
+use Raven\Context\RuntimeContext;
+use Raven\Context\ServerOsContext;
+use Raven\Context\TagsContext;
 
 /**
  * This is the base class for classes containing event data.
@@ -83,29 +87,29 @@ final class Event implements \JsonSerializable
     private $request = [];
 
     /**
-     * @var array The server OS context data
+     * @var ServerOsContext The server OS context data
      */
-    private $serverOsContext = [];
+    private $serverOsContext;
 
     /**
-     * @var array The runtime context data
+     * @var RuntimeContext The runtime context data
      */
-    private $runtimeContext = [];
+    private $runtimeContext;
 
     /**
-     * @var array The user context data
+     * @var Context The user context data
      */
-    private $userContext = [];
+    private $userContext;
 
     /**
-     * @var array An arbitrary mapping of additional metadata
+     * @var Context An arbitrary mapping of additional metadata
      */
-    private $extraContext = [];
+    private $extraContext;
 
     /**
-     * @var string[] A List of tags associated to this event
+     * @var TagsContext A List of tags associated to this event
      */
-    private $tagsContext = [];
+    private $tagsContext;
 
     /**
      * @var string[] An array of strings used to dictate the deduplication of this event
@@ -140,18 +144,11 @@ final class Event implements \JsonSerializable
         $this->serverName = $config->getServerName();
         $this->release = $config->getRelease();
         $this->environment = $config->getCurrentEnvironment();
-    }
-
-    /**
-     * Creates a new instance of this class.
-     *
-     * @param Configuration $config The client configuration
-     *
-     * @return static
-     */
-    public static function create(Configuration $config)
-    {
-        return new static($config);
+        $this->serverOsContext = new ServerOsContext();
+        $this->runtimeContext = new RuntimeContext();
+        $this->userContext = new Context();
+        $this->extraContext = new Context();
+        $this->tagsContext = new TagsContext();
     }
 
     /**
@@ -188,14 +185,10 @@ final class Event implements \JsonSerializable
      * Sets the severity of this event.
      *
      * @param string $level The severity
-     *
-     * @return static
      */
     public function setLevel($level)
     {
         $this->level = $level;
-
-        return $this;
     }
 
     /**
@@ -212,14 +205,10 @@ final class Event implements \JsonSerializable
      * Sets the name of the logger which created the event.
      *
      * @param string $logger The logger name
-     *
-     * @return static
      */
     public function setLogger($logger)
     {
         $this->logger = $logger;
-
-        return $this;
     }
 
     /**
@@ -258,14 +247,10 @@ final class Event implements \JsonSerializable
      * Sets the name of the server.
      *
      * @param string $serverName The server name
-     *
-     * @return static
      */
     public function setServerName($serverName)
     {
         $this->serverName = $serverName;
-
-        return $this;
     }
 
     /**
@@ -282,14 +267,10 @@ final class Event implements \JsonSerializable
      * Sets the release of the program.
      *
      * @param string $release The release
-     *
-     * @return static
      */
     public function setRelease($release)
     {
         $this->release = $release;
-
-        return $this;
     }
 
     /**
@@ -317,15 +298,11 @@ final class Event implements \JsonSerializable
      *
      * @param string $message The message
      * @param array  $params  The parameters to use to format the message
-     *
-     * @return static
      */
     public function setMessage($message, array $params = [])
     {
         $this->message = $message;
         $this->messageParams = $params;
-
-        return $this;
     }
 
     /**
@@ -342,14 +319,10 @@ final class Event implements \JsonSerializable
      * Sets a list of relevant modules and their versions.
      *
      * @param array $modules
-     *
-     * @return static
      */
     public function setModules(array $modules)
     {
         $this->modules = $modules;
-
-        return $this;
     }
 
     /**
@@ -366,20 +339,16 @@ final class Event implements \JsonSerializable
      * Sets the request data.
      *
      * @param array $request The request data
-     *
-     * @return static
      */
     public function setRequest(array $request)
     {
         $this->request = $request;
-
-        return $this;
     }
 
     /**
      * Gets an arbitrary mapping of additional metadata.
      *
-     * @return array
+     * @return Context
      */
     public function getExtraContext()
     {
@@ -387,24 +356,9 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Sets an arbitrary mapping of additional metadata.
-     *
-     * @param array $extraContext Additional metadata
-     * @param bool  $replace      Whether to merge the old data with the new one or replace entirely it
-     *
-     * @return static
-     */
-    public function setExtraContext(array $extraContext, $replace = true)
-    {
-        $this->extraContext = $replace ? $extraContext : array_merge($this->extraContext, $extraContext);
-
-        return $this;
-    }
-
-    /**
      * Gets a list of tags.
      *
-     * @return string[]
+     * @return TagsContext
      */
     public function getTagsContext()
     {
@@ -412,24 +366,9 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Sets a list of tags.
-     *
-     * @param string[] $tagsContext The tags
-     * @param bool     $replace     Whether to merge the old data with the new one or replace entirely it
-     *
-     * @return static
-     */
-    public function setTagsContext(array $tagsContext, $replace = true)
-    {
-        $this->tagsContext = $replace ? $tagsContext : array_merge($this->tagsContext, $tagsContext);
-
-        return $this;
-    }
-
-    /**
      * Gets the user context.
      *
-     * @return array
+     * @return Context
      */
     public function getUserContext()
     {
@@ -437,24 +376,9 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Sets the user context.
-     *
-     * @param array $userContext The context data
-     * @param bool  $replace     Whether to merge the old data with the new one or replace entirely it
-     *
-     * @return static
-     */
-    public function setUserContext(array $userContext, $replace = true)
-    {
-        $this->userContext = $replace ? $userContext : array_merge($this->userContext, $userContext);
-
-        return $this;
-    }
-
-    /**
      * Gets the server OS context.
      *
-     * @return array
+     * @return ServerOsContext
      */
     public function getServerOsContext()
     {
@@ -462,43 +386,13 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Gets the server OS context.
-     *
-     * @param array $serverOsContext The context data
-     * @param bool  $replace         Whether to merge the old data with the new one or replace entirely it
-     *
-     * @return static
-     */
-    public function setServerOsContext(array $serverOsContext, $replace = true)
-    {
-        $this->serverOsContext = $replace ? $serverOsContext : array_merge($this->serverOsContext, $serverOsContext);
-
-        return $this;
-    }
-
-    /**
      * Gets the runtime context data.
      *
-     * @return array
+     * @return RuntimeContext
      */
     public function getRuntimeContext()
     {
         return $this->runtimeContext;
-    }
-
-    /**
-     * Sets the runtime context data.
-     *
-     * @param array $runtimeContext The context data
-     * @param bool  $replace        Whether to merge the old data with the new one or replace entirely it
-     *
-     * @return static
-     */
-    public function setRuntimeContext(array $runtimeContext, $replace = true)
-    {
-        $this->runtimeContext = $replace ? $runtimeContext : array_merge($this->runtimeContext, $runtimeContext);
-
-        return $this;
     }
 
     /**
@@ -517,14 +411,10 @@ final class Event implements \JsonSerializable
      * event.
      *
      * @param string[] $fingerprint The strings
-     *
-     * @return static
      */
     public function setFingerprint(array $fingerprint)
     {
         $this->fingerprint = $fingerprint;
-
-        return $this;
     }
 
     /**
@@ -541,14 +431,10 @@ final class Event implements \JsonSerializable
      * Sets the environment in which this event was generated.
      *
      * @param string $environment The name of the environment
-     *
-     * @return static
      */
     public function setEnvironment($environment)
     {
         $this->environment = $environment;
-
-        return $this;
     }
 
     /**
@@ -565,14 +451,10 @@ final class Event implements \JsonSerializable
      * Adds a new breadcrumb to the event.
      *
      * @param Breadcrumb $breadcrumb The breadcrumb
-     *
-     * @return static
      */
     public function setBreadcrumb(Breadcrumb $breadcrumb)
     {
         $this->breadcrumbs[] = $breadcrumb;
-
-        return $this;
     }
 
     /**
@@ -589,14 +471,10 @@ final class Event implements \JsonSerializable
      * Sets the exception.
      *
      * @param array $exception The exception
-     *
-     * @return static
      */
     public function setException(array $exception)
     {
         $this->exception = $exception;
-
-        return $this;
     }
 
     /**
@@ -613,14 +491,10 @@ final class Event implements \JsonSerializable
      * Sets the stacktrace that generated this event.
      *
      * @param Stacktrace $stacktrace The stacktrace instance
-     *
-     * @return static
      */
     public function setStacktrace(Stacktrace $stacktrace)
     {
         $this->stacktrace = $stacktrace;
-
-        return $this;
     }
 
     /**
@@ -669,24 +543,24 @@ final class Event implements \JsonSerializable
             $data['modules'] = $this->modules;
         }
 
-        if (!empty($this->extraContext)) {
-            $data['extra'] = $this->extraContext;
+        if (!$this->extraContext->isEmpty()) {
+            $data['extra'] = $this->extraContext->toArray();
         }
 
-        if (!empty($this->tagsContext)) {
-            $data['tags'] = $this->tagsContext;
+        if (!$this->tagsContext->isEmpty()) {
+            $data['tags'] = $this->tagsContext->toArray();
         }
 
-        if (!empty($this->userContext)) {
-            $data['user'] = $this->userContext;
+        if (!$this->userContext->isEmpty()) {
+            $data['user'] = $this->userContext->toArray();
         }
 
-        if (!empty($this->serverOsContext)) {
-            $data['contexts']['os'] = $this->serverOsContext;
+        if (!$this->serverOsContext->isEmpty()) {
+            $data['contexts']['os'] = $this->serverOsContext->toArray();
         }
 
-        if (!empty($this->runtimeContext)) {
-            $data['contexts']['runtime'] = $this->runtimeContext;
+        if (!$this->runtimeContext->isEmpty()) {
+            $data['contexts']['runtime'] = $this->runtimeContext->toArray();
         }
 
         if (!empty($this->breadcrumbs)) {

--- a/lib/Raven/Middleware/BreadcrumbInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/BreadcrumbInterfaceMiddleware.php
@@ -52,7 +52,7 @@ final class BreadcrumbInterfaceMiddleware
     public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         foreach ($this->recorder as $breadcrumb) {
-            $event = $event->withBreadcrumb($breadcrumb);
+            $event->setBreadcrumb($breadcrumb);
         }
 
         return $next($event, $request, $exception, $payload);

--- a/lib/Raven/Middleware/ContextInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ContextInterfaceMiddleware.php
@@ -58,24 +58,24 @@ final class ContextInterfaceMiddleware
      */
     public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
-        $context = isset($payload[$this->contextName . '_context']) ? $payload[$this->contextName . '_context'] : [];
-        $context = array_merge($this->context->toArray(), $context);
+        $contextData = isset($payload[$this->contextName . '_context']) ? $payload[$this->contextName . '_context'] : [];
+        $contextData = array_merge($this->context->toArray(), $contextData);
 
         switch ($this->contextName) {
             case Context::CONTEXT_USER:
-                $event->setUserContext($context, false);
+                $event->getUserContext()->setData($contextData);
                 break;
             case Context::CONTEXT_RUNTIME:
-                $event->setRuntimeContext($context, false);
+                $event->getRuntimeContext()->setData($contextData);
                 break;
             case Context::CONTEXT_TAGS:
-                $event->setTagsContext($context, false);
+                $event->getTagsContext()->setData($contextData);
                 break;
             case Context::CONTEXT_EXTRA:
-                $event->setExtraContext($context, false);
+                $event->getExtraContext()->setData($contextData);
                 break;
             case Context::CONTEXT_SERVER_OS:
-                $event->setServerOsContext($context, false);
+                $event->getServerOsContext()->setData($contextData);
                 break;
             default:
                 throw new \RuntimeException(sprintf('The "%s" context is not supported.', $this->contextName));

--- a/lib/Raven/Middleware/ContextInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ContextInterfaceMiddleware.php
@@ -63,19 +63,19 @@ final class ContextInterfaceMiddleware
 
         switch ($this->contextName) {
             case Context::CONTEXT_USER:
-                $event = $event->withUserContext($context, false);
+                $event->setUserContext($context, false);
                 break;
             case Context::CONTEXT_RUNTIME:
-                $event = $event->withRuntimeContext($context, false);
+                $event->setRuntimeContext($context, false);
                 break;
             case Context::CONTEXT_TAGS:
-                $event = $event->withTagsContext($context, false);
+                $event->setTagsContext($context, false);
                 break;
             case Context::CONTEXT_EXTRA:
-                $event = $event->withExtraContext($context, false);
+                $event->setExtraContext($context, false);
                 break;
             case Context::CONTEXT_SERVER_OS:
-                $event = $event->withServerOsContext($context, false);
+                $event->setServerOsContext($context, false);
                 break;
             default:
                 throw new \RuntimeException(sprintf('The "%s" context is not supported.', $this->contextName));

--- a/lib/Raven/Middleware/ExceptionInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/ExceptionInterfaceMiddleware.php
@@ -52,9 +52,9 @@ final class ExceptionInterfaceMiddleware
     public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         if (isset($payload['level'])) {
-            $event = $event->withLevel($payload['level']);
+            $event->setLevel($payload['level']);
         } elseif ($exception instanceof \ErrorException) {
-            $event = $event->withLevel($this->client->translateSeverity($exception->getSeverity()));
+            $event->setLevel($this->client->translateSeverity($exception->getSeverity()));
         }
 
         if (null !== $exception) {
@@ -82,7 +82,7 @@ final class ExceptionInterfaceMiddleware
                 'values' => array_reverse($exceptions),
             ];
 
-            $event = $event->withException($exceptions);
+            $event->setException($exceptions);
         }
 
         return $next($event, $request, $exception, $payload);

--- a/lib/Raven/Middleware/MessageInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/MessageInterfaceMiddleware.php
@@ -40,7 +40,7 @@ final class MessageInterfaceMiddleware
         $messageParams = isset($payload['message_params']) ? $payload['message_params'] : [];
 
         if (null !== $message) {
-            $event = $event->withMessage(substr($message, 0, Client::MESSAGE_MAX_LENGTH_LIMIT), $messageParams);
+            $event->setMessage(substr($message, 0, Client::MESSAGE_MAX_LENGTH_LIMIT), $messageParams);
         }
 
         return $next($event, $request, $exception, $payload);

--- a/lib/Raven/Middleware/ModulesMiddleware.php
+++ b/lib/Raven/Middleware/ModulesMiddleware.php
@@ -62,7 +62,7 @@ final class ModulesMiddleware
                     $modules[$package->getName()] = $package->getVersion();
                 }
 
-                $event = $event->withModules($modules);
+                $event->setModules($modules);
             }
         }
 

--- a/lib/Raven/Middleware/RequestInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/RequestInterfaceMiddleware.php
@@ -54,7 +54,7 @@ final class RequestInterfaceMiddleware
             $requestData['env']['REMOTE_ADDR'] = $request->getHeaderLine('REMOTE_ADDR');
         }
 
-        $event = $event->withRequest($requestData);
+        $event->setRequest($requestData);
 
         return $next($event, $request, $exception, $payload);
     }

--- a/lib/Raven/Middleware/SanitizerMiddleware.php
+++ b/lib/Raven/Middleware/SanitizerMiddleware.php
@@ -52,27 +52,27 @@ final class SanitizerMiddleware
     public function __invoke(Event $event, callable $next, ServerRequestInterface $request = null, $exception = null, array $payload = [])
     {
         if (!empty($request = $event->getRequest())) {
-            $event = $event->withRequest($this->serializer->serialize($request, 5));
+            $event->setRequest($this->serializer->serialize($request, 5));
         }
 
         if (!empty($userContext = $event->getUserContext())) {
-            $event = $event->withUserContext($this->serializer->serialize($userContext));
+            $event->setUserContext($this->serializer->serialize($userContext));
         }
 
         if (!empty($runtimeContext = $event->getRuntimeContext())) {
-            $event = $event->withRuntimeContext($this->serializer->serialize($runtimeContext));
+            $event->setRuntimeContext($this->serializer->serialize($runtimeContext));
         }
 
         if (!empty($serverOsContext = $event->getServerOsContext())) {
-            $event = $event->withServerOsContext($this->serializer->serialize($serverOsContext));
+            $event->setServerOsContext($this->serializer->serialize($serverOsContext));
         }
 
         if (!empty($extraContext = $event->getExtraContext())) {
-            $event = $event->withExtraContext($this->serializer->serialize($extraContext));
+            $event->setExtraContext($this->serializer->serialize($extraContext));
         }
 
         if (!empty($tagsContext = $event->getTagsContext())) {
-            $event = $event->withTagsContext($this->serializer->serialize($tagsContext));
+            $event->setTagsContext($this->serializer->serialize($tagsContext));
         }
 
         return $next($event, $request, $exception, $payload);

--- a/lib/Raven/Middleware/SanitizerMiddleware.php
+++ b/lib/Raven/Middleware/SanitizerMiddleware.php
@@ -55,25 +55,11 @@ final class SanitizerMiddleware
             $event->setRequest($this->serializer->serialize($request, 5));
         }
 
-        if (!empty($userContext = $event->getUserContext())) {
-            $event->setUserContext($this->serializer->serialize($userContext));
-        }
-
-        if (!empty($runtimeContext = $event->getRuntimeContext())) {
-            $event->setRuntimeContext($this->serializer->serialize($runtimeContext));
-        }
-
-        if (!empty($serverOsContext = $event->getServerOsContext())) {
-            $event->setServerOsContext($this->serializer->serialize($serverOsContext));
-        }
-
-        if (!empty($extraContext = $event->getExtraContext())) {
-            $event->setExtraContext($this->serializer->serialize($extraContext));
-        }
-
-        if (!empty($tagsContext = $event->getTagsContext())) {
-            $event->setTagsContext($this->serializer->serialize($tagsContext));
-        }
+        $event->getUserContext()->replaceData($this->serializer->serialize($event->getUserContext()->toArray()));
+        $event->getRuntimeContext()->replaceData($this->serializer->serialize($event->getRuntimeContext()->toArray()));
+        $event->getServerOsContext()->replaceData($this->serializer->serialize($event->getServerOsContext()->toArray()));
+        $event->getExtraContext()->replaceData($this->serializer->serialize($event->getExtraContext()->toArray()));
+        $event->getTagsContext()->replaceData($this->serializer->serialize($event->getTagsContext()->toArray()));
 
         return $next($event, $request, $exception, $payload);
     }

--- a/lib/Raven/Middleware/UserInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/UserInterfaceMiddleware.php
@@ -40,7 +40,7 @@ final class UserInterfaceMiddleware
             $userContext['ip_address'] = $request->getHeaderLine('REMOTE_ADDR');
         }
 
-        $event = $event->withUserContext($userContext);
+        $event->setUserContext($userContext);
 
         return $next($event, $request, $exception, $payload);
     }

--- a/lib/Raven/Middleware/UserInterfaceMiddleware.php
+++ b/lib/Raven/Middleware/UserInterfaceMiddleware.php
@@ -40,8 +40,6 @@ final class UserInterfaceMiddleware
             $userContext['ip_address'] = $request->getHeaderLine('REMOTE_ADDR');
         }
 
-        $event->setUserContext($userContext);
-
         return $next($event, $request, $exception, $payload);
     }
 }

--- a/lib/Raven/Processor/RemoveHttpBodyProcessor.php
+++ b/lib/Raven/Processor/RemoveHttpBodyProcessor.php
@@ -33,6 +33,6 @@ final class RemoveHttpBodyProcessor implements ProcessorInterface
             $request['data'] = self::STRING_MASK;
         }
 
-        return $event->withRequest($request);
+        return $event->setRequest($request);
     }
 }

--- a/lib/Raven/Processor/RemoveHttpBodyProcessor.php
+++ b/lib/Raven/Processor/RemoveHttpBodyProcessor.php
@@ -33,6 +33,8 @@ final class RemoveHttpBodyProcessor implements ProcessorInterface
             $request['data'] = self::STRING_MASK;
         }
 
-        return $event->setRequest($request);
+        $event->setRequest($request);
+
+        return $event;
     }
 }

--- a/lib/Raven/Processor/SanitizeCookiesProcessor.php
+++ b/lib/Raven/Processor/SanitizeCookiesProcessor.php
@@ -75,7 +75,7 @@ final class SanitizeCookiesProcessor implements ProcessorInterface
 
         unset($request['headers']['cookie']);
 
-        return $event->withRequest($request);
+        return $event->setRequest($request);
     }
 
     /**

--- a/lib/Raven/Processor/SanitizeCookiesProcessor.php
+++ b/lib/Raven/Processor/SanitizeCookiesProcessor.php
@@ -75,7 +75,9 @@ final class SanitizeCookiesProcessor implements ProcessorInterface
 
         unset($request['headers']['cookie']);
 
-        return $event->setRequest($request);
+        $event->setRequest($request);
+
+        return $event;
     }
 
     /**

--- a/lib/Raven/Processor/SanitizeDataProcessor.php
+++ b/lib/Raven/Processor/SanitizeDataProcessor.php
@@ -153,7 +153,7 @@ final class SanitizeDataProcessor implements ProcessorInterface
         $exception = $event->getException();
         $stacktrace = $event->getStacktrace();
         $request = $event->getRequest();
-        $extraContext = $event->getExtraContext();
+        $extraContext = $event->getExtraContext()->toArray();
 
         if (!empty($exception)) {
             $event->setException($this->sanitizeException($exception));
@@ -169,7 +169,8 @@ final class SanitizeDataProcessor implements ProcessorInterface
 
         if (!empty($extraContext)) {
             $this->sanitize($extraContext);
-            $event->setExtraContext($extraContext);
+
+            $event->getExtraContext()->replaceData($extraContext);
         }
 
         return $event;

--- a/lib/Raven/Processor/SanitizeDataProcessor.php
+++ b/lib/Raven/Processor/SanitizeDataProcessor.php
@@ -156,20 +156,20 @@ final class SanitizeDataProcessor implements ProcessorInterface
         $extraContext = $event->getExtraContext();
 
         if (!empty($exception)) {
-            $event = $event->withException($this->sanitizeException($exception));
+            $event->setException($this->sanitizeException($exception));
         }
 
         if ($stacktrace) {
-            $event = $event->withStacktrace($this->sanitizeStacktrace($stacktrace));
+            $event->setStacktrace($this->sanitizeStacktrace($stacktrace));
         }
 
         if (!empty($request)) {
-            $event = $event->withRequest($this->sanitizeHttp($request));
+            $event->setRequest($this->sanitizeHttp($request));
         }
 
         if (!empty($extraContext)) {
             $this->sanitize($extraContext);
-            $event = $event->withExtraContext($extraContext);
+            $event->setExtraContext($extraContext);
         }
 
         return $event;

--- a/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
+++ b/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
@@ -58,7 +58,9 @@ final class SanitizeHttpHeadersProcessor implements ProcessorInterface
             }
         }
 
-        return $event->setRequest($request);
+        $event->setRequest($request);
+
+        return $event;
     }
 
     /**

--- a/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
+++ b/lib/Raven/Processor/SanitizeHttpHeadersProcessor.php
@@ -58,7 +58,7 @@ final class SanitizeHttpHeadersProcessor implements ProcessorInterface
             }
         }
 
-        return $event->withRequest($request);
+        return $event->setRequest($request);
     }
 
     /**

--- a/lib/Raven/Processor/SanitizeStacktraceProcessor.php
+++ b/lib/Raven/Processor/SanitizeStacktraceProcessor.php
@@ -38,6 +38,6 @@ final class SanitizeStacktraceProcessor implements ProcessorInterface
             $frame->setPostContext(null);
         }
 
-        return $event->withStacktrace($stacktrace);
+        return $event->setStacktrace($stacktrace);
     }
 }

--- a/lib/Raven/Processor/SanitizeStacktraceProcessor.php
+++ b/lib/Raven/Processor/SanitizeStacktraceProcessor.php
@@ -28,16 +28,16 @@ final class SanitizeStacktraceProcessor implements ProcessorInterface
     {
         $stacktrace = $event->getStacktrace();
 
-        if (null === $stacktrace) {
-            return $event;
+        if (null !== $stacktrace) {
+            foreach ($stacktrace->getFrames() as $frame) {
+                $frame->setPreContext(null);
+                $frame->setContextLine(null);
+                $frame->setPostContext(null);
+            }
+
+            $event->setStacktrace($stacktrace);
         }
 
-        foreach ($stacktrace->getFrames() as $frame) {
-            $frame->setPreContext(null);
-            $frame->setContextLine(null);
-            $frame->setPostContext(null);
-        }
-
-        return $event->setStacktrace($stacktrace);
+        return $event;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -249,9 +249,9 @@ class ClientTest extends TestCase
         $this->assertEquals($inputData['transaction'], $event->getTransaction());
         $this->assertEquals($inputData['level'], $event->getLevel());
         $this->assertEquals($inputData['logger'], $event->getLogger());
-        $this->assertEquals($inputData['tags_context'], $event->getTagsContext());
-        $this->assertEquals($inputData['extra_context'], $event->getExtraContext());
-        $this->assertEquals($inputData['user_context'], $event->getUserContext());
+        $this->assertEquals($inputData['tags_context'], $event->getTagsContext()->toArray());
+        $this->assertEquals($inputData['extra_context'], $event->getExtraContext()->toArray());
+        $this->assertEquals($inputData['user_context'], $event->getUserContext()->toArray());
     }
 
     public function testGetLastEvent()

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -11,6 +11,10 @@ use Raven\Client;
 use Raven\ClientBuilder;
 use Raven\ClientInterface;
 use Raven\Configuration;
+use Raven\Context\Context;
+use Raven\Context\RuntimeContext;
+use Raven\Context\ServerOsContext;
+use Raven\Context\TagsContext;
 use Raven\Event;
 
 /**
@@ -92,6 +96,18 @@ class EventTest extends TestCase
             'server_name' => $this->configuration->getServerName(),
             'release' => $this->configuration->getRelease(),
             'environment' => $this->configuration->getCurrentEnvironment(),
+            'contexts' => [
+                'os' => [
+                    'name' => php_uname('s'),
+                    'version' => php_uname('r'),
+                    'build' => php_uname('v'),
+                    'kernel_version' => php_uname('a'),
+                ],
+                'runtime' => [
+                    'name' => 'php',
+                    'version' => PHP_VERSION,
+                ],
+            ],
         ];
 
         $event = new Event($this->configuration);
@@ -101,8 +117,8 @@ class EventTest extends TestCase
 
     public function testToArrayWithMessage()
     {
-        $event = Event::create($this->configuration)
-            ->setMessage('foo bar');
+        $event = new Event($this->configuration);
+        $event->setMessage('foo bar');
 
         $data = $event->toArray();
 
@@ -118,8 +134,8 @@ class EventTest extends TestCase
             'formatted' => 'foo bar',
         ];
 
-        $event = Event::create($this->configuration)
-            ->setMessage('foo %s', ['bar']);
+        $event = new Event($this->configuration);
+        $event->setMessage('foo %s', ['bar']);
 
         $data = $event->toArray();
 
@@ -148,6 +164,41 @@ class EventTest extends TestCase
         $this->assertSame($breadcrumbs, $data['breadcrumbs']);
     }
 
+    public function testGetServerOsContext()
+    {
+        $event = new Event($this->configuration);
+
+        $this->assertInstanceOf(ServerOsContext::class, $event->getServerOsContext());
+    }
+
+    public function testGetRuntimeContext()
+    {
+        $event = new Event($this->configuration);
+
+        $this->assertInstanceOf(RuntimeContext::class, $event->getRuntimeContext());
+    }
+
+    public function testGetUserContext()
+    {
+        $event = new Event($this->configuration);
+
+        $this->assertInstanceOf(Context::class, $event->getUserContext());
+    }
+
+    public function testGetExtraContext()
+    {
+        $event = new Event($this->configuration);
+
+        $this->assertInstanceOf(Context::class, $event->getExtraContext());
+    }
+
+    public function getTagsContext()
+    {
+        $event = new Event($this->configuration);
+
+        $this->assertInstanceOf(TagsContext::class, $event->getTagsContext());
+    }
+
     /**
      * @dataProvider gettersAndSettersDataProvider
      */
@@ -172,11 +223,6 @@ class EventTest extends TestCase
             ['serverName', 'local.host', ['server_name' => 'local.host']],
             ['release', '0.0.1', ['release' => '0.0.1']],
             ['modules', ['foo' => '0.0.1', 'bar' => '0.0.2'], ['modules' => ['foo' => '0.0.1', 'bar' => '0.0.2']]],
-            ['extraContext', ['foo' => 'bar'], ['extra' => ['foo' => 'bar']]],
-            ['tagsContext', ['bar' => 'foo'], ['tags' => ['bar' => 'foo']]],
-            ['userContext', ['bar' => 'baz'], ['user' => ['bar' => 'baz']]],
-            ['serverOsContext', ['foobar' => 'barfoo'], ['contexts' => ['os' => ['foobar' => 'barfoo']]]],
-            ['runtimeContext', ['barfoo' => 'foobar'], ['contexts' => ['runtime' => ['barfoo' => 'foobar']]]],
             ['fingerprint', ['foo', 'bar'], ['fingerprint' => ['foo', 'bar']]],
             ['environment', 'foo', ['environment' => 'foo']],
         ];

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -102,7 +102,7 @@ class EventTest extends TestCase
     public function testToArrayWithMessage()
     {
         $event = Event::create($this->configuration)
-            ->withMessage('foo bar');
+            ->setMessage('foo bar');
 
         $data = $event->toArray();
 
@@ -119,7 +119,7 @@ class EventTest extends TestCase
         ];
 
         $event = Event::create($this->configuration)
-            ->withMessage('foo %s', ['bar']);
+            ->setMessage('foo %s', ['bar']);
 
         $data = $event->toArray();
 
@@ -137,7 +137,7 @@ class EventTest extends TestCase
         $event = new Event($this->configuration);
 
         foreach ($breadcrumbs as $breadcrumb) {
-            $event = $event->withBreadcrumb($breadcrumb);
+            $event->setBreadcrumb($breadcrumb);
         }
 
         $this->assertSame($breadcrumbs, $event->getBreadcrumbs());
@@ -154,26 +154,13 @@ class EventTest extends TestCase
     public function testGettersAndSetters($propertyName, $propertyValue, $expectedValue)
     {
         $getterMethod = 'get' . ucfirst($propertyName);
-        $setterMethod = 'with' . ucfirst($propertyName);
+        $setterMethod = 'set' . ucfirst($propertyName);
 
         $event = new Event($this->configuration);
-        $newEvent = \call_user_func([$event, $setterMethod], \call_user_func([$event, $getterMethod]));
+        $event->$setterMethod($propertyValue);
 
-        $this->assertSame($event, $newEvent);
-
-        $newEvent = \call_user_func([$event, $setterMethod], $propertyValue);
-
-        $this->assertNotSame($event, $newEvent);
-
-        $value = \call_user_func([$event, $getterMethod]);
-        $newValue = \call_user_func([$newEvent, $getterMethod]);
-
-        $this->assertNotSame($value, $newValue);
-        $this->assertSame($newValue, $propertyValue);
-
-        $data = $newEvent->toArray();
-
-        $this->assertArraySubset($expectedValue, $data);
+        $this->assertSame($event->$getterMethod(), $propertyValue);
+        $this->assertArraySubset($expectedValue, $event->toArray());
     }
 
     public function gettersAndSettersDataProvider()

--- a/tests/Middleware/BreadcrumbInterfaceMiddlewareTest.php
+++ b/tests/Middleware/BreadcrumbInterfaceMiddlewareTest.php
@@ -33,17 +33,16 @@ class BreadcrumbInterfaceMiddlewareTest extends TestCase
         $configuration = new Configuration();
         $event = new Event($configuration);
 
-        $invokationCount = 0;
-        $callback = function (Event $eventArg) use ($event, $breadcrumb, $breadcrumb2, &$invokationCount) {
-            $this->assertNotSame($event, $eventArg);
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use ($breadcrumb, $breadcrumb2, &$callbackInvoked) {
             $this->assertEquals([$breadcrumb, $breadcrumb2], $eventArg->getBreadcrumbs());
 
-            ++$invokationCount;
+            $callbackInvoked = true;
         };
 
         $middleware = new BreadcrumbInterfaceMiddleware($recorder);
         $middleware($event, $callback);
 
-        $this->assertEquals(1, $invokationCount);
+        $this->assertTrue($callbackInvoked);
     }
 }

--- a/tests/Middleware/ContextInterfaceMiddlewareTest.php
+++ b/tests/Middleware/ContextInterfaceMiddlewareTest.php
@@ -35,16 +35,15 @@ class ContextInterfaceMiddlewareTest extends TestCase
         $configuration = new Configuration();
         $event = new Event($configuration);
 
-        $invokationCount = 0;
-        $callback = function (Event $eventArg) use ($event, $contextName, $expectedData, &$invokationCount) {
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use ($contextName, $expectedData, &$callbackInvoked) {
             $method = preg_replace_callback('/_[a-zA-Z]/', function ($matches) {
                 return strtoupper($matches[0][1]);
             }, 'get_' . $contextName . '_context');
 
-            $this->assertNotSame($event, $eventArg);
             $this->assertEquals($expectedData, $eventArg->$method());
 
-            ++$invokationCount;
+            $callbackInvoked = true;
         };
 
         $middleware = new ContextInterfaceMiddleware($context, $contextName);
@@ -52,7 +51,7 @@ class ContextInterfaceMiddlewareTest extends TestCase
             $contextName . '_context' => $payloadData,
         ]);
 
-        $this->assertEquals(1, $invokationCount);
+        $this->assertTrue($callbackInvoked);
     }
 
     public function invokeDataProvider()

--- a/tests/Middleware/ContextInterfaceMiddlewareTest.php
+++ b/tests/Middleware/ContextInterfaceMiddlewareTest.php
@@ -29,11 +29,8 @@ class ContextInterfaceMiddlewareTest extends TestCase
             $this->expectExceptionMessage($expectedExceptionMessage);
         }
 
-        $context = new Context();
-        $context->setData($initialData);
-
-        $configuration = new Configuration();
-        $event = new Event($configuration);
+        $context = new Context($initialData);
+        $event = new Event(new Configuration());
 
         $callbackInvoked = false;
         $callback = function (Event $eventArg) use ($contextName, $expectedData, &$callbackInvoked) {
@@ -41,7 +38,7 @@ class ContextInterfaceMiddlewareTest extends TestCase
                 return strtoupper($matches[0][1]);
             }, 'get_' . $contextName . '_context');
 
-            $this->assertEquals($expectedData, $eventArg->$method());
+            $this->assertEquals($expectedData, $eventArg->$method()->toArray());
 
             $callbackInvoked = true;
         };
@@ -59,16 +56,31 @@ class ContextInterfaceMiddlewareTest extends TestCase
         return [
             [
                 Context::CONTEXT_USER,
-                ['foo' => 'bar', 'foobaz' => 'bazfoo'],
-                ['foobaz' => 'bazfoo'],
-                ['foo' => 'bar', 'foobaz' => 'bazfoo'],
+                [
+                    'foo' => 'bar',
+                    'foobaz' => 'bazfoo',
+                ],
+                [
+                    'foobaz' => 'bazfoo',
+                ],
+                [
+                    'foo' => 'bar',
+                    'foobaz' => 'bazfoo',
+                ],
                 null,
             ],
             [
                 Context::CONTEXT_RUNTIME,
-                ['baz' => 'foo'],
-                ['barfoo' => 'foobar'],
-                ['baz' => 'foo', 'barfoo' => 'foobar'],
+                [
+                    'name' => 'foo',
+                ],
+                [
+                    'name' => 'foobar',
+                ],
+                [
+                    'name' => 'foobar',
+                    'version' => PHP_VERSION,
+                ],
                 null,
             ],
             [
@@ -80,16 +92,32 @@ class ContextInterfaceMiddlewareTest extends TestCase
             ],
             [
                 Context::CONTEXT_EXTRA,
-                ['bar' => 'foo'],
-                ['barbaz' => 'bazbar'],
-                ['bar' => 'foo', 'barbaz' => 'bazbar'],
+                [
+                    'bar' => 'foo',
+                ],
+                [
+                    'barbaz' => 'bazbar',
+                ],
+                [
+                    'bar' => 'foo',
+                    'barbaz' => 'bazbar',
+                ],
                 null,
             ],
             [
                 Context::CONTEXT_SERVER_OS,
-                ['foo' => 'baz'],
-                ['bazfoo' => 'foobaz'],
-                ['foo' => 'baz', 'bazfoo' => 'foobaz'],
+                [
+                    'name' => 'baz',
+                ],
+                [
+                    'name' => 'foobaz',
+                ],
+                [
+                    'name' => 'foobaz',
+                    'version' => php_uname('r'),
+                    'build' => php_uname('v'),
+                    'kernel_version' => php_uname('a'),
+                ],
                 null,
             ],
             [

--- a/tests/Middleware/MessageInterfaceMiddlewareTest.php
+++ b/tests/Middleware/MessageInterfaceMiddlewareTest.php
@@ -44,20 +44,18 @@ class MessageInterfaceMiddlewareTest extends TestCase
         $configuration = new Configuration();
         $event = new Event($configuration);
 
-        $invokationCount = 0;
-        $callback = function (Event $eventArg) use ($event, $payload, &$invokationCount) {
-            $this->assertNotSame($event, $eventArg);
-
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use ($payload, &$callbackInvoked) {
             $this->assertEquals($payload['message'], $eventArg->getMessage());
             $this->assertEquals($payload['message_params'], $eventArg->getMessageParams());
 
-            ++$invokationCount;
+            $callbackInvoked = true;
         };
 
         $middleware = new MessageInterfaceMiddleware();
         $middleware($event, $callback, null, null, $payload);
 
-        $this->assertEquals(1, $invokationCount);
+        $this->assertTrue($callbackInvoked);
     }
 
     public function invokeDataProvider()

--- a/tests/Middleware/ModulesMiddlewareTest.php
+++ b/tests/Middleware/ModulesMiddlewareTest.php
@@ -24,27 +24,8 @@ class ModulesMiddlewareTest extends TestCase
         $event = new Event($configuration);
 
         $callbackInvoked = false;
-        $callback = function (Event $eventArg) use ($event, &$callbackInvoked) {
-            $this->assertNotSame($event, $eventArg);
+        $callback = function (Event $eventArg) use (&$callbackInvoked) {
             $this->assertEquals(['foo/bar' => '1.2.3.0', 'foo/baz' => '4.5.6.0'], $eventArg->getModules());
-
-            $callbackInvoked = true;
-        };
-
-        $middleware = new ModulesMiddleware($configuration);
-        $middleware($event, $callback);
-
-        $this->assertTrue($callbackInvoked);
-    }
-
-    public function testInvokeDoesNothingWhenNoComposerLockFileExists()
-    {
-        $configuration = new Configuration(['project_root' => __DIR__]);
-        $event = new Event($configuration);
-
-        $callbackInvoked = false;
-        $callback = function (Event $eventArg) use ($event, &$callbackInvoked) {
-            $this->assertSame($event, $eventArg);
 
             $callbackInvoked = true;
         };

--- a/tests/Middleware/SanitizerMiddlewareTest.php
+++ b/tests/Middleware/SanitizerMiddlewareTest.php
@@ -22,12 +22,12 @@ class SanitizerMiddlewareTest extends TestCase
     public function testInvoke()
     {
         $event = new Event(new Configuration());
-        $event = $event->withRequest(['bar' => 'baz']);
-        $event = $event->withUserContext(['foo' => 'bar']);
-        $event = $event->withTagsContext(['foo', 'bar']);
-        $event = $event->withServerOsContext(['bar' => 'foo']);
-        $event = $event->withRuntimeContext(['foo' => 'baz']);
-        $event = $event->withExtraContext(['baz' => 'foo']);
+        $event->setRequest(['bar' => 'baz']);
+        $event->setUserContext(['foo' => 'bar']);
+        $event->setTagsContext(['foo', 'bar']);
+        $event->setServerOsContext(['bar' => 'foo']);
+        $event->setRuntimeContext(['foo' => 'baz']);
+        $event->setExtraContext(['baz' => 'foo']);
 
         /** @var Serializer|\PHPUnit_Framework_MockObject_MockObject $sanitizer */
         $sanitizer = $this->createMock(Serializer::class);
@@ -62,8 +62,7 @@ class SanitizerMiddlewareTest extends TestCase
             });
 
         $callbackInvoked = false;
-        $callback = function (Event $eventArg) use ($event, &$callbackInvoked) {
-            $this->assertNotSame($event, $eventArg);
+        $callback = function (Event $eventArg) use (&$callbackInvoked) {
             $this->assertEquals(['baz' => 'bar'], $eventArg->getRequest());
             $this->assertEquals(['bar' => 'foo'], $eventArg->getUserContext());
             $this->assertEquals(['baz' => 'foo'], $eventArg->getRuntimeContext());

--- a/tests/Middleware/SanitizerMiddlewareTest.php
+++ b/tests/Middleware/SanitizerMiddlewareTest.php
@@ -23,52 +23,32 @@ class SanitizerMiddlewareTest extends TestCase
     {
         $event = new Event(new Configuration());
         $event->setRequest(['bar' => 'baz']);
-        $event->setUserContext(['foo' => 'bar']);
-        $event->setTagsContext(['foo', 'bar']);
-        $event->setServerOsContext(['bar' => 'foo']);
-        $event->setRuntimeContext(['foo' => 'baz']);
-        $event->setExtraContext(['baz' => 'foo']);
+        $event->getUserContext()->replaceData(['foo' => 'bar']);
+        $event->getTagsContext()->replaceData(['foo', 'bar']);
+        $event->getServerOsContext()->replaceData(['name' => 'foo']);
+        $event->getRuntimeContext()->replaceData(['name' => 'baz']);
+        $event->getExtraContext()->replaceData(['baz' => 'foo']);
 
         /** @var Serializer|\PHPUnit_Framework_MockObject_MockObject $sanitizer */
         $sanitizer = $this->createMock(Serializer::class);
         $sanitizer->expects($this->exactly(6))
             ->method('serialize')
-            ->withConsecutive(
-                [
-                    $event->getRequest(),
-                    5,
-                ],
-                [
-                    $event->getUserContext(),
-                ],
-                [
-                    $event->getRuntimeContext(),
-                ],
-                [
-                    $event->getServerOsContext(),
-                ],
-                [
-                    $event->getExtraContext(),
-                ],
-                [
-                    $event->getTagsContext(),
-                ]
-            )
             ->willReturnCallback(function ($eventData) {
-                // This is here just because otherwise the event object will
-                // not be updated if the new value being set is the same as
-                // the previous one
-                return array_flip($eventData);
+                foreach ($eventData as $key => $value) {
+                    $eventData[$key] = strrev($value);
+                }
+
+                return $eventData;
             });
 
         $callbackInvoked = false;
         $callback = function (Event $eventArg) use (&$callbackInvoked) {
-            $this->assertEquals(['baz' => 'bar'], $eventArg->getRequest());
-            $this->assertEquals(['bar' => 'foo'], $eventArg->getUserContext());
-            $this->assertEquals(['baz' => 'foo'], $eventArg->getRuntimeContext());
-            $this->assertEquals(['foo' => 'bar'], $eventArg->getServerOsContext());
-            $this->assertEquals(['foo' => 'baz'], $eventArg->getExtraContext());
-            $this->assertEquals(['foo' => 0, 'bar' => 1], $eventArg->getTagsContext());
+            $this->assertArraySubset(['bar' => 'zab'], $eventArg->getRequest());
+            $this->assertArraySubset(['foo' => 'rab'], $eventArg->getUserContext());
+            $this->assertArraySubset(['name' => 'zab'], $eventArg->getRuntimeContext());
+            $this->assertArraySubset(['name' => 'oof'], $eventArg->getServerOsContext());
+            $this->assertArraySubset(['baz' => 'oof'], $eventArg->getExtraContext());
+            $this->assertArraySubset(['oof', 'rab'], $eventArg->getTagsContext());
 
             $callbackInvoked = true;
         };

--- a/tests/Middleware/UserInterfaceMiddlewareTest.php
+++ b/tests/Middleware/UserInterfaceMiddlewareTest.php
@@ -22,7 +22,7 @@ class UserInterfaceMiddlewareTest extends TestCase
     public function testInvoke()
     {
         $event = new Event(new Configuration());
-        $event = $event->withUserContext(['foo' => 'bar']);
+        $event->setUserContext(['foo' => 'bar']);
 
         $invokationCount = 0;
         $callback = function (Event $eventArg) use ($event, &$invokationCount) {
@@ -40,22 +40,21 @@ class UserInterfaceMiddlewareTest extends TestCase
     public function testInvokeWithRequest()
     {
         $event = new Event(new Configuration());
-        $event = $event->withUserContext(['foo' => 'bar']);
+        $event->setUserContext(['foo' => 'bar']);
 
         $request = new ServerRequest();
         $request = $request->withHeader('REMOTE_ADDR', '127.0.0.1');
 
-        $invokationCount = 0;
-        $callback = function (Event $eventArg) use ($event, &$invokationCount) {
-            $this->assertNotSame($event, $eventArg);
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use (&$callbackInvoked) {
             $this->assertEquals(['ip_address' => '127.0.0.1', 'foo' => 'bar'], $eventArg->getUserContext());
 
-            ++$invokationCount;
+            $callbackInvoked = true;
         };
 
         $middleware = new UserInterfaceMiddleware();
         $middleware($event, $callback, $request);
 
-        $this->assertEquals(1, $invokationCount);
+        $this->assertTrue($callbackInvoked);
     }
 }

--- a/tests/Middleware/UserInterfaceMiddlewareTest.php
+++ b/tests/Middleware/UserInterfaceMiddlewareTest.php
@@ -22,32 +22,32 @@ class UserInterfaceMiddlewareTest extends TestCase
     public function testInvoke()
     {
         $event = new Event(new Configuration());
-        $event->setUserContext(['foo' => 'bar']);
+        $event->getUserContext()->setData(['foo' => 'bar']);
 
-        $invokationCount = 0;
-        $callback = function (Event $eventArg) use ($event, &$invokationCount) {
-            $this->assertSame($event, $eventArg);
+        $callbackInvoked = false;
+        $callback = function (Event $eventArg) use (&$callbackInvoked) {
+            $this->assertArrayNotHasKey('ip_address', $eventArg->getUserContext());
 
-            ++$invokationCount;
+            $callbackInvoked = true;
         };
 
         $middleware = new UserInterfaceMiddleware();
         $middleware($event, $callback);
 
-        $this->assertEquals(1, $invokationCount);
+        $this->assertTrue($callbackInvoked);
     }
 
     public function testInvokeWithRequest()
     {
         $event = new Event(new Configuration());
-        $event->setUserContext(['foo' => 'bar']);
+        $event->getUserContext()->setData(['foo' => 'bar']);
 
         $request = new ServerRequest();
         $request = $request->withHeader('REMOTE_ADDR', '127.0.0.1');
 
         $callbackInvoked = false;
         $callback = function (Event $eventArg) use (&$callbackInvoked) {
-            $this->assertEquals(['ip_address' => '127.0.0.1', 'foo' => 'bar'], $eventArg->getUserContext());
+            $this->assertEquals(['ip_address' => '127.0.0.1', 'foo' => 'bar'], $eventArg->getUserContext()->toArray());
 
             $callbackInvoked = true;
         };

--- a/tests/Processor/RemoveHttpBodyProcessorTest.php
+++ b/tests/Processor/RemoveHttpBodyProcessorTest.php
@@ -41,7 +41,7 @@ class RemoveHttpBodyProcessorTest extends TestCase
     public function testProcess($inputData, $expectedData)
     {
         $event = new Event($this->client->getConfig());
-        $event = $event->withRequest($inputData);
+        $event->setRequest($inputData);
 
         $event = $this->processor->process($event);
 

--- a/tests/Processor/SanitizeCookiesProcessorTest.php
+++ b/tests/Processor/SanitizeCookiesProcessorTest.php
@@ -47,7 +47,7 @@ class SanitizeCookiesProcessorTest extends TestCase
     public function testProcess($options, $expectedData)
     {
         $event = new Event($this->client->getConfig());
-        $event = $event->withRequest([
+        $event->setRequest([
             'foo' => 'bar',
             'cookies' => [
                 'foo' => 'bar',

--- a/tests/Processor/SanitizeDataProcessorTest.php
+++ b/tests/Processor/SanitizeDataProcessorTest.php
@@ -48,7 +48,7 @@ class SanitizeDataProcessorTest extends TestCase
         }
 
         if (isset($inputData['extra_context'])) {
-            $event->setExtraContext($inputData['extra_context']);
+            $event->getExtraContext()->replaceData($inputData['extra_context']);
         }
 
         if (isset($inputData['exception'])) {
@@ -72,8 +72,7 @@ class SanitizeDataProcessorTest extends TestCase
             // We must convert the backtrace to a Stacktrace instance here because
             // PHPUnit executes the data provider before the setUp method and so
             // the client instance cannot be accessed from there
-            $this->assertArraySubset($this->convertExceptionValuesToStacktrace($expectedData['exception']),
-                $event->getException());
+            $this->assertArraySubset($this->convertExceptionValuesToStacktrace($expectedData['exception']), $event->getException());
         }
     }
 

--- a/tests/Processor/SanitizeDataProcessorTest.php
+++ b/tests/Processor/SanitizeDataProcessorTest.php
@@ -44,18 +44,18 @@ class SanitizeDataProcessorTest extends TestCase
         $event = new Event($this->client->getConfig());
 
         if (isset($inputData['request'])) {
-            $event = $event->withRequest($inputData['request']);
+            $event->setRequest($inputData['request']);
         }
 
         if (isset($inputData['extra_context'])) {
-            $event = $event->withExtraContext($inputData['extra_context']);
+            $event->setExtraContext($inputData['extra_context']);
         }
 
         if (isset($inputData['exception'])) {
             // We must convert the backtrace to a Stacktrace instance here because
             // PHPUnit executes the data provider before the setUp method and so
             // the client instance cannot be accessed from there
-            $event = $event->withException($this->convertExceptionValuesToStacktrace($expectedData['exception']));
+            $event->setException($this->convertExceptionValuesToStacktrace($expectedData['exception']));
         }
 
         $event = $this->processor->process($event);

--- a/tests/Processor/SanitizeHttpHeadersProcessorTest.php
+++ b/tests/Processor/SanitizeHttpHeadersProcessorTest.php
@@ -43,7 +43,7 @@ class SanitizeHttpHeadersProcessorTest extends TestCase
     public function testProcess($inputData, $expectedData)
     {
         $event = new Event($this->client->getConfig());
-        $event = $event->withRequest($inputData);
+        $event->setRequest($inputData);
 
         $event = $this->processor->process($event);
 

--- a/tests/Processor/SanitizeStacktraceProcessorTest.php
+++ b/tests/Processor/SanitizeStacktraceProcessorTest.php
@@ -42,7 +42,7 @@ class SanitizeStacktraceProcessorTest extends TestCase
         $exception = new \Exception();
 
         $event = new Event($this->client->getConfig());
-        $event = $event->withStacktrace(Stacktrace::createFromBacktrace($this->client, $exception->getTrace(), $exception->getFile(), $exception->getLine()));
+        $event->setStacktrace(Stacktrace::createFromBacktrace($this->client, $exception->getTrace(), $exception->getFile(), $exception->getLine()));
 
         $event = $this->processor->process($event);
 
@@ -59,7 +59,7 @@ class SanitizeStacktraceProcessorTest extends TestCase
         $exception2 = new \Exception('', 0, $exception1);
 
         $event = new Event($this->client->getConfig());
-        $event = $event->withStacktrace(Stacktrace::createFromBacktrace($this->client, $exception2->getTrace(), $exception2->getFile(), $exception2->getLine()));
+        $event->setStacktrace(Stacktrace::createFromBacktrace($this->client, $exception2->getTrace(), $exception2->getFile(), $exception2->getLine()));
 
         $event = $this->processor->process($event);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

After the `*Context` classes have been introduced I started thinking we could use them to enforce data validation inside the events objects too instead of relying on plain arrays. However this led to problems because the context classes were mutable while the event was not. Plus, from a technical point of view we should ensure that if an object is immutable than everything inside itself is immutable too, which is too complicated, so I took the occasion to drop the concept of immutability of the event as I see no benefit anyway in having it for this particular case to simplify the code