### PR TITLE
[2.0] Restrict conflict with php-http/client-common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "monolog/monolog": "Automatically capture Monolog events as breadcrumbs"
     },
     "conflict": {
-        "php-http/client-common": "^1.8.0",
+        "php-http/client-common": "1.8.0",
         "raven/raven": "*"
     },
     "bin": [


### PR DESCRIPTION
In #658 I did found an issue with php-http/client-common 1.8.0, precisely https://github.com/php-http/client-common/issues/109. The problematic code is now reverted, so we can reduce the conflict constraint to the only bugged version.