### PR TITLE
Serialize arrays in a readable format instead of just counting the items.

### DIFF
--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -29,11 +29,11 @@ class Raven_ReprSerializer extends Raven_Serializer
         } elseif (is_integer($value) || is_float($value)) {
             return (string) $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-            return 'Object '.$this->serializeObject($value);
+	        return 'Object '.get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {
-            return 'Array '.$this->serializeArray($value);
+            return $this->serializeArray($value);
         } else {
             return $this->serializeString($value);
         }

--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -29,7 +29,7 @@ class Raven_ReprSerializer extends Raven_Serializer
         } elseif (is_integer($value) || is_float($value)) {
             return (string) $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-	        return 'Object '.get_class($value);
+            return 'Object '.get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {

--- a/lib/Raven/ReprSerializer.php
+++ b/lib/Raven/ReprSerializer.php
@@ -29,11 +29,11 @@ class Raven_ReprSerializer extends Raven_Serializer
         } elseif (is_integer($value) || is_float($value)) {
             return (string) $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-            return 'Object '.get_class($value);
+            return 'Object '.$this->serializeObject($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {
-            return 'Array of length ' . count($value);
+            return 'Array '.$this->serializeArray($value);
         } else {
             return $this->serializeString($value);
         }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -118,12 +118,7 @@ class Raven_Serializer
 
     protected function serializeArray(array $array)
     {
-        return $this->cleanupWhitespace(@var_export($array, true));
-    }
-
-    protected function serializeObject($object)
-    {
-        return get_class($object) . ' ' . $this->serializeArray(get_object_vars($object));
+        return $this->cleanupWhitespace(print_r($array, true));
     }
 
     private function cleanupWhitespace($string)
@@ -140,11 +135,11 @@ class Raven_Serializer
         if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
             return $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-            return 'Object '.$this->serializeObject($value);
+	        return 'Object '.get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {
-            return 'Array '.$this->serializeArray($value);
+            return $this->serializeArray($value);
         } else {
             return $this->serializeString($value);
         }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -116,6 +116,21 @@ class Raven_Serializer
         return $value;
     }
 
+    protected function serializeArray(array $array)
+    {
+        return $this->cleanupWhitespace(@var_export($array, true));
+    }
+
+    protected function serializeObject($object)
+    {
+        return get_class($object) . ' ' . $this->serializeArray(get_object_vars($object));
+    }
+
+    private function cleanupWhitespace($string)
+    {
+        return preg_replace('/\s+/', ' ', $string);
+    }
+
     /**
      * @param mixed $value
      * @return string|bool|double|int|null
@@ -125,11 +140,11 @@ class Raven_Serializer
         if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
             return $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-            return 'Object '.get_class($value);
+            return 'Object '.$this->serializeObject($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {
-            return 'Array of length ' . count($value);
+            return 'Array '.$this->serializeArray($value);
         } else {
             return $this->serializeString($value);
         }

--- a/lib/Raven/Serializer.php
+++ b/lib/Raven/Serializer.php
@@ -135,7 +135,7 @@ class Raven_Serializer
         if (is_null($value) || is_bool($value) || is_float($value) || is_integer($value)) {
             return $value;
         } elseif (is_object($value) || gettype($value) == 'object') {
-	        return 'Object '.get_class($value);
+            return 'Object '.get_class($value);
         } elseif (is_resource($value)) {
             return 'Resource '.get_resource_type($value);
         } elseif (is_array($value)) {

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1403,7 +1403,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
             'context' => array(
                 'line' => 1216,
                 'stack' => array(
-                    1, 'Array of length 1', 3
+                    1, 'Array array ( 0 => 2, )', 3
                 ),
             ),
         )), $data);
@@ -1528,7 +1528,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 'data' => array(
                     'Level 1' => array(
                         'Level 2' => array(
-                            'Level 3' => 'Array of length 1',
+                            'Level 3' => "Array array ( 'Level 4' => 'something', )",
                         ),
                     ),
                 ),
@@ -1561,7 +1561,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 'stack' => array(
                     1, array(
                         'foo' => 'bar',
-                        'level4' => array('Array of length 2', 2),
+                        'level4' => array("Array array ( 0 => 'level5', 1 => 'level5 a', )", 2),
                     ), 3
                 ),
             ),

--- a/test/Raven/Tests/ClientTest.php
+++ b/test/Raven/Tests/ClientTest.php
@@ -1403,7 +1403,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
             'context' => array(
                 'line' => 1216,
                 'stack' => array(
-                    1, 'Array array ( 0 => 2, )', 3
+                    1, 'Array ( [0] => 2 ) ', 3
                 ),
             ),
         )), $data);
@@ -1528,7 +1528,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 'data' => array(
                     'Level 1' => array(
                         'Level 2' => array(
-                            'Level 3' => "Array array ( 'Level 4' => 'something', )",
+                            'Level 3' => "Array ( [Level 4] => something ) ",
                         ),
                     ),
                 ),
@@ -1561,7 +1561,7 @@ class Raven_Tests_ClientTest extends \PHPUnit\Framework\TestCase
                 'stack' => array(
                     1, array(
                         'foo' => 'bar',
-                        'level4' => array("Array array ( 0 => 'level5', 1 => 'level5 a', )", 2),
+                        'level4' => array("Array ( [0] => level5 [1] => level5 a ) ", 2),
                     ), 3
                 ),
             ),

--- a/test/Raven/Tests/ReprSerializerTest.php
+++ b/test/Raven/Tests/ReprSerializerTest.php
@@ -24,7 +24,7 @@ class Raven_Tests_ReprSerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_ReprSerializer();
         $input = new Raven_StacktraceTestObject();
         $result = $serializer->serialize($input);
-        $this->assertEquals('Object Raven_StacktraceTestObject', $result);
+        $this->assertEquals('Object Raven_StacktraceTestObject array ( )', $result);
     }
 
     public function testIntsAreInts()
@@ -73,7 +73,7 @@ class Raven_Tests_ReprSerializerTest extends \PHPUnit\Framework\TestCase
         $input = array();
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array of length 1'))), $result);
+        $this->assertEquals(array(array(array('Array array ( 0 => NULL, )'))), $result);
     }
 
     /**

--- a/test/Raven/Tests/ReprSerializerTest.php
+++ b/test/Raven/Tests/ReprSerializerTest.php
@@ -24,7 +24,7 @@ class Raven_Tests_ReprSerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_ReprSerializer();
         $input = new Raven_StacktraceTestObject();
         $result = $serializer->serialize($input);
-        $this->assertEquals('Object Raven_StacktraceTestObject array ( )', $result);
+        $this->assertEquals('Object Raven_StacktraceTestObject', $result);
     }
 
     public function testIntsAreInts()
@@ -73,7 +73,7 @@ class Raven_Tests_ReprSerializerTest extends \PHPUnit\Framework\TestCase
         $input = array();
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array array ( 0 => NULL, )'))), $result);
+        $this->assertEquals(array(array(array('Array ( [0] => Array *RECURSION* ) '))), $result);
     }
 
     /**

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -93,7 +93,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_Serializer();
         $input = array('foo' => new Raven_Serializer());
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => "Object Raven_Serializer"), $result);
+        $this->assertEquals(array('foo' => 'Object Raven_Serializer'), $result);
     }
 
     /**

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -38,7 +38,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_Serializer();
         $input = new Raven_SerializerTestObject();
         $result = $serializer->serialize($input);
-        $this->assertEquals('Object Raven_SerializerTestObject', $result);
+        $this->assertEquals('Object Raven_SerializerTestObject array ( )', $result);
     }
 
     public function testIntsAreInts()
@@ -85,7 +85,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $input = array();
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array of length 1'))), $result);
+        $this->assertEquals(array(array(array('Array array ( 0 => NULL, )'))), $result);
     }
 
     public function testObjectInArray()
@@ -93,7 +93,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_Serializer();
         $input = array('foo' => new Raven_Serializer());
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => 'Object Raven_Serializer'), $result);
+        $this->assertEquals(array('foo' => "Object Raven_Serializer array ( 'mb_detect_order' => 'auto', 'message_limit' => 1024, )"), $result);
     }
 
     /**

--- a/test/Raven/Tests/SerializerTest.php
+++ b/test/Raven/Tests/SerializerTest.php
@@ -38,7 +38,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_Serializer();
         $input = new Raven_SerializerTestObject();
         $result = $serializer->serialize($input);
-        $this->assertEquals('Object Raven_SerializerTestObject array ( )', $result);
+        $this->assertEquals('Object Raven_SerializerTestObject', $result);
     }
 
     public function testIntsAreInts()
@@ -85,7 +85,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $input = array();
         $input[] = &$input;
         $result = $serializer->serialize($input, 3);
-        $this->assertEquals(array(array(array('Array array ( 0 => NULL, )'))), $result);
+        $this->assertEquals(array(array(array('Array ( [0] => Array *RECURSION* ) '))), $result);
     }
 
     public function testObjectInArray()
@@ -93,7 +93,7 @@ class Raven_Tests_SerializerTest extends \PHPUnit\Framework\TestCase
         $serializer = new Raven_Serializer();
         $input = array('foo' => new Raven_Serializer());
         $result = $serializer->serialize($input);
-        $this->assertEquals(array('foo' => "Object Raven_Serializer array ( 'mb_detect_order' => 'auto', 'message_limit' => 1024, )"), $result);
+        $this->assertEquals(array('foo' => "Object Raven_Serializer"), $result);
     }
 
     /**


### PR DESCRIPTION
We do currently have the problem that we are getting an exception where we can not really reproduce the issue but some of our users are running into the issue. Even though we are able to fail gracefully here, we'd like to resolve the issue.

However, the raven client for PHP serializes arrays in a not very helpful way by just counting the array items, which leads to event data like this:

![](http://i.imgur.com/aL0eMCf.png)

With the proposed changes this changes to (amongst other points where arrays show up):

![](http://i.imgur.com/zDyg6aM.png)

Which is evidently much more helpful as we can see the user input and reproduce the problem now.

Would be awesome if we could put that into one of the next releases for the official client so we can switch back to that from our forked one. 

I adjusted the tests accordingly, let me know if I should change anything else and keep up the good work!


