### PR TITLE
[WIP] [2.0] Unified API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,13 @@ cs:
 cs-dry-run:
 	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run
 
-test: cs-dry-run
+cs-fix:
+	vendor/bin/php-cs-fixer fix --config=.php_cs
+
+phpstan:
+	vendor/bin/phpstan analyse src tests -c phpstan.neon -l 3
+
+test: cs-fix phpstan
 	vendor/bin/phpunit
 
 setup-git:

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,6 +17,7 @@ use Sentry\Context\Context;
 use Sentry\Context\RuntimeContext;
 use Sentry\Context\ServerOsContext;
 use Sentry\Context\TagsContext;
+use Sentry\Context\UserContext;
 use Sentry\Middleware\MiddlewareStack;
 use Sentry\Transport\TransportInterface;
 use Zend\Diactoros\ServerRequestFactory;
@@ -99,7 +100,7 @@ class Client implements ClientInterface
     private $tagsContext;
 
     /**
-     * @var Context The user context
+     * @var UserContext The user context
      */
     private $userContext;
 
@@ -139,7 +140,7 @@ class Client implements ClientInterface
         $this->config = $config;
         $this->transport = $transport;
         $this->tagsContext = new TagsContext();
-        $this->userContext = new Context();
+        $this->userContext = new UserContext();
         $this->extraContext = new Context();
         $this->runtimeContext = new RuntimeContext();
         $this->serverOsContext = new ServerOsContext();

