### PR TITLE
Hub interface & refactoring

### DIFF
--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -101,8 +101,7 @@ interface ClientBuilderInterface
     /**
      * Sets a representation serializer instance to be injected as a dependency of the client.
      *
-     * @param RepresentationSerializerInterface $representationSerializer
-     *                                                                    The representation serializer, used to serialize function
+     * @param RepresentationSerializerInterface $representationSerializer The representation serializer, used to serialize function
      *                                                                    arguments in stack traces, to have string representation
      *                                                                    of non-string values
      *

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -53,16 +53,6 @@ final class Hub implements HubInterface
         return $this->getStackTop()->getScope();
     }
 
-    public function getStack(): array
-    {
-        return $this->stack;
-    }
-
-    public function getStackTop(): Layer
-    {
-        return $this->stack[\count($this->stack) - 1];
-    }
-
     public function getLastEventId(): ?string
     {
         return $this->lastEventId;
@@ -201,5 +191,10 @@ final class Hub implements HubInterface
         }
 
         return null;
+    }
+
+    private function getStackTop(): Layer
+    {
+        return $this->stack[\count($this->stack) - 1];
     }
 }

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -43,21 +43,33 @@ final class Hub implements HubInterface
         $this->stack[] = new Layer($client, $scope);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getClient(): ?ClientInterface
     {
         return $this->getStackTop()->getClient();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getScope(): Scope
     {
         return $this->getStackTop()->getScope();
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getLastEventId(): ?string
     {
         return $this->lastEventId;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function pushScope(): Scope
     {
         $clonedScope = clone $this->getScope();
@@ -67,6 +79,9 @@ final class Hub implements HubInterface
         return $clonedScope;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function popScope(): bool
     {
         if (1 === \count($this->stack)) {
@@ -76,6 +91,9 @@ final class Hub implements HubInterface
         return null !== \array_pop($this->stack);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function withScope(callable $callback): void
     {
         $scope = $this->pushScope();
@@ -87,17 +105,26 @@ final class Hub implements HubInterface
         }
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function configureScope(callable $callback): void
     {
         $callback($this->getScope());
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function bindClient(ClientInterface $client): void
     {
         $layer = $this->getStackTop();
         $layer->setClient($client);
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function captureMessage(string $message, ?Severity $level = null): ?string
     {
         $client = $this->getClient();
@@ -109,6 +136,9 @@ final class Hub implements HubInterface
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function captureException(\Throwable $exception): ?string
     {
         $client = $this->getClient();
@@ -120,6 +150,9 @@ final class Hub implements HubInterface
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function captureEvent(array $payload): ?string
     {
         $client = $this->getClient();
@@ -131,6 +164,9 @@ final class Hub implements HubInterface
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function captureLastError(): ?string
     {
         $client = $this->getClient();
@@ -142,6 +178,9 @@ final class Hub implements HubInterface
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function addBreadcrumb(Breadcrumb $breadcrumb): bool
     {
         $client = $this->getClient();
@@ -167,6 +206,9 @@ final class Hub implements HubInterface
         return null !== $breadcrumb;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public static function getCurrent(): HubInterface
     {
         if (null === self::$currentHub) {
@@ -176,6 +218,9 @@ final class Hub implements HubInterface
         return self::$currentHub;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public static function setCurrent(HubInterface $hub): HubInterface
     {
         self::$currentHub = $hub;
@@ -183,6 +228,9 @@ final class Hub implements HubInterface
         return $hub;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getIntegration(string $className): ?IntegrationInterface
     {
         $client = $this->getClient();
@@ -193,6 +241,11 @@ final class Hub implements HubInterface
         return null;
     }
 
+    /**
+     * Gets the topmost client/layer pair in the stack.
+     *
+     * @return Layer
+     */
     private function getStackTop(): Layer
     {
         return $this->stack[\count($this->stack) - 1];

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -9,11 +9,7 @@ use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
 
-/**
- * This class is responsible for maintaining a stack of pairs of clients and
- * scopes. It is the main entry point to talk with the Sentry client.
- */
-final class Hub
+final class Hub implements HubInterface
 {
     /**
      * @var Layer[] The stack of client/scope pairs
@@ -47,65 +43,31 @@ final class Hub
         $this->stack[] = new Layer($client, $scope);
     }
 
-    /**
-     * Gets the client binded to the top of the stack.
-     *
-     * @return ClientInterface|null
-     */
     public function getClient(): ?ClientInterface
     {
         return $this->getStackTop()->getClient();
     }
 
-    /**
-     * Gets the scope binded to the top of the stack.
-     *
-     * @return Scope
-     */
     public function getScope(): Scope
     {
         return $this->getStackTop()->getScope();
     }
 
-    /**
-     * Gets the stack of clients and scopes.
-     *
-     * @return Layer[]
-     */
     public function getStack(): array
     {
         return $this->stack;
     }
 
-    /**
-     * Gets the topmost client/layer pair in the stack.
-     *
-     * @return Layer
-     */
     public function getStackTop(): Layer
     {
         return $this->stack[\count($this->stack) - 1];
     }
 
-    /**
-     * Gets the ID of the last captured event.
-     *
-     * @return null|string
-     */
     public function getLastEventId(): ?string
     {
         return $this->lastEventId;
     }
 
-    /**
-     * Creates a new scope to store context information that will be layered on
-     * top of the current one. It is isolated, i.e. all breadcrumbs and context
-     * information added to this scope will be removed once the scope ends. Be
-     * sure to always remove this scope with {@see Hub::popScope} when the
-     * operation finishes or throws.
-     *
-     * @return Scope
-     */
     public function pushScope(): Scope
     {
         $clonedScope = clone $this->getScope();
@@ -115,13 +77,6 @@ final class Hub
         return $clonedScope;
     }
 
-    /**
-     * Removes a previously pushed scope from the stack. This restores the state
-     * before the scope was pushed. All breadcrumbs and context information added
-     * since the last call to {@see Hub::pushScope} are discarded.
-     *
-     * @return bool
-     */
     public function popScope(): bool
     {
         if (1 === \count($this->stack)) {
@@ -131,12 +86,6 @@ final class Hub
         return null !== \array_pop($this->stack);
     }
 
-    /**
-     * Creates a new scope with and executes the given operation within. The scope
-     * is automatically removed once the operation finishes or throws.
-     *
-     * @param callable $callback The callback to be executed
-     */
     public function withScope(callable $callback): void
     {
         $scope = $this->pushScope();
@@ -148,36 +97,17 @@ final class Hub
         }
     }
 
-    /**
-     * Calls the given callback passing to it the current scope so that any
-     * operation can be run within its context.
-     *
-     * @param callable $callback The callback to be executed
-     */
     public function configureScope(callable $callback): void
     {
         $callback($this->getScope());
     }
 
-    /**
-     * Binds the given client to the current scope.
-     *
-     * @param ClientInterface $client The client
-     */
     public function bindClient(ClientInterface $client): void
     {
         $layer = $this->getStackTop();
         $layer->setClient($client);
     }
 
-    /**
-     * Captures a message event and sends it to Sentry.
-     *
-     * @param string   $message The message
-     * @param Severity $level   The severity level of the message
-     *
-     * @return null|string
-     */
     public function captureMessage(string $message, ?Severity $level = null): ?string
     {
         $client = $this->getClient();
@@ -189,13 +119,6 @@ final class Hub
         return null;
     }
 
-    /**
-     * Captures an exception event and sends it to Sentry.
-     *
-     * @param \Throwable $exception The exception
-     *
-     * @return null|string
-     */
     public function captureException(\Throwable $exception): ?string
     {
         $client = $this->getClient();
@@ -207,13 +130,6 @@ final class Hub
         return null;
     }
 
-    /**
-     * Captures a new event using the provided data.
-     *
-     * @param array $payload The data of the event being captured
-     *
-     * @return null|string
-     */
     public function captureEvent(array $payload): ?string
     {
         $client = $this->getClient();
@@ -225,11 +141,6 @@ final class Hub
         return null;
     }
 
-    /**
-     * Captures an event that logs the last occurred error.
-     *
-     * @return null|string
-     */
     public function captureLastError(): ?string
     {
         $client = $this->getClient();
@@ -241,15 +152,6 @@ final class Hub
         return null;
     }
 
-    /**
-     * Records a new breadcrumb which will be attached to future events. They
-     * will be added to subsequent events to provide more context on user's
-     * actions prior to an error or crash.
-     *
-     * @param Breadcrumb $breadcrumb The breadcrumb to record
-     *
-     * @return bool Whether the breadcrumb was actually added to the current scope
-     */
     public function addBreadcrumb(Breadcrumb $breadcrumb): bool
     {
         $client = $this->getClient();
@@ -275,11 +177,6 @@ final class Hub
         return null !== $breadcrumb;
     }
 
-    /**
-     * Returns the current global Hub.
-     *
-     * @return Hub
-     */
     public static function getCurrent(): self
     {
         if (null === self::$currentHub) {
@@ -289,13 +186,6 @@ final class Hub
         return self::$currentHub;
     }
 
-    /**
-     * Sets the Hub as the current.
-     *
-     * @param self $hub
-     *
-     * @return Hub
-     */
     public static function setCurrent(self $hub): self
     {
         self::$currentHub = $hub;
@@ -303,13 +193,6 @@ final class Hub
         return $hub;
     }
 
-    /**
-     * Gets the integration whose FQCN matches the given one if it's available on the current client.
-     *
-     * @param string $className The FQCN of the integration
-     *
-     * @return null|IntegrationInterface
-     */
     public function getIntegration(string $className): ?IntegrationInterface
     {
         $client = $this->getClient();

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -24,7 +24,7 @@ final class Hub implements HubInterface
     /**
      * Constructor.
      *
-     * @var Hub
+     * @var HubInterface
      */
     private static $currentHub;
 
@@ -177,7 +177,7 @@ final class Hub implements HubInterface
         return null !== $breadcrumb;
     }
 
-    public static function getCurrent(): self
+    public static function getCurrent(): HubInterface
     {
         if (null === self::$currentHub) {
             self::$currentHub = new self();
@@ -186,7 +186,7 @@ final class Hub implements HubInterface
         return self::$currentHub;
     }
 
-    public static function setCurrent(self $hub): self
+    public static function setCurrent(HubInterface $hub): HubInterface
     {
         self::$currentHub = $hub;
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -9,6 +9,9 @@ use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
 
+/**
+ * This class is a basic implementation of the {@see HubInterface} interface.
+ */
 final class Hub implements HubInterface
 {
     /**

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -25,9 +25,7 @@ final class Hub implements HubInterface
     private $lastEventId;
 
     /**
-     * Constructor.
-     *
-     * @var HubInterface
+     * @var HubInterface The hub that is set as the current one
      */
     private static $currentHub;
 

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -30,20 +30,6 @@ interface HubInterface
     public function getScope(): Scope;
 
     /**
-     * Gets the stack of clients and scopes.
-     *
-     * @return Layer[]
-     */
-    public function getStack(): array;
-
-    /**
-     * Gets the topmost client/layer pair in the stack.
-     *
-     * @return Layer
-     */
-    public function getStackTop(): Layer;
-
-    /**
      * Gets the ID of the last captured event.
      *
      * @return null|string

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Sentry\State;
+declare(strict_types=1);
 
+namespace Sentry\State;
 
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
@@ -9,7 +10,7 @@ use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
 
 /**
- * This interface represent the class which is responsible for maintaining a stack of pairs of clients and scopes. 
+ * This interface represent the class which is responsible for maintaining a stack of pairs of clients and scopes.
  * It is the main entry point to talk with the Sentry client.
  */
 interface HubInterface
@@ -95,8 +96,8 @@ interface HubInterface
     /**
      * Captures a message event and sends it to Sentry.
      *
-     * @param string $message The message
-     * @param Severity $level The severity level of the message
+     * @param string   $message The message
+     * @param Severity $level   The severity level of the message
      *
      * @return null|string
      */
@@ -141,7 +142,7 @@ interface HubInterface
     /**
      * Returns the current global Hub.
      *
-     * @return Hub
+     * @return self
      */
     public static function getCurrent(): self;
 
@@ -150,7 +151,7 @@ interface HubInterface
      *
      * @param self $hub
      *
-     * @return Hub
+     * @return self
      */
     public static function setCurrent(self $hub): self;
 

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Sentry\State;
+
+
+use Sentry\Breadcrumb;
+use Sentry\ClientInterface;
+use Sentry\Integration\IntegrationInterface;
+use Sentry\Severity;
+
+/**
+ * This interface represent the class which is responsible for maintaining a stack of pairs of clients and scopes. 
+ * It is the main entry point to talk with the Sentry client.
+ */
+interface HubInterface
+{
+    /**
+     * Gets the client bound to the top of the stack.
+     *
+     * @return ClientInterface|null
+     */
+    public function getClient(): ?ClientInterface;
+
+    /**
+     * Gets the scope bound to the top of the stack.
+     *
+     * @return Scope
+     */
+    public function getScope(): Scope;
+
+    /**
+     * Gets the stack of clients and scopes.
+     *
+     * @return Layer[]
+     */
+    public function getStack(): array;
+
+    /**
+     * Gets the topmost client/layer pair in the stack.
+     *
+     * @return Layer
+     */
+    public function getStackTop(): Layer;
+
+    /**
+     * Gets the ID of the last captured event.
+     *
+     * @return null|string
+     */
+    public function getLastEventId(): ?string;
+
+    /**
+     * Creates a new scope to store context information that will be layered on
+     * top of the current one. It is isolated, i.e. all breadcrumbs and context
+     * information added to this scope will be removed once the scope ends. Be
+     * sure to always remove this scope with {@see Hub::popScope} when the
+     * operation finishes or throws.
+     *
+     * @return Scope
+     */
+    public function pushScope(): Scope;
+
+    /**
+     * Removes a previously pushed scope from the stack. This restores the state
+     * before the scope was pushed. All breadcrumbs and context information added
+     * since the last call to {@see Hub::pushScope} are discarded.
+     *
+     * @return bool
+     */
+    public function popScope(): bool;
+
+    /**
+     * Creates a new scope with and executes the given operation within. The scope
+     * is automatically removed once the operation finishes or throws.
+     *
+     * @param callable $callback The callback to be executed
+     */
+    public function withScope(callable $callback): void;
+
+    /**
+     * Calls the given callback passing to it the current scope so that any
+     * operation can be run within its context.
+     *
+     * @param callable $callback The callback to be executed
+     */
+    public function configureScope(callable $callback): void;
+
+    /**
+     * Binds the given client to the current scope.
+     *
+     * @param ClientInterface $client The client
+     */
+    public function bindClient(ClientInterface $client): void;
+
+    /**
+     * Captures a message event and sends it to Sentry.
+     *
+     * @param string $message The message
+     * @param Severity $level The severity level of the message
+     *
+     * @return null|string
+     */
+    public function captureMessage(string $message, ?Severity $level = null): ?string;
+
+    /**
+     * Captures an exception event and sends it to Sentry.
+     *
+     * @param \Throwable $exception The exception
+     *
+     * @return null|string
+     */
+    public function captureException(\Throwable $exception): ?string;
+
+    /**
+     * Captures a new event using the provided data.
+     *
+     * @param array $payload The data of the event being captured
+     *
+     * @return null|string
+     */
+    public function captureEvent(array $payload): ?string;
+
+    /**
+     * Captures an event that logs the last occurred error.
+     *
+     * @return null|string
+     */
+    public function captureLastError(): ?string;
+
+    /**
+     * Records a new breadcrumb which will be attached to future events. They
+     * will be added to subsequent events to provide more context on user's
+     * actions prior to an error or crash.
+     *
+     * @param Breadcrumb $breadcrumb The breadcrumb to record
+     *
+     * @return bool Whether the breadcrumb was actually added to the current scope
+     */
+    public function addBreadcrumb(Breadcrumb $breadcrumb): bool;
+
+    /**
+     * Returns the current global Hub.
+     *
+     * @return Hub
+     */
+    public static function getCurrent(): self;
+
+    /**
+     * Sets the Hub as the current.
+     *
+     * @param self $hub
+     *
+     * @return Hub
+     */
+    public static function setCurrent(self $hub): self;
+
+    /**
+     * Gets the integration whose FQCN matches the given one if it's available on the current client.
+     *
+     * @param string $className The FQCN of the integration
+     *
+     * @return null|IntegrationInterface
+     */
+    public function getIntegration(string $className): ?IntegrationInterface;
+}

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -10,8 +10,9 @@ use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
 
 /**
- * This interface represent the class which is responsible for maintaining a stack of pairs of clients and scopes.
- * It is the main entry point to talk with the Sentry client.
+ * This interface represent the class which is responsible for maintaining a
+ * stack of pairs of clients and scopes. It is the main entry point to talk
+ * with the Sentry client.
  */
 interface HubInterface
 {
@@ -135,7 +136,7 @@ interface HubInterface
     /**
      * Sets the Hub as the current.
      *
-     * @param self $hub
+     * @param self $hub The Hub that will become the current one
      *
      * @return self
      */

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -39,40 +39,6 @@ final class HubTest extends TestCase
         $this->assertSame($scope, $hub->getScope());
     }
 
-    public function testGetStack(): void
-    {
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $scope = new Scope();
-        $hub = new Hub($client, $scope);
-
-        $stack = $hub->getStack();
-
-        $this->assertCount(1, $stack);
-        $this->assertSame($client, $stack[0]->getClient());
-        $this->assertSame($scope, $stack[0]->getScope());
-    }
-
-    public function testGetStackTop(): void
-    {
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $scope = new Scope();
-        $hub = new Hub($client, $scope);
-
-        $stackTop = $hub->getStackTop();
-
-        $this->assertSame($client, $stackTop->getClient());
-        $this->assertSame($scope, $stackTop->getScope());
-
-        $scope = $hub->pushScope();
-
-        $stackTop = $hub->getStackTop();
-
-        $this->assertSame($client, $stackTop->getClient());
-        $this->assertSame($scope, $stackTop->getScope());
-    }
-
     public function testGetLastEventId(): void
     {
         /** @var ClientInterface|MockObject $client */
@@ -91,35 +57,39 @@ final class HubTest extends TestCase
     {
         $hub = new Hub($this->createMock(ClientInterface::class));
 
-        $this->assertCount(1, $hub->getStack());
-
         $scope1 = $hub->getScope();
+        $client1 = $hub->getClient();
+
         $scope2 = $hub->pushScope();
+        $client2 = $hub->getClient();
 
-        $layers = $hub->getStack();
-
-        $this->assertCount(2, $layers);
         $this->assertNotSame($scope1, $scope2);
-        $this->assertSame($scope1, $layers[0]->getScope());
-        $this->assertSame($scope2, $layers[1]->getScope());
+        $this->assertSame($scope2, $hub->getScope());
+        $this->assertSame($client1, $client2);
+        $this->assertSame($client1, $hub->getClient());
     }
 
     public function testPopScope(): void
     {
         $hub = new Hub($this->createMock(ClientInterface::class));
 
-        $this->assertCount(1, $hub->getStack());
-
         $scope1 = $hub->getScope();
+        $client = $hub->getClient();
+
         $scope2 = $hub->pushScope();
 
         $this->assertSame($scope2, $hub->getScope());
+        $this->assertSame($client, $hub->getClient());
 
         $this->assertTrue($hub->popScope());
+
         $this->assertSame($scope1, $hub->getScope());
+        $this->assertSame($client, $hub->getClient());
 
         $this->assertFalse($hub->popScope());
+
         $this->assertSame($scope1, $hub->getScope());
+        $this->assertSame($client, $hub->getClient());
     }
 
     public function testWithScope(): void


### PR DESCRIPTION
This PR:

 * moves all the breadcrumb handling logic from the client to the hub, completely (from #709. which is included)
 * extracts a `HubInterface` from the `Hub`, to make it mockable (especially in integrations) since it's final
 * hides the `Hub` stack from the public API of the class/interface