### PR TITLE
Added passing data from context in monolog breadcrumb handler

### DIFF
--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -92,6 +92,7 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
                     'level' => $this->logLevels[$record['level']],
                     'category' => $record['channel'],
                     'message' => $record['message'],
+                    'data' => $record['context'],
                 );
             }
         }

--- a/test/Raven/Tests/Breadcrumbs/MonologTest.php
+++ b/test/Raven/Tests/Breadcrumbs/MonologTest.php
@@ -51,6 +51,27 @@ EOF;
         $this->assertEquals($crumbs[0]['level'], 'warning');
     }
 
+    public function testContext()
+    {
+        $client = new \Raven_Client(array(
+            'install_default_breadcrumb_handlers' => false,
+        ));
+        $handler = new \Raven_Breadcrumbs_MonologHandler($client);
+        
+        $context = array('Foo' => 'Bar');
+
+        $logger = new Monolog\Logger('sentry');
+        $logger->pushHandler($handler);
+        $logger->addWarning('Foo', $context);
+
+        $crumbs = $client->breadcrumbs->fetch();
+        $this->assertEquals(count($crumbs), 1);
+        $this->assertEquals($crumbs[0]['message'], 'Foo');
+        $this->assertEquals($crumbs[0]['category'], 'sentry');
+        $this->assertEquals($crumbs[0]['level'], 'warning');
+        $this->assertEquals($crumbs[0]['data'], $context);
+    }
+
     public function testErrorInMessage()
     {
         $client = new \Raven_Client(array(


### PR DESCRIPTION
This simple change is very useful for breadcrumbs when using monolog. My app uses Monolog via Laravel and I think others will want this behavior too.

Before:
<img width="834" alt="screen shot 2018-10-31 at 2 31 58 pm" src="https://user-images.githubusercontent.com/207171/47813779-f6d6e700-dd19-11e8-804a-d803a346fad6.png">

After:
<img width="862" alt="screen shot 2018-10-31 at 2 32 21 pm" src="https://user-images.githubusercontent.com/207171/47813783-f9d1d780-dd19-11e8-88ff-ce61f764e017.png">