### PR TITLE
[2.0] Do not break in sanitize

### DIFF
--- a/src/Middleware/SanitizeDataMiddleware.php
+++ b/src/Middleware/SanitizeDataMiddleware.php
@@ -99,16 +99,17 @@ final class SanitizeDataMiddleware implements ProcessorMiddlewareInterface
                         $value = self::STRING_MASK;
                     });
 
-                    break;
+                    continue;
                 }
 
                 $item = self::STRING_MASK;
+                continue;
             }
 
             if (\is_array($item)) {
                 $this->sanitize($item);
 
-                break;
+                continue;
             }
 
             if (preg_match($this->options['values_re'], $item)) {

--- a/tests/Middleware/SanitizeDataMiddlewareTest.php
+++ b/tests/Middleware/SanitizeDataMiddlewareTest.php
@@ -234,6 +234,50 @@ class SanitizeDataMiddlewareTest extends MiddlewareTestCase
                     ],
                 ],
             ],
+            [
+                [
+                    'request' => [
+                        'data' => [
+                            'array' => [
+                                'foo' => 'bar',
+                            ],
+                            'password' => 'hello',
+                        ],
+                    ],
+                ],
+                [
+                    'request' => [
+                        'data' => [
+                            'array' => [
+                                'foo' => 'bar',
+                            ],
+                            'password' => SanitizeDataMiddleware::STRING_MASK,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'request' => [
+                        'data' => [
+                            'password' => [
+                                'foo' => 'bar',
+                            ],
+                            'the_secret' => 'hello',
+                        ],
+                    ],
+                ],
+                [
+                    'request' => [
+                        'data' => [
+                            'password' => [
+                                'foo' => SanitizeDataMiddleware::STRING_MASK,
+                            ],
+                            'the_secret' => SanitizeDataMiddleware::STRING_MASK,
+                        ],
+                    ],
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
The breaks in the sanitize method will stop sanitizing at the first array and/or sensitive data match failing to replace any sensitive data further down the data being sanitized.