### PR TITLE
[2.0] `init` remove ClientBuilder arg

### DIFF
--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -9,14 +9,11 @@ use Sentry\State\Hub;
 /**
  * Creates a new Client and Hub which will be set as current.
  *
- * @param array              $options       The client options
- * @param null|ClientBuilder $clientBuilder An optional client builder instance
+ * @param array $options The client options
  */
-function init(array $options = [], ?ClientBuilder $clientBuilder = null): void
+function init(array $options = []): void
 {
-    $builder = $clientBuilder ?? ClientBuilder::create($options);
-
-    Hub::setCurrent(new Hub($builder->getClient()));
+    Hub::setCurrent(new Hub(ClientBuilder::create($options)->getClient()));
 }
 
 /**

--- a/tests/phpt/fatal_error_not_captured_twice.phpt
+++ b/tests/phpt/fatal_error_not_captured_twice.phpt
@@ -10,7 +10,6 @@ use Sentry\Spool\MemorySpool;
 use Sentry\Transport\SpoolTransport;
 use Sentry\ClientBuilder;
 use Sentry\State\Hub;
-use function Sentry\init;
 
 $vendor = __DIR__;
 
@@ -23,9 +22,8 @@ require $vendor . '/vendor/autoload.php';
 $spool = new MemorySpool();
 $transport = new SpoolTransport($spool);
 
-init([]);
-
 $builder = ClientBuilder::create()->setTransport($transport);
+
 Hub::getCurrent()->bindClient($builder->getClient());
 
 register_shutdown_function('register_shutdown_function', function () use ($spool) {

--- a/tests/phpt/fatal_error_not_captured_twice.phpt
+++ b/tests/phpt/fatal_error_not_captured_twice.phpt
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Assert;
 use Sentry\Spool\MemorySpool;
 use Sentry\Transport\SpoolTransport;
 use Sentry\ClientBuilder;
+use Sentry\State\Hub;
 use function Sentry\init;
 
 $vendor = __DIR__;
@@ -22,7 +23,10 @@ require $vendor . '/vendor/autoload.php';
 $spool = new MemorySpool();
 $transport = new SpoolTransport($spool);
 
-init([], ClientBuilder::create()->setTransport($transport));
+init([]);
+
+$builder = ClientBuilder::create()->setTransport($transport);
+Hub::getCurrent()->bindClient($builder->getClient());
 
 register_shutdown_function('register_shutdown_function', function () use ($spool) {
     Assert::assertAttributeCount(1, 'events', $spool);


### PR DESCRIPTION
This PR removes the ambiguous `ClientBuilder` arg.
We do not really need it since we can bind a new Client to the Hub anytime -> see phpt test

Fixes https://github.com/getsentry/sentry-php/issues/695