### PR TITLE
Monolog > Pass `context` with breadcrumb

### DIFF
--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -92,6 +92,7 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
                     'level' => $this->logLevels[$record['level']],
                     'category' => $record['channel'],
                     'message' => $record['message'],
+                    'data' => $record['context'],
                 );
             }
         }

--- a/test/Raven/Tests/Breadcrumbs/MonologTest.php
+++ b/test/Raven/Tests/Breadcrumbs/MonologTest.php
@@ -42,11 +42,14 @@ EOF;
 
         $logger = new Monolog\Logger('sentry');
         $logger->pushHandler($handler);
-        $logger->addWarning('Foo');
+        $logger->addWarning('Foo {error}', array(
+            'error' => 'Bar',
+        ));
 
         $crumbs = $client->breadcrumbs->fetch();
         $this->assertEquals(count($crumbs), 1);
-        $this->assertEquals($crumbs[0]['message'], 'Foo');
+        $this->assertEquals($crumbs[0]['message'], 'Foo {error}');
+        $this->assertEquals($crumbs[0]['data'], array('error' => 'Bar'));
         $this->assertEquals($crumbs[0]['category'], 'sentry');
         $this->assertEquals($crumbs[0]['level'], 'warning');
     }


### PR DESCRIPTION
Because this is not very useful:
<img width="889" alt="screenshot 2018-11-07 at 12 56 16" src="https://user-images.githubusercontent.com/104180/48130315-8df8ed00-e28c-11e8-97a2-8b40a0b3dcbc.png">
