### PR TITLE
Do not force IPv4 protocol by default

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -179,7 +179,7 @@ class Raven_Client
         $this->send_callback = Raven_Util::get($options, 'send_callback', null);
         $this->curl_method = Raven_Util::get($options, 'curl_method', 'sync');
         $this->curl_path = Raven_Util::get($options, 'curl_path', 'curl');
-        $this->curl_ipv4 = Raven_Util::get($options, 'curl_ipv4', true);
+        $this->curl_ipv4 = Raven_Util::get($options, 'curl_ipv4', false);
         $this->ca_cert = Raven_Util::get($options, 'ca_cert', static::get_default_ca_cert());
         $this->verify_ssl = Raven_Util::get($options, 'verify_ssl', true);
         $this->curl_ssl_version = Raven_Util::get($options, 'curl_ssl_version');


### PR DESCRIPTION
Todays world is moving to IPv6 fast. Let's not be tied to IPv4 and let the system to choose, which protocol to use.

For networks with broken IPv6 implementation - the ability to force IPv4 only connection still remains.