### PR TITLE
[2.0] feat: Add global SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ cs-fix:
 	vendor/bin/php-cs-fixer fix --config=.php_cs
 
 phpstan:
-	vendor/bin/phpstan analyse src tests -c phpstan.neon -l 7
+	vendor/bin/phpstan analyse
 
 test: cs-fix phpstan
 	vendor/bin/phpunit --verbose

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ cs-fix:
 	vendor/bin/php-cs-fixer fix --config=.php_cs
 
 phpstan:
-	vendor/bin/phpstan analyse
+	vendor/bin/phpstan analyse src tests -c phpstan.neon -l 7
 
 test: cs-fix phpstan
-	vendor/bin/phpunit
+	vendor/bin/phpunit --verbose
 
 setup-git:
 	git config branch.autosetuprebase always

--- a/composer.json
+++ b/composer.json
@@ -47,11 +47,13 @@
         "bin/sentry"
     ],
     "autoload": {
+        "files": ["src/Sdk.php"],
         "psr-4" : {
             "Sentry\\" : "src/"
         }
     },
     "autoload-dev": {
+        "files": ["src/Sdk.php"],
         "psr-4": {
             "Sentry\\Tests\\": "tests/"
         }

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         }
     },
     "autoload-dev": {
-        "files": ["src/Sdk.php"],
         "psr-4": {
             "Sentry\\Tests\\": "tests/"
         }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -131,7 +131,7 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public static function create(array $options = [])
+    public static function create(array $options = []): self
     {
         return new static($options);
     }
@@ -239,7 +239,7 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function getClient()
+    public function getClient(): Client
     {
         $this->messageFactory = $this->messageFactory ?? MessageFactoryDiscovery::find();
         $this->uriFactory = $this->uriFactory ?? UriFactoryDiscovery::find();

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -239,7 +239,7 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function getClient(): Client
+    public function getClient(): ClientInterface
     {
         $this->messageFactory = $this->messageFactory ?? MessageFactoryDiscovery::find();
         $this->uriFactory = $this->uriFactory ?? UriFactoryDiscovery::find();

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -119,7 +119,7 @@ interface ClientBuilderInterface
     /**
      * Gets the instance of the client built using the configured options.
      *
-     * @return Client
+     * @return ClientInterface
      */
-    public function getClient(): Client;
+    public function getClient(): ClientInterface;
 }

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -119,7 +119,7 @@ interface ClientBuilderInterface
     /**
      * Gets the instance of the client built using the configured options.
      *
-     * @return ClientInterface
+     * @return Client
      */
-    public function getClient();
+    public function getClient(): Client;
 }

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -5,52 +5,59 @@ namespace Sentry;
 use Sentry\Breadcrumbs\Breadcrumb;
 use Sentry\State\Hub;
 
+/**
+ * Creates a new Client and Hub which will be set as current.
+ *
+ * @param array $options
+ */
 function init(array $options = []): void
 {
     Hub::setCurrent(new Hub(ClientBuilder::create($options)->getClient()));
 }
 
 /**
- * Capture a message and send it to Sentry.
+ * Captures a message event and sends it to Sentry.
  *
- * @param string $message
+ * @param string   $message The message
+ * @param Severity $level   The severity level of the message
  *
- * @return string
+ * @return null|string
  */
-function captureMessage(string $message): ?string
+function captureMessage(string $message, ?Severity $level = null): ?string
 {
-    return Hub::getCurrent()->captureMessage($message);
+    return Hub::getCurrent()->captureMessage($message, $level);
 }
 
 /**
- * Capture a \Throwable and send it to Sentry.
+ * Captures an exception event and sends it to Sentry.
  *
- * @param \Throwable $exception
+ * @param \Throwable $exception The exception
  *
- * @return string
+ * @return null|string
  */
-function captureException($exception): ?string
+function captureException(\Throwable $exception): ?string
 {
     return Hub::getCurrent()->captureException($exception);
 }
 
-// TODO
-///**
-// * Captures and event and send it to Sentry.
-// *
-// * @param Event $event
-// *
-// * @return null|string
-// */
-//function captureEvent(Event $event): ?string
-//{
-//    return Hub::getCurrent()->captureEvent($event);
-//}
+/**
+ * Captures a new event using the provided data.
+ *
+ * @param array $payload The data of the event being captured
+ *
+ * @return null|string
+ */
+function captureEvent(array $payload): ?string
+{
+    return Hub::getCurrent()->captureEvent($payload);
+}
 
 /**
- * Add a breadcrumb which will be send with the next event.
+ * Records a new breadcrumb which will be attached to future events. They
+ * will be added to subsequent events to provide more context on user's
+ * actions prior to an error or crash.
  *
- * @param Breadcrumb $breadcrumb
+ * @param Breadcrumb $breadcrumb The breadcrumb to record
  */
 function addBreadcrumb(Breadcrumb $breadcrumb): void
 {
@@ -58,21 +65,23 @@ function addBreadcrumb(Breadcrumb $breadcrumb): void
 }
 
 /**
- * Configure the current scope to send context information with the event.
+ * Calls the given callback passing to it the current scope so that any
+ * operation can be run within its context.
  *
- * @param \Closure $callback
+ * @param callable $callback The callback to be executed
  */
-function configureScope(\Closure $callback): void
+function configureScope(callable $callback): void
 {
     Hub::getCurrent()->configureScope($callback);
 }
 
 /**
- * Pushes and Pops a Scope. Use this to have an isolated state before sending a event.
+ * Creates a new scope with and executes the given operation within. The scope
+ * is automatically removed once the operation finishes or throws.
  *
- * @param \Closure $callback
+ * @param callable $callback The callback to be executed
  */
-function withScope(\Closure $callback): void
+function withScope(callable $callback): void
 {
     Hub::getCurrent()->withScope($callback);
 }

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Sentry;
+
+use Sentry\Breadcrumbs\Breadcrumb;
+use Sentry\State\Hub;
+
+function init(array $options = []): void
+{
+    Hub::setCurrent(new Hub(ClientBuilder::create($options)->getClient()));
+}
+
+/**
+ * Capture a message and send it to Sentry.
+ *
+ * @param string $message
+ *
+ * @return string
+ */
+function captureMessage(string $message): ?string
+{
+    return Hub::getCurrent()->captureMessage($message);
+}
+
+/**
+ * Capture a \Throwable and send it to Sentry.
+ *
+ * @param \Throwable $exception
+ *
+ * @return string
+ */
+function captureException($exception): ?string
+{
+    return Hub::getCurrent()->captureException($exception);
+}
+
+// TODO
+///**
+// * Captures and event and send it to Sentry.
+// *
+// * @param Event $event
+// *
+// * @return null|string
+// */
+//function captureEvent(Event $event): ?string
+//{
+//    return Hub::getCurrent()->captureEvent($event);
+//}
+
+/**
+ * Add a breadcrumb which will be send with the next event.
+ *
+ * @param Breadcrumb $breadcrumb
+ */
+function addBreadcrumb(Breadcrumb $breadcrumb): void
+{
+    Hub::getCurrent()->addBreadcrumb($breadcrumb);
+}
+
+/**
+ * Configure the current scope to send context information with the event.
+ *
+ * @param \Closure $callback
+ */
+function configureScope(\Closure $callback): void
+{
+    Hub::getCurrent()->configureScope($callback);
+}
+
+/**
+ * Pushes and Pops a Scope. Use this to have an isolated state before sending a event.
+ *
+ * @param \Closure $callback
+ */
+function withScope(\Closure $callback): void
+{
+    Hub::getCurrent()->withScope($callback);
+}

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -214,6 +214,24 @@ final class Hub
     }
 
     /**
+     * Captures a new event using the provided data.
+     *
+     * @param array $payload The data of the event being captured
+     *
+     * @return null|string
+     */
+    public function captureEvent(array $payload): ?string
+    {
+        $client = $this->getClient();
+
+        if (null !== $client) {
+            return $this->lastEventId = $client->capture($payload);
+        }
+
+        return null;
+    }
+
+    /**
      * Records a new breadcrumb which will be attached to future events. They
      * will be added to subsequent events to provide more context on user's
      * actions prior to an error or crash.

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -34,6 +34,13 @@ final class Hub
     /**
      * Constructor.
      *
+     * @var Hub
+     */
+    public static $currentHub;
+
+    /**
+     * Hub constructor.
+     *
      * @param ClientInterface|null $client The client bound to the hub
      * @param Scope|null           $scope  The scope bound to the hub
      */
