### PR TITLE
[2.0] fix: gzip compressed requests

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -14,6 +14,7 @@ namespace Sentry;
 use Http\Client\Common\Plugin;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
 use Http\Client\Common\Plugin\BaseUriPlugin;
+use Http\Client\Common\Plugin\DecoderPlugin;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\HeaderSetPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
@@ -262,6 +263,10 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->addHttpClientPlugin(new AuthenticationPlugin(new SentryAuth($this->options)));
         $this->addHttpClientPlugin(new RetryPlugin(['retries' => $this->options->getSendAttempts()]));
         $this->addHttpClientPlugin(new ErrorPlugin());
+
+        if ('gzip' === $this->options->getEncoding()) {
+            $this->addHttpClientPlugin(new DecoderPlugin());
+        }
 
         return new PluginClient($this->httpClient, $this->httpClientPlugins);
     }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -264,7 +264,7 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->addHttpClientPlugin(new RetryPlugin(['retries' => $this->options->getSendAttempts()]));
         $this->addHttpClientPlugin(new ErrorPlugin());
 
-        if ('gzip' === $this->options->getEncoding()) {
+        if ($this->options->isCompressionEnabled()) {
             $this->addHttpClientPlugin(new DecoderPlugin());
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -233,23 +233,23 @@ class Options
     }
 
     /**
-     * Gets the encoding type for event bodies (GZIP or JSON).
+     * Returns is compression is enabled.
      *
-     * @return string
+     * @return bool
      */
-    public function getEncoding()
+    public function isCompressionEnabled(): bool
     {
-        return $this->options['encoding'];
+        return $this->options['enableCompression'];
     }
 
     /**
-     * Sets the encoding type for event bodies (GZIP or JSON).
+     * Sets if the request should be compressed or not.
      *
-     * @param string $encoding The encoding type
+     * @param bool $enabled Should compression be enabled
      */
-    public function setEncoding($encoding)
+    public function setEnableCompression(bool $enabled): void
     {
-        $options = array_merge($this->options, ['encoding' => $encoding]);
+        $options = array_merge($this->options, ['enableCompression' => $enabled]);
 
         $this->options = $this->resolver->resolve($options);
     }
@@ -672,7 +672,7 @@ class Options
             'mb_detect_order' => null,
             'auto_log_stacks' => true,
             'context_lines' => 3,
-            'encoding' => 'gzip',
+            'enableCompression' => true,
             'current_environment' => 'default',
             'environments' => [],
             'excluded_loggers' => [],
@@ -701,7 +701,7 @@ class Options
         $resolver->setAllowedTypes('mb_detect_order', ['null', 'array', 'string']);
         $resolver->setAllowedTypes('auto_log_stacks', 'bool');
         $resolver->setAllowedTypes('context_lines', 'int');
-        $resolver->setAllowedTypes('encoding', 'string');
+        $resolver->setAllowedTypes('enableCompression', 'bool');
         $resolver->setAllowedTypes('current_environment', 'string');
         $resolver->setAllowedTypes('environments', 'array');
         $resolver->setAllowedTypes('excluded_loggers', 'array');
@@ -733,7 +733,6 @@ class Options
             return true;
         });
 
