### PR TITLE
Merge extra contexts to contexts

### DIFF
--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -975,6 +975,9 @@ class Raven_Client
                 $data['contexts'] = $data['extra']['contexts'];
             }
             unset($data['extra']['contexts']);
+            if (empty($data['extra'])) {
+                unset($data['extra']);
+            }
         }
         if (!empty($data['breadcrumbs'])) {
             $data['breadcrumbs'] = $this->serializer->serialize($data['breadcrumbs'], 5);

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -968,6 +968,14 @@ class Raven_Client
         if (!empty($data['contexts'])) {
             $data['contexts'] = $this->serializer->serialize($data['contexts'], 5);
         }
+        if (!empty($data['extra']['contexts'])) {
+            if (!empty($data['contexts'])) {
+                $data['contexts'] = array_merge($data['contexts'], $data['extra']['contexts']);
+            } else {
+                $data['contexts'] = $data['extra']['contexts'];
+            }
+            unset($data['extra']['contexts']);
+        }
         if (!empty($data['breadcrumbs'])) {
             $data['breadcrumbs'] = $this->serializer->serialize($data['breadcrumbs'], 5);
         }


### PR DESCRIPTION
This Fix solved the Problem with extra data to contexts.
See also: https://github.com/Seldaek/monolog/pull/1214/files/4a86052a6e621284ca19eec4e9c94f647f0dd16d

Example: 
$sentry->extra_context([
    'contexts' => ['browser' => [
        'version' => '32.0',
        'name' => 'Firefox'
    ]]