### PR TITLE
feat: Make options extensible

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -115,11 +115,11 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * Class constructor.
      *
-     * @param array $options The client options
+     * @param Options $options The client options
      */
-    public function __construct(array $options = [])
+    public function __construct(Options $options)
     {
-        $this->options = new Options($options);
+        $this->options = $options;
 
         if (null !== $this->options->getIntegrations()) {
             $this->integrations = \array_merge([
@@ -132,9 +132,9 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public static function create(array $options = []): self
+    public static function create(?Options $options = null): self
     {
-        return new static($options);
+        return new static($options ?? new Options());
     }
 
     /**

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -22,11 +22,11 @@ interface ClientBuilderInterface
     /**
      * Creates a new instance of this builder.
      *
-     * @param array $options The client options
+     * @param null|Options $options The client options
      *
      * @return static
      */
-    public static function create(array $options = []);
+    public static function create(?Options $options);
 
     /**
      * Sets the factory to use to create URIs.

--- a/src/Options.php
+++ b/src/Options.php
@@ -23,7 +23,7 @@ class Options
     /**
      * @var array The configuration options
      */
-    private $options = [];
+    protected $options = [];
 
     /**
      * @var string|null A simple server string, set to the DSN found on your Sentry settings
@@ -48,7 +48,7 @@ class Options
     /**
      * @var OptionsResolver The options resolver
      */
-    private $resolver;
+    protected $resolver;
 
     /**
      * Class constructor.
@@ -583,7 +583,7 @@ class Options
      * @throws \Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException
      * @throws \Symfony\Component\OptionsResolver\Exception\AccessException
      */
-    private function configureOptions(OptionsResolver $resolver): void
+    protected function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'integrations' => [],

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -9,10 +9,14 @@ use Sentry\State\Hub;
 /**
  * Creates a new Client and Hub which will be set as current.
  *
- * @param array $options The client options
+ * @param array|Options $options The client options
  */
-function init(array $options = []): void
+function init($options = []): void
 {
+    if (!$options instanceof Options) {
+        $options = new Options($options);
+    }
+
     Hub::setCurrent(new Hub(ClientBuilder::create($options)->getClient()));
 }
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -30,7 +30,7 @@ final class ClientBuilderTest extends TestCase
 
     public function testHttpTransportIsUsedWhenServeIsConfigured(): void
     {
-        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(new Options(['dsn' => 'http://public:secret@example.com/sentry/1']));
 
         $transport = $this->getObjectAttribute($clientBuilder->getClient(), 'transport');
 
@@ -39,7 +39,7 @@ final class ClientBuilderTest extends TestCase
 
     public function testNullTransportIsUsedWhenNoServerIsConfigured(): void
     {
-        $clientBuilder = new ClientBuilder();
+        $clientBuilder = new ClientBuilder(new Options());
 
         $transport = $this->getObjectAttribute($clientBuilder->getClient(), 'transport');
 
@@ -51,7 +51,7 @@ final class ClientBuilderTest extends TestCase
         /** @var UriFactory|MockObject $uriFactory */
         $uriFactory = $this->createMock(UriFactory::class);
 
-        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(new Options(['dsn' => 'http://public:secret@example.com/sentry/1']));
         $clientBuilder->setUriFactory($uriFactory);
 
         $this->assertAttributeSame($uriFactory, 'uriFactory', $clientBuilder);
@@ -62,7 +62,7 @@ final class ClientBuilderTest extends TestCase
         /** @var MessageFactory|MockObject $messageFactory */
         $messageFactory = $this->createMock(MessageFactory::class);
 
-        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(new Options(['dsn' => 'http://public:secret@example.com/sentry/1']));
         $clientBuilder->setMessageFactory($messageFactory);
 
         $this->assertAttributeSame($messageFactory, 'messageFactory', $clientBuilder);
@@ -77,7 +77,7 @@ final class ClientBuilderTest extends TestCase
         /** @var TransportInterface|MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
 
-        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(new Options(['dsn' => 'http://public:secret@example.com/sentry/1']));
         $clientBuilder->setTransport($transport);
 
         $this->assertAttributeSame($transport, 'transport', $clientBuilder);
@@ -89,7 +89,7 @@ final class ClientBuilderTest extends TestCase
         /** @var HttpAsyncClient|MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
 
-        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(new Options(['dsn' => 'http://public:secret@example.com/sentry/1']));
         $clientBuilder->setHttpClient($httpClient);
 
         $this->assertAttributeSame($httpClient, 'httpClient', $clientBuilder);
@@ -104,7 +104,7 @@ final class ClientBuilderTest extends TestCase
         /** @var Plugin|MockObject $plugin */
         $plugin = $this->createMock(Plugin::class);
 
-        $clientBuilder = new ClientBuilder();
+        $clientBuilder = new ClientBuilder(new Options());
         $clientBuilder->addHttpClientPlugin($plugin);
 
         $plugins = $this->getObjectAttribute($clientBuilder, 'httpClientPlugins');
@@ -118,7 +118,7 @@ final class ClientBuilderTest extends TestCase
         $plugin = new PluginStub1();
         $plugin2 = new PluginStub2();
 
-        $clientBuilder = new ClientBuilder();
+        $clientBuilder = new ClientBuilder(new Options());
         $clientBuilder->addHttpClientPlugin($plugin);
         $clientBuilder->addHttpClientPlugin($plugin);
         $clientBuilder->addHttpClientPlugin($plugin2);
@@ -135,7 +135,7 @@ final class ClientBuilderTest extends TestCase
 
     public function testGetClient(): void
     {
-        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $clientBuilder = new ClientBuilder(new Options(['dsn' => 'http://public:secret@example.com/sentry/1']));
         $client = $clientBuilder->getClient();
 
         $this->assertInstanceOf(Client::class, $client);
@@ -157,7 +157,7 @@ final class ClientBuilderTest extends TestCase
      */
     public function testCallInvalidMethodThrowsException(): void
     {
-        $clientBuilder = new ClientBuilder();
+        $clientBuilder = new ClientBuilder(new Options());
         $clientBuilder->methodThatDoesNotExists();
     }
 
@@ -171,7 +171,7 @@ final class ClientBuilderTest extends TestCase
             ->method($setterMethod)
             ->with($this->equalTo($value));
 
-        $clientBuilder = new ClientBuilder();
+        $clientBuilder = new ClientBuilder(new Options());
 
         $reflectionProperty = new \ReflectionProperty(ClientBuilder::class, 'options');
         $reflectionProperty->setAccessible(true);
@@ -206,7 +206,7 @@ final class ClientBuilderTest extends TestCase
      */
     public function testGetClientTogglesCompressionPluginInHttpClient(bool $enabled): void
     {
-        $builder = ClientBuilder::create(['enable_compression' => $enabled, 'dsn' => 'http://public:secret@example.com/sentry/1']);
+        $builder = ClientBuilder::create(new Options(['enable_compression' => $enabled, 'dsn' => 'http://public:secret@example.com/sentry/1']));
         $builder->getClient();
 
         $decoderPluginFound = false;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -138,7 +138,7 @@ class ClientTest extends TestCase
                 return true;
             }));
 
-        $client = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/1'])
+        $client = ClientBuilder::create(new Options(['dsn' => 'http://public:secret@example.com/1']))
             ->setTransport($transport)
             ->getClient();
 
@@ -156,7 +156,7 @@ class ClientTest extends TestCase
         $transport->expects($this->never())
             ->method('send');
 
-        $client = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/1'])
+        $client = ClientBuilder::create(new Options(['dsn' => 'http://public:secret@example.com/1']))
             ->setTransport($transport)
             ->getClient();
 
@@ -167,7 +167,7 @@ class ClientTest extends TestCase
 
     public function testAppPathLinux()
     {
-        $client = ClientBuilder::create(['project_root' => '/foo/bar'])->getClient();
+        $client = ClientBuilder::create(new Options(['project_root' => '/foo/bar']))->getClient();
 
         $this->assertEquals('/foo/bar/', $client->getOptions()->getProjectRoot());
 
@@ -178,7 +178,7 @@ class ClientTest extends TestCase
 
     public function testAppPathWindows()
     {
-        $client = ClientBuilder::create(['project_root' => 'C:\\foo\\bar\\'])->getClient();
+        $client = ClientBuilder::create(new Options(['project_root' => 'C:\\foo\\bar\\']))->getClient();
 
         $this->assertEquals('C:\\foo\\bar\\', $client->getOptions()->getProjectRoot());
     }
@@ -192,14 +192,14 @@ class ClientTest extends TestCase
         $transport->expects($this->never())
             ->method('send');
 
-        $client = ClientBuilder::create([
+        $client = ClientBuilder::create(new Options([
             'dsn' => 'http://public:secret@example.com/1',
             'before_send' => function () use (&$beforeSendCalled) {
                 $beforeSendCalled = true;
 
                 return null;
             },
-        ])->setTransport($transport)->getClient();
+        ]))->setTransport($transport)->getClient();
 
         $client->captureEvent([]);
 
@@ -213,7 +213,7 @@ class ClientTest extends TestCase
     {
         $httpClient = new MockClient();
 
-        $client = ClientBuilder::create($options)
+        $client = ClientBuilder::create(new Options($options))
             ->setHttpClient($httpClient)
             ->getClient();
 
@@ -292,7 +292,7 @@ class ClientTest extends TestCase
                 return true;
             }));
 
-        $client = ClientBuilder::create($clientConfig)
+        $client = ClientBuilder::create(new Options($clientConfig))
             ->setTransport($transport)
             ->getClient();
 
@@ -415,7 +415,7 @@ class ClientTest extends TestCase
                 return true;
             }));
 
-        $client = ClientBuilder::create(['attach_stacktrace' => true])
+        $client = ClientBuilder::create(new Options(['attach_stacktrace' => true]))
             ->setTransport($transport)
             ->getClient();
 

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\ClientBuilder;
 use Sentry\ClientInterface;
+use Sentry\Options;
 use Sentry\Severity;
 use Sentry\State\Hub;
 use Sentry\State\Scope;
@@ -222,7 +223,7 @@ final class HubTest extends TestCase
 
     public function testAddBreadcrumbDoesNothingIfMaxBreadcrumbsLimitIsZero(): void
     {
-        $client = ClientBuilder::create(['max_breadcrumbs' => 0])->getClient();
+        $client = ClientBuilder::create(new Options(['max_breadcrumbs' => 0]))->getClient();
         $hub = new Hub($client);
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
@@ -232,7 +233,7 @@ final class HubTest extends TestCase
 
     public function testAddBreadcrumbRespectsMaxBreadcrumbsLimit(): void
     {
-        $client = ClientBuilder::create(['max_breadcrumbs' => 2])->getClient();
+        $client = ClientBuilder::create(new Options(['max_breadcrumbs' => 2]))->getClient();
         $hub = new Hub($client);
         $scope = $hub->getScope();
 
@@ -255,7 +256,7 @@ final class HubTest extends TestCase
         $callback = function (): ?Breadcrumb {
             return null;
         };
-        $client = ClientBuilder::create(['before_breadcrumb' => $callback])->getClient();
+        $client = ClientBuilder::create(new Options(['before_breadcrumb' => $callback]))->getClient();
         $hub = new Hub($client);
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
@@ -271,7 +272,7 @@ final class HubTest extends TestCase
         $callback = function () use ($breadcrumb2): ?Breadcrumb {
             return $breadcrumb2;
         };
-        $client = ClientBuilder::create(['before_breadcrumb' => $callback])->getClient();
+        $client = ClientBuilder::create(new Options(['before_breadcrumb' => $callback]))->getClient();
         $hub = new Hub($client);
 
         $hub->addBreadcrumb($breadcrumb1);


### PR DESCRIPTION
This makes it possible for "sub" SDKs to have their own options while still using the `ClientBuilder`.