### PR TITLE
feat: Add default_integrations option

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -79,13 +79,12 @@ class Client implements ClientInterface
      * @param TransportInterface                $transport                The transport
      * @param SerializerInterface               $serializer               The serializer used for events
      * @param RepresentationSerializerInterface $representationSerializer The representation serializer to be used with stacktrace frames
-     * @param IntegrationInterface[]            $integrations             The integrations used by the client
      */
-    public function __construct(Options $options, TransportInterface $transport, SerializerInterface $serializer, RepresentationSerializerInterface $representationSerializer, array $integrations = [])
+    public function __construct(Options $options, TransportInterface $transport, SerializerInterface $serializer, RepresentationSerializerInterface $representationSerializer)
     {
         $this->options = $options;
         $this->transport = $transport;
-        $this->integrations = Handler::setupIntegrations($integrations);
+        $this->integrations = Handler::setupIntegrations($options->getIntegrations());
         $this->serializer = $serializer;
         $this->representationSerializer = $representationSerializer;
     }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -64,7 +64,7 @@ use Sentry\Transport\TransportInterface;
  * @method setTags(string[] $tags)
  * @method bool shouldSendDefaultPii()
  * @method setSendDefaultPii(bool $enable)
- * @method bool getDefaultIntegrations()
+ * @method bool hasDefaultIntegrations()
  * @method setDefaultIntegrations(bool $enable)
  */
 final class ClientBuilder implements ClientBuilderInterface
@@ -123,13 +123,13 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $this->options = new Options($options);
 
-        if ($this->options->getDefaultIntegrations()) {
+        $this->integrations = $this->options->getIntegrations();
+
+        if ($this->options->hasDefaultIntegrations()) {
             $this->integrations = \array_merge([
                 new ErrorHandlerIntegration(),
                 new RequestIntegration($this->options),
             ], $this->options->getIntegrations());
-        } else {
-            $this->integrations = $this->options->getIntegrations();
         }
     }
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -20,7 +20,6 @@ use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Sentry\HttpClient\Authentication\SentryAuth;
 use Sentry\Integration\ErrorHandlerIntegration;
