### PR TITLE
[2.0] Do not return error id if we know we did not send the error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -124,7 +124,7 @@ class Client implements ClientInterface
     private $middlewareStack;
 
     /**
-     * @var Event The last event that was captured
+     * @var Event|null The last event that was captured
      */
     private $lastEvent;
 
@@ -343,7 +343,11 @@ class Client implements ClientInterface
             $payload
         );
 
-        $this->send($event);
+        if (false === $this->send($event)) {
+            $this->lastEvent = null;
+
+            return null;
+        }
 
         $this->lastEvent = $event;
 
@@ -356,15 +360,15 @@ class Client implements ClientInterface
     public function send(Event $event)
     {
         if (!$this->config->shouldCapture($event)) {
-            return;
+            return false;
         }
 
         // should this event be sampled?
         if (mt_rand(1, 100) / 100.0 > $this->config->getSampleRate()) {
-            return;
+            return false;
         }
 
-        $this->transport->send($event);
+        return $this->transport->send($event);
     }
 
     /**

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -109,7 +109,7 @@ interface ClientInterface
      * Gets the last event that was captured by the client. However, it could
      * have been sent or still sit in the queue of pending events.
      *
-     * @return Event
+     * @return Event|null
      */
     public function getLastEvent();
 
@@ -127,7 +127,7 @@ interface ClientInterface
      *
      * @param array $payload The data of the event being captured
      *
-     * @return string
+     * @return string|null
      */
     public function capture(array $payload);
 
@@ -135,6 +135,8 @@ interface ClientInterface
      * Sends the given event to the Sentry server.
      *
      * @param Event $event The event to send
+     *
+     * @return bool|null
      */
     public function send(Event $event);
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -237,6 +237,19 @@ class ClientTest extends TestCase
         $this->assertSame($lastEvent, $client->getLastEvent());
     }
 
+    public function testGetLastEventEmptyIfNotSent()
+    {
+        $client = ClientBuilder::create([
+            'should_capture' => function () {
+                return false;
+            },
+        ])->getClient();
+
+        $client->capture(['message' => 'foo']);
+
+        $this->assertNull($client->getLastEvent());
+    }
+
     /**
      * @group legacy
      *


### PR DESCRIPTION
If we know we did not sent the error to a Sentry server we should not return the error id or keep track of that event as the last event.