@@ -220,5 +227,33 @@ final class Hub
         if (null !== $client) {
             $client->addBreadcrumb($breadcrumb, $this->getScope());
         }
+    }
+
+    /**
+     * Returns the current global Hub.
+     *
+     * @return Hub
+     */
+    public static function getCurrent(): self
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new self();
+        }
+
+        return self::$currentHub;
+    }
+
+    /**
+     * Sets the Hub as the current.
+     *
+     * @param self $hub
+     *
+     * @return Hub
+     */
+    public static function setCurrent(self $hub): self
+    {
+        self::$currentHub = $hub;
+
+        return $hub;
     }
 }

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -36,7 +36,7 @@ final class Hub
      *
      * @var Hub
      */
-    public static $currentHub;
+    private static $currentHub;
 
     /**
      * Hub constructor.

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\State\Hub;
+use function Sentry\init;
+
+class SdkTest extends TestCase
+{
+    public function testInit()
+    {
+        init();
+        $this->assertNotNull(Hub::getCurrent()->getClient());
+    }
+}

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -1,16 +1,111 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sentry\Tests;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sentry\Breadcrumbs\Breadcrumb;
+use Sentry\ClientInterface;
 use Sentry\State\Hub;
+use function Sentry\addBreadcrumb;
+use function Sentry\captureEvent;
+use function Sentry\captureException;
+use function Sentry\captureMessage;
+use function Sentry\configureScope;
 use function Sentry\init;
+use function Sentry\withScope;
 
 class SdkTest extends TestCase
 {
-    public function testInit()
+    protected function setUp(): void
     {
         init();
+    }
+
+    public function testInit(): void
+    {
         $this->assertNotNull(Hub::getCurrent()->getClient());
+    }
+
+    public function testCaptureMessage(): void
+    {
+        /** @var ClientInterface|MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureMessage')
+            ->with('foo', [], ['level' => null])
+            ->willReturn('92db40a886c0458288c7c83935a350ef');
+
+        Hub::getCurrent()->bindClient($client);
+        $this->assertEquals($client, Hub::getCurrent()->getClient());
+        $this->assertEquals('92db40a886c0458288c7c83935a350ef', captureMessage('foo'));
+    }
+
+    public function testCaptureException(): void
+    {
+        $exception = new \RuntimeException('foo');
+
+        /** @var ClientInterface|MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureException')
+            ->with($exception)
+            ->willReturn('2b867534eead412cbdb882fd5d441690');
+
+        Hub::getCurrent()->bindClient($client);
+
+        $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureException($exception));
+    }
+
+    public function testCaptureEvent(): void
+    {
+        /** @var ClientInterface|MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('capture')
+            ->with(['message' => 'test'])
+            ->willReturn('2b867534eead412cbdb882fd5d441690');
+
+        Hub::getCurrent()->bindClient($client);
+
+        $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureEvent(['message' => 'test']));
+    }
+
+    public function testAddBreadcrumb(): void
+    {
+        $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
+
+        /** @var ClientInterface|MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('addBreadcrumb')
+            ->with($breadcrumb, Hub::getCurrent()->getScope());
+
+        Hub::getCurrent()->bindClient($client);
+        addBreadcrumb($breadcrumb);
+    }
+
+    public function testWithScope(): void
+    {
+        $callbackInvoked = false;
+
+        withScope(function () use (&$callbackInvoked): void {
+            $callbackInvoked = true;
+        });
+
+        $this->assertTrue($callbackInvoked);
+    }
+
+    public function configureScope(): void
+    {
+        $callbackInvoked = false;
+
+        configureScope(function () use (&$callbackInvoked): void {
+            $callbackInvoked = true;
+        });
+
+        $this->assertTrue($callbackInvoked);
     }
 }

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -262,4 +262,18 @@ final class HubTest extends TestCase
         $hub = new Hub($client, $scope);
         $hub->addBreadcrumb($breadcrumb);
     }
+
+    public function testCaptureEvent(): void
+    {
+        /** @var ClientInterface|MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('capture')
+            ->with(['message' => 'test'])
+            ->willReturn('2b867534eead412cbdb882fd5d441690');
+
+        $hub = new Hub($client);
+
+        $this->assertEquals('2b867534eead412cbdb882fd5d441690', $hub->captureEvent(['message' => 'test']));
+    }
 }


### PR DESCRIPTION
This PR add the "global" SDK to the SDK 🙃 
Which means it should enable stuff like:

```php
init(["dsn" => "DSN"]);

captureMessage("test");
```

Internally it uses a `Hub`, `Scope` and `Client` to make everything work.