-use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\RequestIntegration;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\RepresentationSerializerInterface;
@@ -110,11 +109,6 @@ final class ClientBuilder implements ClientBuilderInterface
     private $representationSerializer;
 
     /**
-     * @var IntegrationInterface[] List of default integrations
-     */
-    private $integrations = [];
-
-    /**
      * Class constructor.
      *
      * @param array $options The client options
@@ -123,13 +117,11 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $this->options = new Options($options);
 
-        $this->integrations = $this->options->getIntegrations();
-
         if ($this->options->hasDefaultIntegrations()) {
-            $this->integrations = \array_merge([
+            $this->options->setIntegrations(\array_merge([
                 new ErrorHandlerIntegration(),
                 new RequestIntegration($this->options),
-            ], $this->options->getIntegrations());
+            ], $this->options->getIntegrations()));
         }
     }
 
@@ -239,7 +231,7 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->serializer = $this->serializer ?? new Serializer();
         $this->representationSerializer = $this->representationSerializer ?? new RepresentationSerializer();
 
-        return new Client($this->options, $this->transport, $this->serializer, $this->representationSerializer, $this->integrations);
+        return new Client($this->options, $this->transport, $this->serializer, $this->representationSerializer);
     }
 
     /**

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -64,6 +64,8 @@ use Sentry\Transport\TransportInterface;
  * @method setTags(string[] $tags)
  * @method bool shouldSendDefaultPii()
  * @method setSendDefaultPii(bool $enable)
+ * @method bool getDefaultIntegrations()
+ * @method setDefaultIntegrations(bool $enable)
  */
 final class ClientBuilder implements ClientBuilderInterface
 {
@@ -121,11 +123,13 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $this->options = new Options($options);
 
-        if (null !== $this->options->getIntegrations()) {
+        if ($this->options->getDefaultIntegrations()) {
             $this->integrations = \array_merge([
                 new ErrorHandlerIntegration(),
                 new RequestIntegration($this->options),
             ], $this->options->getIntegrations());
+        } else {
+            $this->integrations = $this->options->getIntegrations();
         }
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -813,11 +813,11 @@ class Options
      * Validates that the elements of this option are all class instances that
      * implements the {@see IntegrationInterface} interface.
      *
-     * @param array|null $integrations The value to validate
+     * @param array $integrations The value to validate
      *
      * @return bool
      */
-    private function validateIntegrationsOption(?array $integrations): bool
+    private function validateIntegrationsOption(array $integrations): bool
     {
         foreach ($integrations as $integration) {
             if (!$integration instanceof IntegrationInterface) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -819,9 +819,6 @@ class Options
      */
     private function validateIntegrationsOption(?array $integrations): bool
     {
-        if (null === $integrations) {
-            return true;
-        }
         foreach ($integrations as $integration) {
             if (!$integration instanceof IntegrationInterface) {
                 return false;

--- a/src/Options.php
+++ b/src/Options.php
@@ -576,19 +576,19 @@ class Options
     }
 
     /**
-     * Returns if default integrations will be enabled.
+     * Returns whether the default integrations are enabled.
      *
      * @return bool
      */
-    public function getDefaultIntegrations(): bool
+    public function hasDefaultIntegrations(): bool
     {
         return $this->options['default_integrations'];
     }
 
     /**
-     * Sets if default integrations will be enabled.
+     * Sets whether the default integrations are enabled.
      *
-     * @param bool $enable flag indicating if default integration will be enabled
+     * @param bool $enable Flag indicating whether the default integrations should be enabled
      */
     public function setDefaultIntegrations(bool $enable): void
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -659,11 +659,12 @@ class Options
         $resolver->setAllowedTypes('error_types', ['int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');
         $resolver->setAllowedTypes('before_breadcrumb', ['callable']);
-        $resolver->setAllowedTypes('integrations', 'IntegrationInterface[]');
+        $resolver->setAllowedTypes('integrations', 'array');
         $resolver->setAllowedTypes('send_default_pii', 'bool');
         $resolver->setAllowedTypes('default_integrations', 'bool');
 
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
+        $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
@@ -803,6 +804,28 @@ class Options
 
         if (!\in_array(strtolower($parsed['scheme']), ['http', 'https'])) {
             return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validates that the elements of this option are all class instances that
+     * implements the {@see IntegrationInterface} interface.
+     *
+     * @param array|null $integrations The value to validate
+     *
+     * @return bool
+     */
+    private function validateIntegrationsOption(?array $integrations): bool
+    {
+        if (null === $integrations) {
+            return true;
+        }
+        foreach ($integrations as $integration) {
+            if (!$integration instanceof IntegrationInterface) {
+                return false;
+            }
         }
 
         return true;

--- a/src/Options.php
+++ b/src/Options.php
@@ -534,9 +534,9 @@ class Options
     /**
      * Set integrations that will be used by the created client.
      *
-     * @param null|IntegrationInterface[] $integrations The integrations
+     * @param IntegrationInterface[] $integrations The integrations
      */
-    public function setIntegrations(?array $integrations): void
+    public function setIntegrations(array $integrations): void
     {
         $options = array_merge($this->options, ['integrations' => $integrations]);
 
@@ -546,9 +546,9 @@ class Options
     /**
      * Returns all configured integrations that will be used by the Client.
      *
-     * @return null|IntegrationInterface[]
+     * @return IntegrationInterface[]
      */
-    public function getIntegrations(): ?array
+    public function getIntegrations(): array
     {
         return $this->options['integrations'];
     }
@@ -576,6 +576,28 @@ class Options
     }
 
     /**
+     * Returns if default integrations will be enabled.
+     *
+     * @return bool
+     */
+    public function getDefaultIntegrations(): bool
+    {
+        return $this->options['default_integrations'];
+    }
+
+    /**
+     * Sets if default integrations will be enabled.
+     *
+     * @param bool $enable flag indicating if default integration will be enabled
+     */
+    public function setDefaultIntegrations(bool $enable): void
+    {
+        $options = array_merge($this->options, ['default_integrations' => $enable]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -587,6 +609,7 @@ class Options
     {
         $resolver->setDefaults([
             'integrations' => [],
+            'default_integrations' => true,
             'send_attempts' => 6,
             'prefixes' => explode(PATH_SEPARATOR, get_include_path()),
             'serialize_all_object' => false,
@@ -636,11 +659,11 @@ class Options
         $resolver->setAllowedTypes('error_types', ['int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');
         $resolver->setAllowedTypes('before_breadcrumb', ['callable']);
-        $resolver->setAllowedTypes('integrations', ['null', 'array']);
+        $resolver->setAllowedTypes('integrations', 'IntegrationInterface[]');
         $resolver->setAllowedTypes('send_default_pii', 'bool');
+        $resolver->setAllowedTypes('default_integrations', 'bool');
 
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
-        $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
@@ -780,29 +803,6 @@ class Options
 
         if (!\in_array(strtolower($parsed['scheme']), ['http', 'https'])) {
             return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * Validates that the elements of this option are all class instances that
-     * implements the {@see IntegrationInterface} interface.
-     *
-     * @param array|null $integrations The value to validate
-     *
-     * @return bool
-     */
-    private function validateIntegrationsOption(?array $integrations): bool
-    {
-        if (null === $integrations) {
-            return true;
-        }
-
-        foreach ($integrations as $integration) {
-            if (!$integration instanceof IntegrationInterface) {
-                return false;
-            }
         }
 
         return true;

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -156,8 +156,6 @@ final class ClientBuilderTest extends TestCase
         $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $client = $clientBuilder->getClient();
 
-        $this->assertInstanceOf(Client::class, $client);
-
         $integrations = $this->getObjectAttribute($client, 'integrations');
 
         $this->assertNotEmpty($integrations);
@@ -167,8 +165,6 @@ final class ClientBuilderTest extends TestCase
     {
         $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1', 'default_integrations' => false]);
         $client = $clientBuilder->getClient();
-
-        $this->assertInstanceOf(Client::class, $client);
 
         $integrations = $this->getObjectAttribute($client, 'integrations');
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -162,7 +162,7 @@ final class ClientBuilderTest extends TestCase
         $clientBuilder = new ClientBuilder([
             'dsn' => 'http://public:secret@example.com/sentry/1',
             'default_integrations' => $defaultIntegrations,
-            'integrations' => $integrations
+            'integrations' => $integrations,
         ]);
 
         $client = $clientBuilder->getClient();

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -151,6 +151,30 @@ final class ClientBuilderTest extends TestCase
         $this->assertAttributeSame($this->getObjectAttribute($clientBuilder, 'httpClient'), 'client', $httpClientPlugin);
     }
 
+    public function testClientHasDefaultIntegration(): void
+    {
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $client = $clientBuilder->getClient();
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        $integrations = $this->getObjectAttribute($client, 'integrations');
+
+        $this->assertNotEmpty($integrations);
+    }
+
+    public function testClientHasNoDefaultIntegration(): void
+    {
+        $clientBuilder = new ClientBuilder(['dsn' => 'http://public:secret@example.com/sentry/1', 'default_integrations' => false]);
+        $client = $clientBuilder->getClient();
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        $integrations = $this->getObjectAttribute($client, 'integrations');
+
+        $this->assertEmpty($integrations);
+    }
+
     /**
      * @expectedException \BadMethodCallException
      * @expectedExceptionMessage The method named "methodThatDoesNotExists" does not exists.

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -158,7 +158,10 @@ final class ClientBuilderTest extends TestCase
 
         $integrations = $this->getObjectAttribute($client, 'integrations');
 
-        $this->assertNotEmpty($integrations);
+        $expectedIntegrationsClassNames = array_map('get_class', $client->getOptions()->getIntegrations());
+        $actualIntegrationsClassNames = array_map('get_class', $integrations);
+
+        $this->assertEquals($expectedIntegrationsClassNames, $actualIntegrationsClassNames, '', 0, 10, true);
     }
 
     public function testClientHasNoDefaultIntegration(): void

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -160,14 +160,12 @@ final class ClientBuilderTest extends TestCase
     public function testIntegrationsAreAddedToClientCorrectly(bool $defaultIntegrations, array $integrations, array $expectedIntegrations): void
     {
         $clientBuilder = new ClientBuilder([
-            'dsn' => 'http://public:secret@example.com/sentry/1',
             'default_integrations' => $defaultIntegrations,
             'integrations' => $integrations,
         ]);
 
         $client = $clientBuilder->getClient();
-        $clientIntegrations = $client->getOptions()->getIntegrations();
-        $actualIntegrationsClassNames = array_map('get_class', $clientIntegrations);
+        $actualIntegrationsClassNames = array_map('get_class', $client->getOptions()->getIntegrations());
 
         $this->assertEquals($expectedIntegrations, $actualIntegrationsClassNames, '', 0, 10, true);
     }
@@ -175,10 +173,26 @@ final class ClientBuilderTest extends TestCase
     public function integrationsAreAddedToClientCorrectlyDataProvider(): array
     {
         return [
-            [false, [], []],
-            [false, [new StubIntegration()], [StubIntegration::class]],
-            [true, [], [RequestIntegration::class, ErrorHandlerIntegration::class]],
-            [true, [new StubIntegration()], [RequestIntegration::class, ErrorHandlerIntegration::class, StubIntegration::class]],
+            [
+                false,
+                [],
+                [],
+            ],
+            [
+                false,
+                [new StubIntegration()],
+                [StubIntegration::class],
+            ],
+            [
+                true,
+                [],
+                [RequestIntegration::class, ErrorHandlerIntegration::class],
+            ],
+            [
+                true,
+                [new StubIntegration()],
+                [RequestIntegration::class, ErrorHandlerIntegration::class, StubIntegration::class],
+            ],
         ];
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -264,7 +264,7 @@ class ClientTest extends TestCase
                 return true;
             }));
 
-        $client = new Client(new Options(), $transport, $this->createMock(SerializerInterface::class), $this->createMock(RepresentationSerializerInterface::class), []);
+        $client = new Client(new Options(), $transport, $this->createMock(SerializerInterface::class), $this->createMock(RepresentationSerializerInterface::class));
 
         Hub::getCurrent()->bindClient($client);
         $client->captureException($this->createCarelessExceptionWithStacktrace(), Hub::getCurrent()->getScope());

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -55,6 +55,8 @@ final class OptionsTest extends TestCase
             ['max_breadcrumbs', 50, 'getMaxBreadcrumbs', 'setMaxBreadcrumbs'],
             ['before_send', function () {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
             ['before_breadcrumb', function () {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
+            ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
+            ['default_integrations', false, 'getDefaultIntegrations', 'setDefaultIntegrations'],
         ];
     }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -56,7 +56,7 @@ final class OptionsTest extends TestCase
             ['before_send', function () {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
             ['before_breadcrumb', function () {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
             ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
-            ['default_integrations', false, 'getDefaultIntegrations', 'setDefaultIntegrations'],
+            ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
         ];
     }
 


### PR DESCRIPTION
I realized while writing the docs that just `integrations` allowing `null` isn't enough.
Added `default_integrations` : `bool` and restricted `integrations` option to `IntegrationInterface[]`.