### PR TITLE
[2.0] send_default_pii option

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -62,6 +62,8 @@ use Sentry\Transport\TransportInterface;
  * @method setServerName(string $serverName)
  * @method string[] getTags()
  * @method setTags(string[] $tags)
+ * @method bool shouldSendDefaultPii()
+ * @method setSendDefaultPii(bool $enable)
  */
 final class ClientBuilder implements ClientBuilderInterface
 {
@@ -112,7 +114,7 @@ final class ClientBuilder implements ClientBuilderInterface
         if (null !== $this->options->getIntegrations()) {
             $this->integrations = \array_merge([
                 new ErrorHandlerIntegration(),
-                new RequestIntegration(),
+                new RequestIntegration($this->options),
             ], $this->options->getIntegrations());
         }
     }

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -100,14 +100,9 @@ final class RequestIntegration implements IntegrationInterface
     private function removePiiFromHeaders(array $headers): array
     {
         $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];
-        $sanitizedHeaders = [];
 
-        foreach ($headers as $key => $value) {
-            if (!\in_array(\strtolower($key), $keysToRemove)) {
-                $sanitizedHeaders[$key] = $value;
-            }
-        }
-
-        return $sanitizedHeaders;
+        return array_filter($headers, function ($key) use ($keysToRemove) {
+            return !\in_array(\strtolower($key), $keysToRemove);
+        }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -87,6 +87,7 @@ final class RequestIntegration implements IntegrationInterface
             $requestData['headers'] = $request->getHeaders();
 
             $userContext = $event->getUserContext();
+
             if (null === $userContext->getIpAddress() && $request->hasHeader('REMOTE_ADDR')) {
                 $userContext->setIpAddress($request->getHeaderLine('REMOTE_ADDR'));
             }
@@ -102,7 +103,7 @@ final class RequestIntegration implements IntegrationInterface
         $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];
 
         return array_filter($headers, function ($key) use ($keysToRemove) {
-            return !\in_array(\strtolower($key), $keysToRemove);
+            return !\in_array(\strtolower($key), $keysToRemove, true);
         }, ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -98,6 +98,13 @@ final class RequestIntegration implements IntegrationInterface
         $event->setRequest($requestData);
     }
 
+    /**
+     * Removes headers containing potential PII.
+     *
+     * @param array $headers Array containing request headers
+     *
+     * @return array
+     */
     private function removePiiFromHeaders(array $headers): array
     {
         $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];

--- a/src/Options.php
+++ b/src/Options.php
@@ -598,6 +598,28 @@ class Options
     }
 
     /**
+     * Should default PII be sent by default.
+     *
+     * @return bool
+     */
+    public function shouldSendDefaultPii(): bool
+    {
+        return $this->options['send_default_pii'];
+    }
+
+    /**
+     * Sets if default PII should be sent with every event (if possible).
+     *
+     * @param bool $enable flag indicating if default PII will be sent
+     */
+    public function setSendDefaultPii(bool $enable): void
+    {
+        $options = array_merge($this->options, ['send_default_pii' => $enable]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -634,6 +656,7 @@ class Options
             },
             'excluded_exceptions' => [],
             'excluded_app_paths' => [],
+            'send_default_pii' => false,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -658,6 +681,7 @@ class Options
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');
         $resolver->setAllowedTypes('before_breadcrumb', ['callable']);
         $resolver->setAllowedTypes('integrations', ['null', 'array']);
+        $resolver->setAllowedTypes('send_default_pii', 'bool');
 
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -610,7 +610,7 @@ class Options
     /**
      * Sets if default PII should be sent with every event (if possible).
      *
-     * @param bool $enable flag indicating if default PII will be sent
+     * @param bool $enable Flag indicating if default PII will be sent
      */
     public function setSendDefaultPii(bool $enable): void
     {

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -65,8 +65,8 @@ final class RequestIntegrationTest extends TestCase
         }
 
         $this->assertInstanceOf(ServerRequestInterface::class, $request);
-        
-        $integration = new RequestIntegration(new Options(['send_default_pai' => $shouldSendPii]));
+
+        $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
 
         RequestIntegration::applyToEvent($integration, $event, $request);
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -64,7 +64,9 @@ final class RequestIntegrationTest extends TestCase
             $request = $request->withHeader($name, $value);
         }
 
-        $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
+        $this->assertInstanceOf(ServerRequestInterface::class, $request);
+        
+        $integration = new RequestIntegration(new Options(['send_default_pai' => $shouldSendPii]));
 
         RequestIntegration::applyToEvent($integration, $event, $request);
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -17,7 +17,7 @@ final class RequestIntegrationTest extends TestCase
     /**
      * @dataProvider invokeUserContextPiiDataProvider
      */
