### PR TITLE
Remove addBreadcrumb from client

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -100,25 +100,6 @@ class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function addBreadcrumb(Breadcrumb $breadcrumb, ?Scope $scope = null): void
-    {
-        $beforeBreadcrumbCallback = $this->options->getBeforeBreadcrumbCallback();
-        $maxBreadcrumbs = $this->options->getMaxBreadcrumbs();
-
-        if ($maxBreadcrumbs <= 0) {
-            return;
-        }
-
-        $breadcrumb = \call_user_func($beforeBreadcrumbCallback, $breadcrumb);
-
-        if (null !== $breadcrumb && null !== $scope) {
-            $scope->addBreadcrumb($breadcrumb, $maxBreadcrumbs);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?string
     {
         $payload['message'] = $message;

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -22,14 +22,6 @@ interface ClientInterface
     public function getOptions(): Options;
 
     /**
-     * Records the given breadcrumb.
-     *
-     * @param Breadcrumb $breadcrumb The breadcrumb instance
-     * @param Scope|null $scope      An optional scope to store this breadcrumb in
-     */
-    public function addBreadcrumb(Breadcrumb $breadcrumb, ?Scope $scope = null): void;
-
-    /**
      * Logs a message.
      *
      * @param string     $message The message (primary description) for the event

--- a/src/Options.php
+++ b/src/Options.php
@@ -662,7 +662,7 @@ class Options
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
         $resolver->setAllowedValues('max_breadcrumbs', function ($value) {
-            return $value <= self::DEFAULT_MAX_BREADCRUMBS;
+            return $value >= 0 && $value <= self::DEFAULT_MAX_BREADCRUMBS;
         });
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -661,9 +661,7 @@ class Options
 
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
-        $resolver->setAllowedValues('max_breadcrumbs', function ($value) {
-            return $value >= 0 && $value <= self::DEFAULT_MAX_BREADCRUMBS;
-        });
+        $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
         $resolver->setNormalizer('project_root', function (SymfonyOptions $options, $value) {
@@ -828,5 +826,17 @@ class Options
         }
 
         return true;
+    }
+
+    /**
+     * Validates if the value of the max_breadcrumbs option is in range.
+     *
+     * @param int $value The value to validate
+     *
+     * @return bool
+     */
+    private function validateMaxBreadcrumbsOptions(int $value): bool
+    {
+        return $value >= 0 && $value <= self::DEFAULT_MAX_BREADCRUMBS;
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -246,22 +246,29 @@ final class OptionsTest extends TestCase
     }
 
     /**
-     * @dataProvider maxBreadCrumbsInvalidValuesDataProvider
+     * @dataProvider maxBreadcrumbsOptionIsValidatedCorrectlyDataProvider
      */
-    public function testMaxBreadCrumbsInvalidValues($invalidValue): void
+    public function testMaxBreadcrumbsOptionIsValidatedCorrectly(bool $isValid, $value): void
     {
-        $this->expectException(InvalidOptionsException::class);
+        if (!$isValid) {
+            $this->expectException(InvalidOptionsException::class);
+        }
 
-        new Options(['max_breadcrumbs' => [$invalidValue]]);
+        $options = new Options(['max_breadcrumbs' => $value]);
+
+        $this->assertSame($value, $options->getMaxBreadcrumbs());
     }
 
-    public function maxBreadCrumbsInvalidValuesDataProvider()
+    public function maxBreadcrumbsOptionIsValidatedCorrectlyDataProvider(): array
     {
         return [
-            [-1],
-            [Options::DEFAULT_MAX_BREADCRUMBS + 1],
-            ['string'],
-            ['1'],
+            [false, -1],
+            [true, 0],
+            [true, 1],
+            [true, Options::DEFAULT_MAX_BREADCRUMBS],
+            [false, Options::DEFAULT_MAX_BREADCRUMBS + 1],
+            [false, 'string'],
+            [false, '1'],
         ];
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -6,6 +6,7 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\Options;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class OptionsTest extends TestCase
 {
@@ -241,6 +242,26 @@ final class OptionsTest extends TestCase
             ['some/specific/file.php', 'some/specific/file.php'],
             [__DIR__, __DIR__ . '/'],
             [__FILE__, __FILE__],
+        ];
+    }
+
+    /**
+     * @dataProvider maxBreadCrumbsInvalidValuesDataProvider
+     */
+    public function testMaxBreadCrumbsInvalidValues($invalidValue): void
+    {
+        $this->expectException(InvalidOptionsException::class);
+
+        new Options(['max_breadcrumbs' => [$invalidValue]]);
+    }
+
+    public function maxBreadCrumbsInvalidValuesDataProvider()
+    {
+        return [
+            [-1],
+            [Options::DEFAULT_MAX_BREADCRUMBS + 1],
+            ['string'],
+            ['1'],
         ];
     }
 }

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -92,15 +92,9 @@ class SdkTest extends TestCase
     {
         $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('addBreadcrumb')
-            ->with($breadcrumb, Hub::getCurrent()->getScope());
-
-        Hub::getCurrent()->bindClient($client);
-
         addBreadcrumb($breadcrumb);
+
+        $this->assertSame([$breadcrumb], Hub::getCurrent()->getScope()->getBreadcrumbs());
     }
 
     public function testWithScope(): void

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -241,17 +241,13 @@ final class HubTest extends TestCase
 
     public function testAddBreadcrumb(): void
     {
-        $scope = new Scope();
+        $client = ClientBuilder::create()->getClient();
+        $hub = new Hub($client);
         $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('addBreadcrumb')
-            ->with($breadcrumb, $scope);
-
-        $hub = new Hub($client, $scope);
         $hub->addBreadcrumb($breadcrumb);
+
+        $this->assertSame([$breadcrumb], $hub->getScope()->getBreadcrumbs());
     }
 
     /**

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -250,25 +250,14 @@ final class HubTest extends TestCase
         $this->assertSame([$breadcrumb], $hub->getScope()->getBreadcrumbs());
     }
 
-    /**
-     * @dataProvider addBreadcrumbDoesNothingIfMaxBreadcrumbsLimitIsTooLowDataProvider
-     */
-    public function testAddBreadcrumbDoesNothingIfMaxBreadcrumbsLimitIsTooLow(int $maxBreadcrumbs): void
+    public function testAddBreadcrumbDoesNothingIfMaxBreadcrumbsLimitIsZero(): void
     {
-        $client = ClientBuilder::create(['max_breadcrumbs' => $maxBreadcrumbs])->getClient();
+        $client = ClientBuilder::create(['max_breadcrumbs' => 0])->getClient();
         $hub = new Hub($client);
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
 
         $this->assertEmpty($hub->getScope()->getBreadcrumbs());
-    }
-
-    public function addBreadcrumbDoesNothingIfMaxBreadcrumbsLimitIsTooLowDataProvider(): array
-    {
-        return [
-            [0],
-            [-1],
-        ];
     }
 
     public function testAddBreadcrumbRespectsMaxBreadcrumbsLimit(): void


### PR DESCRIPTION
This spurred while analyzing the migration for the Symfony integration to the 2.0 client. It should simplify usage, avoiding the mirroring of the `addBreadcrumb' method between the client and the hub.