--- a/src/Context/OptionsResolverContext.php
+++ b/src/Context/OptionsResolverContext.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Sentry\Context;
+
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class OptionsResolverContext extends Context
+{
+    /**
+     * @var OptionsResolver The options resolver
+     */
+    protected $resolver;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function __construct(array $data = [])
+    {
+        $this->resolver = new OptionsResolver();
+
+        $this->configureOptions($this->resolver);
+
+        parent::__construct($this->resolver->resolve($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function merge(array $data, $recursive = false)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::merge($data, $recursive);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function setData(array $data)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::setData($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function replaceData(array $data)
+    {
+        $data = $this->resolver->resolve($data);
+
+        parent::replaceData($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws UndefinedOptionsException If any of the options are not supported
+     *                                   by the context
+     * @throws InvalidOptionsException   If any of the options don't fulfill the
+     *                                   specified validation rules
+     */
+    public function offsetSet($offset, $value)
+    {
+        $data = $this->resolver->resolve([$offset => $value]);
+
+        parent::offsetSet($offset, $data[$offset]);
+    }
+
+    /**
+     * Configures the options of the context.
+     *
+     * @param OptionsResolver $resolver The resolver for the options
+     */
+    abstract protected function configureOptions(OptionsResolver $resolver);
+}

--- a/src/Context/RuntimeContext.php
+++ b/src/Context/RuntimeContext.php
@@ -1,19 +1,8 @@
 <?php
 
-/*
- * This file is part of Raven.
- *
- * (c) Sentry Team
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Sentry\Context;
 
 use Sentry\Util\PHPVersion;
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -22,90 +11,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class RuntimeContext extends Context
+final class RuntimeContext extends OptionsResolverContext
 {
-    /**
-     * @var OptionsResolver The options resolver
-     */
-    private $resolver;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function __construct(array $data = [])
-    {
-        $this->resolver = new OptionsResolver();
-
-        $this->configureOptions($this->resolver);
-
-        parent::__construct($this->resolver->resolve($data));
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function merge(array $data, $recursive = false)
-    {
-        $data = $this->resolver->resolve($data);
-
-        parent::merge($data, $recursive);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function setData(array $data)
-    {
-        $data = $this->resolver->resolve($data);
-
-        parent::setData($data);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function replaceData(array $data)
-    {
-        $data = $this->resolver->resolve($data);
-
-        parent::replaceData($data);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function offsetSet($offset, $value)
-    {
-        $data = $this->resolver->resolve([$offset => $value]);
-
-        parent::offsetSet($offset, $data[$offset]);
-    }
-
     /**
      * Gets the name of the runtime.
      *
@@ -147,11 +54,9 @@ class RuntimeContext extends Context
     }
 
     /**
-     * Configures the options of the context.
-     *
-     * @param OptionsResolver $resolver The resolver for the options
+     * {@inheritdoc}
      */
-    private function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'name' => 'php',

--- a/src/Context/ServerOsContext.php
+++ b/src/Context/ServerOsContext.php
@@ -11,8 +11,6 @@
 
 namespace Sentry\Context;
 
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
-use Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -21,90 +19,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class ServerOsContext extends Context
+final class ServerOsContext extends OptionsResolverContext
 {
-    /**
-     * @var OptionsResolver The options resolver
-     */
-    private $resolver;
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function __construct(array $data = [])
-    {
-        $this->resolver = new OptionsResolver();
-
-        $this->configureOptions($this->resolver);
-
-        parent::__construct($this->resolver->resolve($data));
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function merge(array $data, $recursive = false)
-    {
-        $data = $this->resolver->resolve($data);
-
-        parent::merge($data, $recursive);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function setData(array $data)
-    {
-        $data = $this->resolver->resolve($data);
-
-        parent::setData($data);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function replaceData(array $data)
-    {
-        $data = $this->resolver->resolve($data);
-
-        parent::replaceData($data);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws UndefinedOptionsException If any of the options are not supported
-     *                                   by the context
-     * @throws InvalidOptionsException   If any of the options don't fulfill the
-     *                                   specified validation rules
-     */
-    public function offsetSet($offset, $value)
-    {
-        $data = $this->resolver->resolve([$offset => $value]);
-
-        parent::offsetSet($offset, $data[$offset]);
-    }
-
     /**
      * Gets the name of the operating system.
      *
@@ -186,11 +102,9 @@ class ServerOsContext extends Context
     }
 
     /**
-     * Configures the options of the context.
-     *
-     * @param OptionsResolver $resolver The resolver for the options
+     * {@inheritdoc}
      */
-    private function configureOptions(OptionsResolver $resolver)
+    protected function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
             'name' => php_uname('s'),

--- a/src/Context/TagsContext.php
+++ b/src/Context/TagsContext.php
@@ -17,7 +17,7 @@ namespace Sentry\Context;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-class TagsContext extends Context
+final class TagsContext extends Context
 {
     /**
      * {@inheritdoc}

--- a/src/Context/UserContext.php
+++ b/src/Context/UserContext.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Sentry\Context;
+
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class UserContext extends OptionsResolverContext
+{
+    /**
+     * @return null|string
+     */
+    public function getId(): ?string
+    {
+        return $this->data['id'];
+    }
+
+    /**
+     * @param null|string $id
+     */
+    public function setId(?string $id): void
+    {
+        $this->offsetSet('id', $id);
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getUsername(): ?string
+    {
+        return $this->data['username'];
+    }
+
+    /**
+     * @param null|string $username
+     */
+    public function setUsername(?string $username): void
+    {
+        $this->offsetSet('username', $username);
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getEmail(): ?string
+    {
+        return $this->data['email'];
+    }
+
+    /**
+     * @param null|string $email
+     */
+    public function setEmail(?string $email): void
+    {
+        $this->offsetSet('email', $email);
+    }
+
+    /**
+     * @return null|array
+     */
+    public function getExtra(): ?array
+    {
+        return $this->data['data'];
+    }
+
+    /**
+     * @param mixed $data
+     */
+    public function setExtra($data): void
+    {
+        $this->offsetSet('data', $data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefined(['id', 'username', 'email', 'data']);
+        $resolver->setAllowedTypes('id', 'string');
+        $resolver->setAllowedTypes('username', 'string');
+        $resolver->setAllowedTypes('email', 'string');
+    }
+}

--- a/src/Interfaces/Severity.php
+++ b/src/Interfaces/Severity.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sentry\Interfaces;
+
+final class Severity
+{
+    const DEBUG = 'debug';
+    const INFO = 'info';
+    const WARNING = 'warning';
+    const ERROR = 'error';
+    const FATAL = 'fatal';
+
+    private $value;
+
+    public function __construct(string $value = self::INFO)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Sentry\State;
+
+use Sentry\Breadcrumbs\Breadcrumb;
+use Sentry\Client;
+use Sentry\Interfaces\Severity;
+
+/**
+ * Class Hub.
+ *
+ * Responsible for maintaining a stack of Client <-> Scope. Basically it's the main entry point to talk to the Client.
+ */
+final class Hub
+{
+    /**
+     * @var Layer[]
+     */
+    private $stack = [];
+
+    /**
+     * Hub constructor.
+     *
+     * @param null|Client $client
+     * @param null|Scope  $scope
+     */
+    public function __construct(?Client $client = null, ?Scope $scope = null)
+    {
+        if (null === $scope) {
+            $scope = new Scope();
+        }
+        $this->stack[] = new Layer($client, $scope);
+    }
+
+    /**
+     * @return Layer
+     */
+    private function getStackTop(): Layer
+    {
+        return \end($this->stack);
+    }
+
+    /**
+     * @return null|Client
+     */
+    public function getClient(): ?Client
+    {
+        return $this->getStackTop()->getClient();
+    }
+
+    /**
+     * @return Scope
+     */
+    public function getScope(): Scope
+    {
+        return $this->getStackTop()->getScope();
+    }
+
+    /**
+     * @return Scope
+     */
+    public function pushScope(): Scope
+    {
+        $clonedScope = clone $this->getScope();
+        $this->stack[] = new Layer($this->getClient(), $clonedScope);
+
+        return $clonedScope;
+    }
+
+    /**
+     * @return bool
+     */
+    public function popScope(): bool
+    {
+        if (1 === \count($this->stack)) {
+            return false;
+        }
+
+        return null !== \array_pop($this->stack);
+    }
+
+    /**
+     * @param \Closure $callback
+     */
+    public function withScope(\Closure $callback): void
+    {
+        $scope = $this->pushScope();
+        $callback($scope);
+        $this->popScope();
+    }
+
+    /**
+     * @param \Closure $callback
+     */
+    public function configureScope(\Closure $callback): void
+    {
+        $top = $this->getStackTop();
+        if (null !== $top->getClient()) {
+            $callback($top->getScope());
+        }
+    }
+
+    /**
+     * @param Client $client
+     */
+    public function bindClient(Client $client): void
+    {
+        $top = $this->getStackTop();
+        $top->setClient($client);
+    }
+
+    /**
+     * @param string   $message
+     * @param Severity $level
+     *
+     * @return null|string
+     */
+    public function captureMessage(string $message, ?Severity $level = null): ?string
+    {
+        if ($client = $this->getClient()) {
+            // TODO: add level to call
+            return $client->captureMessage($message);
+        }
+    }
+
+    /**
+     * @param \Throwable $exception
+     *
+     * @return null|string
+     */
+    public function captureException($exception): ?string
+    {
+        if ($client = $this->getClient()) {
+            return $client->captureException($exception);
+        }
+    }
+
+    /**
+     * @param Breadcrumb $crumb
+     */
+    public function addBreadcrumb(Breadcrumb $crumb): void
+    {
+        if ($client = $this->getClient()) {
+            $client->leaveBreadcrumb($crumb);
+        }
+    }
+}

--- a/src/State/Layer.php
+++ b/src/State/Layer.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Sentry\State;
+
+use Sentry\Client;
+
+final class Layer
+{
+    private $client;
+    private $scope;
+
+    public function __construct(?Client $client, Scope $scope)
+    {
+        $this->client = $client;
+        $this->scope = $scope;
+    }
+
+    /**
+     * @return null|Client
+     */
+    public function getClient(): ?Client
+    {
+        return $this->client;
+    }
+
+    /**
+     * @param Client $client
+     *
+     * @return Layer
+     */
+    public function setClient(Client $client): self
+    {
+        $this->client = $client;
+
+        return $this;
+    }
+
+    /**
+     * @return Scope
+     */
+    public function getScope(): Scope
+    {
+        return $this->scope;
+    }
+
+    /**
+     * @param Scope $scope
+     *
+     * @return Layer
+     */
+    public function setScope(Scope $scope): self
+    {
+        $this->scope = $scope;
+
+        return $this;
+    }
+}

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Sentry\State;
+
+use Sentry\Breadcrumbs\Breadcrumb;
+use Sentry\Context\Context;
+use Sentry\Context\TagsContext;
+use Sentry\Context\UserContext;
+use Sentry\Event;
+use Sentry\Interfaces\Severity;
+
+final class Scope
+{
+    /**
+     * Array holding all breadcrumbs.
+     *
+     * @var Breadcrumb[]
+     */
+    private $breadcrumbs = [];
+
+    /**
+     * @var null|UserContext
+     */
+    private $user;
+
+    /**
+     * Array holding all tags.
+     *
+     * @var null|TagsContext
+     */
+    private $tags;
+
+    /**
+     * Array holding all extra.
+     *
+     * @var null|Context
+     */
+    private $extra;
+
+    /**
+     * Array holding all fingerprints. This is used to group events together in Sentry.
+     *
+     * @var string[]
+     */
+    private $fingerprint = [];
+
+    /**
+     * @var null|Severity
+     */
+    private $level = null;
+
+    /**
+     * Array of eventProcessors. Closure receiving the event, they should return an event or null.
+     *
+     * @var array
+     */
+    private $eventProcessors;
+
+    /**
+     * Scope constructor.
+     */
+    public function __construct()
+    {
+        $this->user = new UserContext();
+        $this->tags = new TagsContext();
+        $this->extra = new Context();
+    }
+
+    /**
+     * Scope __clone function.
+     */
+    public function __clone()
+    {
+        // We need to create new Contexts here
+        $this->user = new UserContext($this->user->toArray());
+        $this->tags = new TagsContext($this->tags->toArray());
+        $this->extra = new Context($this->extra->toArray());
+    }
+
+    /**
+     * @param Event $event
+     *
+     * @return null|Event
+     */
+    private function notifyEventProcessors(Event $event): ?Event
+    {
+        foreach ($this->eventProcessors as $processor) {
+            $event = $processor($event);
+            if (null === $event) {
+                return null;
+            }
+        }
+
+        return $event;
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     *
+     * @return Scope
+     */
+    public function setTag(string $key, string $value): self
+    {
+        $this->tags->offsetSet($key, $value);
+
+        return $this;
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @return Scope
+     */
+    public function setExtra(string $key, $value): self
+    {
+        $this->extra[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param null|UserContext $user
+     *
+     * @return Scope
+     */
+    public function setUser(?UserContext $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $fingerprint
+     *
+     * @return Scope
+     */
+    public function setFingerprint(array $fingerprint): self
+    {
+        $this->fingerprint = $fingerprint;
+
+        return $this;
+    }
+
+    /**
+     * @param null|Severity $level
+     *
+     * @return Scope
+     */
+    public function setLevel(?Severity $level): self
+    {
+        $this->level = $level;
+
+        return $this;
+    }
+
+    /**
+     * @param Breadcrumb $crumb
+     * @param int        $maxBreadcrumbs
+     *
+     * @return Scope
+     */
+    public function addBreadcrumb(Breadcrumb $crumb, int $maxBreadcrumbs = 100): self
+    {
+        $this->breadcrumbs[] = $crumb;
+        $this->breadcrumbs = \array_slice($this->breadcrumbs, -$maxBreadcrumbs);
+
+        return $this;
+    }
+
+    /**
+     * @param Event $event
+     * @param int   $maxBreadcrumbs
+     *
+     * @return null|Event
+     */
+    public function applyToEvent(Event $event, int $maxBreadcrumbs = 100): ?Event
+    {
+        if ($this->level) {
+            $event->setLevel($this->level);
+        }
+        if (!empty($this->fingerprint)) {
+            $event->setFingerprint($this->fingerprint);
+        }
+        // TODO: extra, tags, breadcrumbs, user
+
+        return $this->notifyEventProcessors($event);
+    }
+
+    /**
+     * @param \Closure $callback
+     *
+     * @return Scope
+     */
+    public function addEventProcessor(\Closure $callback): self
+    {
+        $this->eventProcessors[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * @return Scope
+     */
+    public function clear(): self
+    {
+        $this->tags = new TagsContext();
+        $this->extra = new Context();
+        $this->user = new UserContext();
+        $this->level = null;
+        $this->breadcrumbs = [];
+
+        return $this;
+    }
+}

--- a/tests/Context/UserContextTest.php
+++ b/tests/Context/UserContextTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sentry\Tests\Context;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Context\UserContext;
+
+class UserContextTest extends TestCase
+{
+    /**
+     * @dataProvider gettersAndSettersDataProvider
+     */
+    public function testGettersAndSetters($getterMethod, $setterMethod, $value)
+    {
+        $context = new UserContext();
+        $context->$setterMethod($value);
+
+        $this->assertEquals($value, $context->$getterMethod());
+    }
+
+    public function gettersAndSettersDataProvider()
+    {
+        return [
+            [
+                'getId',
+                'setId',
+                'foo',
+            ],
+            [
+                'getUsername',
+                'setUsername',
+                'bar',
+            ],
+            [
+                'getEmail',
+                'setEmail',
+                'baz',
+            ],
+            [
+                'getExtra',
+                'setExtra',
+                ['a' => 'b'],
+            ],
+        ];
+    }
+}

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Sentry\Tests\State;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientBuilder;
+use Sentry\Context\TagsContext;
+use Sentry\Event;
+use Sentry\State\Hub;
+use Sentry\State\Scope;
+
+class HubTest extends TestCase
+{
+    public function testWithScope()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'tags');
+        $reflectionProperty->setAccessible(true);
+        $hub = new Hub();
+        $hub->withScope(function (Scope $scope) use ($hub, $reflectionProperty) {
+            $scope->setTag('foo', 'bar');
+            /* @var $tags TagsContext */
+            $tags = $reflectionProperty->getValue($hub->getScope());
+            $this->assertInstanceOf(TagsContext::class, $tags);
+            $this->assertEquals(['foo' => 'bar'], $tags->toArray());
+        });
+        /* @var $tags TagsContext */
+        $tags = $reflectionProperty->getValue($hub->getScope());
+        $this->assertTrue($tags->isEmpty());
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testConfigureScope()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'tags');
+        $reflectionProperty->setAccessible(true);
+        $hub = new Hub();
+        $hub->configureScope(function ($scope) {
+            // This should never be called since there is no client on the hub
+            $scope->setTag('foo', 'bar');
+        });
+        /* @var $tags TagsContext */
+        $tags = $reflectionProperty->getValue($hub->getScope());
+        $this->assertTrue($tags->isEmpty());
+
+        $client = ClientBuilder::create()->getClient();
+        $hub = new Hub($client);
+        $hub->configureScope(function ($scope) {
+            $scope->setTag('foo', 'bar');
+        });
+        /* @var $tags TagsContext */
+        $tags = $reflectionProperty->getValue($hub->getScope());
+        $this->assertInstanceOf(TagsContext::class, $tags);
+        $this->assertEquals(['foo' => 'bar'], $tags->toArray());
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testPush()
+    {
+        $reflectionProperty = new \ReflectionProperty(Hub::class, 'stack');
+        $reflectionProperty->setAccessible(true);
+        $hub = new Hub();
+        $scope = $hub->pushScope();
+        $this->assertEquals($scope, $hub->getScope());
+        $this->assertCount(2, $reflectionProperty->getValue($hub));
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testPop()
+    {
+        $reflectionProperty = new \ReflectionProperty(Hub::class, 'stack');
+        $reflectionProperty->setAccessible(true);
+        $hub = new Hub();
+        $hub->pushScope();
+        $this->assertCount(2, $reflectionProperty->getValue($hub));
+        $hub->popScope();
+        $this->assertCount(1, $reflectionProperty->getValue($hub));
+        $hub->popScope();
+        $this->assertCount(1, $reflectionProperty->getValue($hub));
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testBindClient()
+    {
+        $hub = new Hub();
+        $this->assertNull($hub->getClient());
+        $client = ClientBuilder::create()->getClient();
+        $hub->bindClient($client);
+        $this->assertEquals($client, $hub->getClient());
+    }
+
+    public function testApplyToEventWithEventProcessor()
+    {
+        $client = ClientBuilder::create()->getClient();
+        $event = new Event($client->getConfig());
+        $hub = new Hub($client);
+        $hub->configureScope(function ($scope) use ($event) {
+            $scope->setTag('foo', 'bar');
+            $scope->addEventProcessor(function ($event) {
+                $event->setMessage('test');
+
+                return $event;
+            });
+            $finalEvent = $scope->applyToEvent($event);
+            $this->assertEquals($event, $finalEvent);
+            $this->assertEquals('test', $event->getMessage());
+        });
+        // TODO set everything on the scope
+    }
+
+    public function testApplyToEventWithEventProcessorReturningNull()
+    {
+        $client = ClientBuilder::create()->getClient();
+        $event = new Event($client->getConfig());
+        $hub = new Hub($client);
+        $hub->configureScope(function ($scope) use ($event) {
+            $scope->setTag('foo', 'bar');
+            $scope->addEventProcessor(function () {
+                return null;
+            });
+            $finalEvent = $scope->applyToEvent($event);
+            $this->assertNull($finalEvent);
+        });
+    }
+}

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Sentry\Tests\State;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Breadcrumbs\Breadcrumb;
+use Sentry\Interfaces\Severity;
+use Sentry\State\Scope;
+
+class ScopeTest extends TestCase
+{
+    public function testSetTag()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'tags');
+        $reflectionProperty->setAccessible(true);
+        $scope = new Scope();
+        $this->assertTrue($reflectionProperty->getValue($scope)->isEmpty());
+        $this->assertEquals($scope->setTag('foo', 'bar'), $scope);
+        $this->assertEquals(['foo' => 'bar'], $reflectionProperty->getValue($scope)->toArray());
+        $scope->setTag('foo', 'bar1');
+        $this->assertEquals(['foo' => 'bar1'], $reflectionProperty->getValue($scope)->toArray());
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testSetExtra()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'extra');
+        $reflectionProperty->setAccessible(true);
+        $scope = new Scope();
+        $this->assertTrue($reflectionProperty->getValue($scope)->isEmpty());
+        $this->assertEquals($scope->setExtra('foo', 'bar'), $scope);
+        $this->assertEquals(['foo' => 'bar'], $reflectionProperty->getValue($scope)->toArray());
+        $scope->setExtra('foo', 'bar1');
+        $this->assertEquals(['foo' => 'bar1'], $reflectionProperty->getValue($scope)->toArray());
+        $scope->setExtra('bar', 'baz');
+        $this->assertEquals(['foo' => 'bar1', 'bar' => 'baz'], $reflectionProperty->getValue($scope)->toArray());
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testSetFingerprint()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'fingerprint');
+        $reflectionProperty->setAccessible(true);
+        $scope = new Scope();
+        $this->assertEquals([], $reflectionProperty->getValue($scope));
+        $this->assertEquals($scope->setFingerprint(['a']), $scope);
+        $this->assertEquals(['a'], $reflectionProperty->getValue($scope));
+        $scope->setFingerprint(['b']);
+        $this->assertEquals(['b'], $reflectionProperty->getValue($scope));
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testSetLevel()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'level');
+        $reflectionProperty->setAccessible(true);
+        $scope = new Scope();
+        $this->assertNull($reflectionProperty->getValue($scope));
+        $this->assertEquals($scope->setLevel(new Severity(Severity::WARNING)), $scope);
+        $this->assertEquals('warning', $reflectionProperty->getValue($scope));
+        $scope->setLevel(new Severity(Severity::FATAL));
+        $this->assertEquals('fatal', $reflectionProperty->getValue($scope));
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testAddBreadcrumb()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'breadcrumbs');
+        $reflectionProperty->setAccessible(true);
+        $scope = new Scope();
+        $this->assertEquals([], $reflectionProperty->getValue($scope));
+        $scope->addBreadcrumb(new Breadcrumb('warning', Breadcrumb::TYPE_ERROR, 'first'));
+        $this->assertInstanceOf(Breadcrumb::class, $reflectionProperty->getValue($scope)[0]);
+        for ($i = 0; $i <= 5; ++$i) {
+            $scope->addBreadcrumb(new Breadcrumb('warning', Breadcrumb::TYPE_ERROR, 'for'));
+        }
+        $breadcrumbs = $reflectionProperty->getValue($scope);
+        $this->assertEquals('first', $breadcrumbs[0]->getCategory());
+        $this->assertCount(7, $reflectionProperty->getValue($scope));
+        $scope->addBreadcrumb(new Breadcrumb('warning', Breadcrumb::TYPE_ERROR, 'last'), 7);
+        $breadcrumbs = $reflectionProperty->getValue($scope);
+        $this->assertCount(7, $reflectionProperty->getValue($scope));
+        $this->assertEquals('last', \end($breadcrumbs)->getCategory());
+        $this->assertEquals('for', $breadcrumbs[0]->getCategory());
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testClear()
+    {
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'breadcrumbs');
+        $reflectionProperty->setAccessible(true);
+        $scope = new Scope();
+        $this->assertEquals($scope->addBreadcrumb(new Breadcrumb('warning', Breadcrumb::TYPE_ERROR, 'first')), $scope);
+        $scope->clear();
+        $this->assertCount(0, $reflectionProperty->getValue($scope));
+        $reflectionProperty->setAccessible(false);
+    }
+}


### PR DESCRIPTION
This is a non-exhaustive list containing todo's to refactor the current `2.0` branch to conform the unified SDK API see: https://docs.sentry.io/clientdev/unified-api/
In general, all points are up for discussion. This should be a rough guideline to hold on to while we progress through it.

- [ ] Up minimum PHP version to 7.1 and use features (like: Return type declarations, nullable types, Throwable, …)
- [ ] General wording changes to functions (e.g.: `leaveBreadcrumb` -> `addBreadcrumb`, `Config` -> `Options`)
- [ ] Change Sentry protocol version to 7
- [ ] Update SDK identifier + User Agent (`sentry.php`)
- [x] `Context` → `Scope`
- [x] Create `Hub` which takes some responsibility of the `Client` / `ClientBuilder`
- [ ] Breakup Client
  - [x] Move `getLastEventID` to Hub
  - [ ] Move breadcrumbs, context information into Scope
  - [ ] Refactor `Middleware`'s to Integrations
  - [ ] Remove some public setter/getter
- [ ] DSN → We no longer need `path` (`projectRoot`)
- [ ] `shouldCapture` → `beforeSend`
- [ ] Do not `setTags` in `Configuration`
- [ ] `Stacktrace` should be `stacktrace.values[].frames`
- [ ] `Breadcrumbs` should be `breadcrumbs.values[].crumb`
- [ ] Remove base64 encoding
- [ ] Remove `sanitization`
- [ ] Remove docs from repo, they new live in https://github.com/getsentry/sentry-docs
- [ ] Write + Update Docs https://github.com/getsentry/sentry-php/issues/650