### PR TITLE
[2.0] Fix examples using `server` instead of `dsn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use Sentry\ClientBuilder;
 require 'vendor/autoload.php';
 
 // Instantiate the SDK with your DSN
-$client = ClientBuilder::create(['server' => 'http://public@example.com/1'])->getClient();
+$client = ClientBuilder::create(['dsn' => 'http://public@example.com/1'])->getClient();
 
 // Capture an exception
 $eventId = $client->captureException(new \RuntimeException('Hello World!'));


### PR DESCRIPTION
it's `dsn`, not `server` (unless maybe you mean to change it and didn't do it yet - but the current version expected `dsn`)