-    public function testInvokeWithRequestHavingIpAddress(bool $pii, array $expectedValue): void
+    public function testInvokeWithRequestHavingIpAddress(bool $shouldSendPii, array $expectedValue): void
     {
         $event = new Event();
         $event->getUserContext()->setData(['foo' => 'bar']);
@@ -27,7 +27,7 @@ final class RequestIntegrationTest extends TestCase
 
         $this->assertInstanceOf(ServerRequestInterface::class, $request);
 
-        $integration = new RequestIntegration(new Options(['send_default_pii' => $pii]));
+        $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
 
         RequestIntegration::applyToEvent($integration, $event, $request);
 
@@ -51,7 +51,7 @@ final class RequestIntegrationTest extends TestCase
     /**
      * @dataProvider invokeDataProvider
      */
-    public function testInvoke(bool $pii, array $requestData, array $expectedResult): void
+    public function testInvoke(bool $shouldSendPii, array $requestData, array $expectedResult): void
     {
         $event = new Event();
 
@@ -64,9 +64,7 @@ final class RequestIntegrationTest extends TestCase
             $request = $request->withHeader($name, $value);
         }
 
-        $this->assertInstanceOf(ServerRequestInterface::class, $request);
-
-        $integration = new RequestIntegration(new Options(['send_default_pii' => $pii]));
+        $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
 
         RequestIntegration::applyToEvent($integration, $event, $request);
 
@@ -77,8 +75,7 @@ final class RequestIntegrationTest extends TestCase
     {
         return [
             [
-                true, // send_default_pii
-                // Request
+                true,
                 [
                     'uri' => 'http://www.example.com/foo',
                     'method' => 'GET',
@@ -87,7 +84,6 @@ final class RequestIntegrationTest extends TestCase
                     ],
                     'headers' => [],
                 ],
-                // Expected result
                 [
                     'url' => 'http://www.example.com/foo',
                     'method' => 'GET',
@@ -99,10 +95,8 @@ final class RequestIntegrationTest extends TestCase
                     ],
                 ],
             ],
-
             [
-                false, // send_default_pii
-                // Request
+                false,
                 [
                     'uri' => 'http://www.example.com/foo',
                     'method' => 'GET',
@@ -111,7 +105,6 @@ final class RequestIntegrationTest extends TestCase
                     ],
                     'headers' => [],
                 ],
-                // Expected result
                 [
                     'url' => 'http://www.example.com/foo',
                     'method' => 'GET',
@@ -120,17 +113,14 @@ final class RequestIntegrationTest extends TestCase
                     ],
                 ],
             ],
-
             [
-                true, // send_default_pii
-                // Request
+                true,
                 [
                     'uri' => 'http://www.example.com:123/foo',
                     'method' => 'GET',
                     'cookies' => [],
                     'headers' => [],
                 ],
-                // Expected result
                 [
                     'url' => 'http://www.example.com:123/foo',
                     'method' => 'GET',
@@ -142,15 +132,13 @@ final class RequestIntegrationTest extends TestCase
             ],
 
             [
-                false, // send_default_pii
-                // Request
+                false,
                 [
                     'uri' => 'http://www.example.com:123/foo',
                     'method' => 'GET',
                     'cookies' => [],
                     'headers' => [],
                 ],
-                // Expected result
                 [
                     'url' => 'http://www.example.com:123/foo',
                     'method' => 'GET',
@@ -161,8 +149,7 @@ final class RequestIntegrationTest extends TestCase
             ],
 
             [
-                true, // send_default_pii
-                // Request
+                true,
                 [
                     'uri' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',
@@ -175,7 +162,6 @@ final class RequestIntegrationTest extends TestCase
                         'Set-Cookie' => 'z',
                     ],
                 ],
-                // Expected result
                 [
                     'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',
@@ -195,8 +181,7 @@ final class RequestIntegrationTest extends TestCase
             ],
 
             [
-                false, // send_default_pii
-                // Request
+                false,
                 [
                     'uri' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',
@@ -209,7 +194,6 @@ final class RequestIntegrationTest extends TestCase
                         'Set-Cookie' => 'z',
                     ],
                 ],
-                // Expected result
                 [
                     'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
                     'method' => 'GET',


### PR DESCRIPTION
This PR adds `send_default_pii` as an option to the SDK.
Purpose of this is that it must be opt-in to send any user-related information such as IP address or cookies.
Frames or anything more sophisticated than this will not be done for now since in future "Relay" will handle PII stripping.

This though is the bare minimum we have to support in each SDK.