-        $resolver->setAllowedValues('encoding', ['gzip', 'json']);
         $resolver->setAllowedValues('dsn', function ($value) {
             if (empty($value)) {
                 return true;

--- a/src/Options.php
+++ b/src/Options.php
@@ -233,23 +233,23 @@ class Options
     }
 
     /**
-     * Returns is compression is enabled.
+     * Returns whether the requests should be compressed using GZIP or not.
      *
      * @return bool
      */
     public function isCompressionEnabled(): bool
     {
-        return $this->options['enableCompression'];
+        return $this->options['enable_compression'];
     }
 
     /**
-     * Sets if the request should be compressed or not.
+     * Sets whether the request should be compressed using JSON or not.
      *
-     * @param bool $enabled Should compression be enabled
+     * @param bool $enabled Flag indicating whether the request should be compressed
      */
     public function setEnableCompression(bool $enabled): void
     {
-        $options = array_merge($this->options, ['enableCompression' => $enabled]);
+        $options = array_merge($this->options, ['enable_compression' => $enabled]);
 
         $this->options = $this->resolver->resolve($options);
     }
@@ -672,7 +672,7 @@ class Options
             'mb_detect_order' => null,
             'auto_log_stacks' => true,
             'context_lines' => 3,
-            'enableCompression' => true,
+            'enable_compression' => true,
             'current_environment' => 'default',
             'environments' => [],
             'excluded_loggers' => [],
@@ -701,7 +701,7 @@ class Options
         $resolver->setAllowedTypes('mb_detect_order', ['null', 'array', 'string']);
         $resolver->setAllowedTypes('auto_log_stacks', 'bool');
         $resolver->setAllowedTypes('context_lines', 'int');
-        $resolver->setAllowedTypes('enableCompression', 'bool');
+        $resolver->setAllowedTypes('enable_compression', 'bool');
         $resolver->setAllowedTypes('current_environment', 'string');
         $resolver->setAllowedTypes('environments', 'array');
         $resolver->setAllowedTypes('excluded_loggers', 'array');

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -84,7 +84,7 @@ final class HttpTransport implements TransportInterface
     {
         $request = $this->requestFactory->createRequest(
             'POST',
-            sprintf('api/%d/store/', $this->config->getProjectId()),
+            sprintf('/api/%d/store/', $this->config->getProjectId()),
             ['Content-Type' => 'application/json'],
             JSON::encode($event)
         );

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -214,7 +214,7 @@ class ClientBuilderTest extends TestCase
     /**
      * @dataProvider getClientTogglesCompressionPluginInHttpClientDataProvider
      */
-    public function testGetClientTogglesCompressionPluginInHttpClient($enabled): void
+    public function testGetClientTogglesCompressionPluginInHttpClient(bool $enabled): void
     {
         $builder = ClientBuilder::create(['enable_compression' => $enabled, 'dsn' => 'http://public:secret@example.com/sentry/1']);
         $builder->getClient();

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -196,7 +196,7 @@ class ClientBuilderTest extends TestCase
             ['setMbDetectOrder', ['foo', 'bar']],
             ['setAutoLogStacks', false],
             ['setContextLines', 0],
-            ['setEncoding', 'gzip'],
+            ['setEnableCompression', false],
             ['setCurrentEnvironment', 'test'],
             ['setEnvironments', ['default']],
             ['setExcludedLoggers', ['foo', 'bar']],
@@ -213,7 +213,7 @@ class ClientBuilderTest extends TestCase
 
     public function testCompressionPluginAdded()
     {
-        $builder = ClientBuilder::create(['encoding' => 'gzip', 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
+        $builder = ClientBuilder::create(['enableCompression' => true, 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
         $builder->getClient();
         $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'httpClientPlugins');
         $reflectionProperty->setAccessible(true);
@@ -229,7 +229,7 @@ class ClientBuilderTest extends TestCase
 
     public function testCompressionPluginNotAdded()
     {
-        $builder = ClientBuilder::create(['encoding' => 'json', 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
+        $builder = ClientBuilder::create(['enableCompression' => false, 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
         $builder->getClient();
         $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'httpClientPlugins');
         $reflectionProperty->setAccessible(true);

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -211,36 +211,31 @@ class ClientBuilderTest extends TestCase
         ];
     }
 
-    public function testCompressionPluginAdded()
+    /**
+     * @dataProvider compressionOptionDataProvider
+     */
+    public function testCompressionPlugin($enabled)
     {
-        $builder = ClientBuilder::create(['enableCompression' => true, 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
+        $builder = ClientBuilder::create(['enable_compression' => $enabled, 'dsn' => 'http://public:secret@example.com/sentry/1']);
         $builder->getClient();
-        $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'httpClientPlugins');
-        $reflectionProperty->setAccessible(true);
-        $foundDecoderPlugin = false;
-        foreach ($reflectionProperty->getValue($builder) as $plugin) {
+
+        $decoderPluginFound = false;
+        foreach ($this->getObjectAttribute($builder, 'httpClientPlugins') as $plugin) {
             if ($plugin instanceof Plugin\DecoderPlugin) {
-                $foundDecoderPlugin = true;
+                $decoderPluginFound = true;
+                break;
             }
         }
-        $this->assertTrue($foundDecoderPlugin);
-        $reflectionProperty->setAccessible(false);
+
+        $this->assertEquals($enabled, $decoderPluginFound);
     }
 
-    public function testCompressionPluginNotAdded()
+    public function compressionOptionDataProvider()
     {
-        $builder = ClientBuilder::create(['enableCompression' => false, 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
-        $builder->getClient();
-        $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'httpClientPlugins');
-        $reflectionProperty->setAccessible(true);
-        $foundDecoderPlugin = false;
-        foreach ($reflectionProperty->getValue($builder) as $plugin) {
-            if ($plugin instanceof Plugin\DecoderPlugin) {
-                $foundDecoderPlugin = true;
-            }
-        }
-        $this->assertFalse($foundDecoderPlugin);
-        $reflectionProperty->setAccessible(false);
+        return [
+            [true],
+            [false],
+        ];
     }
 }
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -212,17 +212,19 @@ class ClientBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider compressionOptionDataProvider
+     * @dataProvider getClientTogglesCompressionPluginInHttpClientDataProvider
      */
-    public function testCompressionPlugin($enabled)
+    public function testGetClientTogglesCompressionPluginInHttpClient($enabled): void
     {
         $builder = ClientBuilder::create(['enable_compression' => $enabled, 'dsn' => 'http://public:secret@example.com/sentry/1']);
         $builder->getClient();
 
         $decoderPluginFound = false;
+
         foreach ($this->getObjectAttribute($builder, 'httpClientPlugins') as $plugin) {
             if ($plugin instanceof Plugin\DecoderPlugin) {
                 $decoderPluginFound = true;
+
                 break;
             }
         }
@@ -230,7 +232,7 @@ class ClientBuilderTest extends TestCase
         $this->assertEquals($enabled, $decoderPluginFound);
     }
 
-    public function compressionOptionDataProvider()
+    public function getClientTogglesCompressionPluginInHttpClientDataProvider(): array
     {
         return [
             [true],

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -210,6 +210,38 @@ class ClientBuilderTest extends TestCase
             ['setErrorTypes', 0],
         ];
     }
+
+    public function testCompressionPluginAdded()
+    {
+        $builder = ClientBuilder::create(['encoding' => 'gzip', 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
+        $builder->getClient();
+        $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'httpClientPlugins');
+        $reflectionProperty->setAccessible(true);
+        $foundDecoderPlugin = false;
+        foreach ($reflectionProperty->getValue($builder) as $plugin) {
+            if ($plugin instanceof Plugin\DecoderPlugin) {
+                $foundDecoderPlugin = true;
+            }
+        }
+        $this->assertTrue($foundDecoderPlugin);
+        $reflectionProperty->setAccessible(false);
+    }
+
+    public function testCompressionPluginNotAdded()
+    {
+        $builder = ClientBuilder::create(['encoding' => 'json', 'dsn' => 'https://completelyrandom@dsn.asdf/42']);
+        $builder->getClient();
+        $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'httpClientPlugins');
+        $reflectionProperty->setAccessible(true);
+        $foundDecoderPlugin = false;
+        foreach ($reflectionProperty->getValue($builder) as $plugin) {
+            if ($plugin instanceof Plugin\DecoderPlugin) {
+                $foundDecoderPlugin = true;
+            }
+        }
+        $this->assertFalse($foundDecoderPlugin);
+        $reflectionProperty->setAccessible(false);
+    }
 }
 
 class PluginStub1 implements Plugin

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -52,7 +52,7 @@ class OptionsTest extends TestCase
             ['mb_detect_order', ['UTF-8'], 'getMbDetectOrder', 'setMbDetectOrder'],
             ['auto_log_stacks', false, 'getAutoLogStacks', 'setAutoLogStacks'],
             ['context_lines', 3, 'getContextLines', 'setContextLines'],
-            ['enableCompression', false, 'isCompressionEnabled', 'setEnableCompression'],
+            ['enable_compression', false, 'isCompressionEnabled', 'setEnableCompression'],
             ['current_environment', 'foo', 'getCurrentEnvironment', 'setCurrentEnvironment'],
             ['environments', ['foo', 'bar'], 'getEnvironments', 'setEnvironments'],
             ['excluded_loggers', ['bar', 'foo'], 'getExcludedLoggers', 'setExcludedLoggers'],

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -52,7 +52,7 @@ class OptionsTest extends TestCase
             ['mb_detect_order', ['UTF-8'], 'getMbDetectOrder', 'setMbDetectOrder'],
             ['auto_log_stacks', false, 'getAutoLogStacks', 'setAutoLogStacks'],
             ['context_lines', 3, 'getContextLines', 'setContextLines'],
-            ['encoding', 'json', 'getEncoding', 'setEncoding'],
+            ['enableCompression', false, 'isCompressionEnabled', 'setEnableCompression'],
             ['current_environment', 'foo', 'getCurrentEnvironment', 'setCurrentEnvironment'],
             ['environments', ['foo', 'bar'], 'getEnvironments', 'setEnvironments'],
             ['excluded_loggers', ['bar', 'foo'], 'getExcludedLoggers', 'setExcludedLoggers'],

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -86,7 +86,7 @@ class HttpTransportTest extends TestCase
 
     public function testSendWithoutCompressedEncoding()
     {
-        $config = new Options(['enableCompression' => false]);
+        $config = new Options(['enable_compression' => false]);
         $event = new Event();
 
         $promise = $this->createMock(Promise::class);

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -86,7 +86,7 @@ class HttpTransportTest extends TestCase
 
     public function testSendWithoutCompressedEncoding()
     {
-        $config = new Options(['encoding' => 'json']);
+        $config = new Options(['enableCompression' => false]);
         $event = new Event();
 
         $promise = $this->createMock(Promise::class);

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -114,40 +114,6 @@ class HttpTransportTest extends TestCase
         $reflectionMethod->setAccessible(false);
     }
 
-    public function testSendWithCompressedEncoding()
-    {
-        $config = new Options(['encoding' => 'gzip']);
-        $event = new Event();
-
-        $promise = $this->createMock(Promise::class);
-        $promise->expects($this->once())
-            ->method('wait');
-
-        /** @var HttpAsyncClient|\PHPUnit_Framework_MockObject_MockObject $httpClient */
-        $httpClient = $this->createMock(HttpAsyncClient::class);
-        $httpClient->expects($this->once())
-            ->method('sendAsyncRequest')
-            ->with($this->callback(function (RequestInterface $request) use ($event) {
-                $request->getBody()->rewind();
-
-                $compressedPayload = gzcompress(JSON::encode($event));
-
-                $this->assertNotFalse($compressedPayload);
-
-                return 'application/octet-stream' === $request->getHeaderLine('Content-Type')
-                    && $compressedPayload === $request->getBody()->getContents();
-            }))
-            ->willReturn($promise);
-
-        $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find());
-        $transport->send($event);
-
-        $reflectionMethod = new \ReflectionMethod(HttpTransport::class, 'cleanupPendingRequests');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($transport);
-        $reflectionMethod->setAccessible(false);
-    }
-
     public function testSendFailureCleanupPendingRequests()
     {
         /** @var HttpException|\PHPUnit_Framework_MockObject_MockObject $exception */


### PR DESCRIPTION
I think this broke when I removed the base64 encoding.
Before we were compressing the JSON manually and then encoding it with base64, basically sending an uncompressed base64 request.

This now properly sets all requests header and compresses the whole request.

Headers before:
```
POST /api/15/store/ HTTP/1.1
Host: x.eu.ngrok.io
Accept: */*
Transfer-Encoding: chunked
Content-Type: application/octet-stream
User-Agent: sentry.php/2.0.x-dev
X-Sentry-Auth: Sentry sentry_version=7, sentry_client=sentry.php/2.0.x-dev, sentry_timestamp=1542796018.247622, sentry_key=45cca635c50a4e4695681086588e6454
```


Headers with this PR:
```
POST /api/15/store/ HTTP/1.1
Host: x.eu.ngrok.io
Accept: */*
Content-Type: application/json
User-Agent: sentry.php/2.0.x-dev
X-Sentry-Auth: Sentry sentry_version=7, sentry_client=sentry.php/2.0.x-dev, sentry_timestamp=1542797229.347195, sentry_key=45cca635c50a4e4695681086588e6454
Accept-Encoding: gzip
Accept-Encoding: deflate
TE: gzip
TE: deflate
TE: chunked
Content-Length: 14752
```