### PR TITLE
Event factory with packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": "^7.1",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "jean85/pretty-package-versions": "^1.2",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5",
         "php-http/discovery": "^1.2",
@@ -26,7 +27,6 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
-        "jean85/pretty-package-versions": "^1.2",
         "monolog/monolog": "^1.3",
         "php-http/curl-client": "^1.7.1",
         "php-http/message": "^1.5",
@@ -35,9 +35,6 @@
         "phpstan/phpstan": "^0.10.3",
         "phpunit/phpunit": "^7.0",
         "symfony/phpunit-bridge": "^4.1.6"
-    },
-    "suggest": {
-        "jean85/pretty-package-versions": "To use the ModulesIntegration, that lists all installed dependencies in every sent event"
     },
     "conflict": {
         "php-http/client-common": "1.8.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,11 +17,6 @@ use Sentry\Transport\TransportInterface;
 class Client implements ClientInterface
 {
     /**
-     * The version of the library.
-     */
-    public const VERSION = '2.0.x-dev';
-
-    /**
      * The version of the protocol to communicate with the Sentry server.
      */
     public const PROTOCOL_VERSION = '7';

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -243,7 +243,7 @@ final class ClientBuilder implements ClientBuilderInterface
     }
 
     /**
-     * @return string
+     * @return string Sets the SDK version to be passed onto {@see Event} and HTTP User-Agent header
      */
     private function getSdkVersion(): string
     {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -66,6 +66,8 @@ use Sentry\Transport\TransportInterface;
  * @method setSendDefaultPii(bool $enable)
  * @method bool hasDefaultIntegrations()
  * @method setDefaultIntegrations(bool $enable)
+ * @method callable getBeforeSendCallback()
+ * @method setBeforeSendCallback(callable $beforeSend)
  */
 final class ClientBuilder implements ClientBuilderInterface
 {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -246,7 +246,7 @@ final class ClientBuilder implements ClientBuilderInterface
     private function getSdkVersion(): string
     {
         if (null === $this->sdkVersion) {
-            $this->sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
+            $this->setSdkVersionByPackageName('sentry/sentry');
         }
 
         return $this->sdkVersion;
@@ -258,6 +258,16 @@ final class ClientBuilder implements ClientBuilderInterface
     public function setSdkVersion(string $sdkVersion): void
     {
         $this->sdkVersion = $sdkVersion;
+    }
+
+    /**
+     * Sets the version of the SDK package that generated this Event using the Packagist name.
+     *
+     * @param string $packageName
+     */
+    public function setSdkVersionByPackageName(string $packageName): void
+    {
+        $this->sdkVersion = PrettyVersions::getVersion($packageName)->getPrettyVersion();
     }
 
     /**
@@ -350,6 +360,6 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->serializer = $this->serializer ?? new Serializer();
         $this->representationSerializer = $this->representationSerializer ?? new RepresentationSerializer();
 
-        return new EventFactory($this->serializer, $this->representationSerializer, $this->options, $this->sdkIdentifier);
+        return new EventFactory($this->serializer, $this->representationSerializer, $this->options, $this->sdkIdentifier, $this->getSdkVersion());
     }
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -114,10 +114,10 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * @var string The SDK identifier, to be used in {@see Event} and {@see SentryAuth}
      */
-    private $sdkIdentifier;
+    private $sdkIdentifier = Client::SDK_IDENTIFIER;
 
     /**
-     * @var string the SDK version of the Client
+     * @var string The SDK version of the Client
      */
     private $sdkVersion;
 
@@ -136,8 +136,6 @@ final class ClientBuilder implements ClientBuilderInterface
                 new RequestIntegration($this->options),
             ], $this->options->getIntegrations()));
         }
-
-        $this->sdkIdentifier = Client::SDK_IDENTIFIER;
     }
 
     /**
@@ -243,7 +241,9 @@ final class ClientBuilder implements ClientBuilderInterface
     }
 
     /**
-     * @return string Sets the SDK version to be passed onto {@see Event} and HTTP User-Agent header
+     * Gets the SDK version to be passed onto {@see Event} and HTTP User-Agent header.
+     *
+     * @return string
      */
     private function getSdkVersion(): string
     {
@@ -265,7 +265,7 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * Sets the version of the SDK package that generated this Event using the Packagist name.
      *
-     * @param string $packageName
+     * @param string $packageName The package name that will be used to get the version from (i.e. "sentry/sentry")
      */
     public function setSdkVersionByPackageName(string $packageName): void
     {

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -110,6 +110,8 @@ interface ClientBuilderInterface
     public function setRepresentationSerializer(RepresentationSerializerInterface $representationSerializer);
 
     /**
+     * Sets the SDK identifier to be passed onto {@see Event} and HTTP User-Agent header.
+     *
      * @param string $sdkIdentifier The SDK identifier to be sent in {@see Event} and HTTP User-Agent headers
      *
      * @internal
@@ -117,6 +119,8 @@ interface ClientBuilderInterface
     public function setSdkIdentifier(string $sdkIdentifier): void;
 
     /**
+     * Sets the SDK version to be passed onto {@see Event} and HTTP User-Agent header.
+     *
      * @param string $sdkVersion The version of the SDK in use, to be sent alongside the SDK identifier
      *
      * @internal

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -110,7 +110,12 @@ interface ClientBuilderInterface
     public function setRepresentationSerializer(RepresentationSerializerInterface $representationSerializer);
 
     /**
-     * @param string|null $sdkIdentifierSuffix The suffix for the SDK identifier, to be used by official SDK integrations
+     * @param string $sdkIdentifier The SDK identifier to be sent in {@see Event} and HTTP User-Agent headers
      */
-    public function setSdkIdentifierSuffix(?string $sdkIdentifierSuffix): void;
+    public function setSdkIdentifier(string $sdkIdentifier): void;
+
+    /**
+     * @param string $sdkVersion The version of the SDK in use, to be sent alongside the SDK identifier
+     */
+    public function setSdkVersion(string $sdkVersion): void;
 }

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -111,11 +111,15 @@ interface ClientBuilderInterface
 
     /**
      * @param string $sdkIdentifier The SDK identifier to be sent in {@see Event} and HTTP User-Agent headers
+     *
+     * @internal
      */
     public function setSdkIdentifier(string $sdkIdentifier): void;
 
     /**
      * @param string $sdkVersion The version of the SDK in use, to be sent alongside the SDK identifier
+     *
+     * @internal
      */
     public function setSdkVersion(string $sdkVersion): void;
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry;
 
 use Jean85\PrettyVersions;
-use PackageVersions\Versions;
 use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
@@ -171,6 +170,8 @@ final class Event implements \JsonSerializable
      * Gets the SDK identifier for the SDK package that generated this Event.
      *
      * @return string
+     *
+     * @internal
      */
     public function getSdkIdentifier(): string
     {
@@ -181,6 +182,8 @@ final class Event implements \JsonSerializable
      * Sets the SDK identifier for the SDK package that generated this Event.
      *
      * @param string $sdkIdentifier
+     *
+     * @internal
      */
     public function setSdkIdentifier(string $sdkIdentifier): void
     {
@@ -191,6 +194,8 @@ final class Event implements \JsonSerializable
      * Gets the version of the SDK package that generated this Event.
      *
      * @return string
+     *
+     * @internal
      */
     public function getSdkVersion(): string
     {
@@ -205,6 +210,8 @@ final class Event implements \JsonSerializable
      * Sets the version of the SDK package that generated this Event.
      *
      * @param string $sdkVersion
+     *
+     * @internal
      */
     public function setSdkVersion(string $sdkVersion): void
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -167,7 +167,7 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Gets the SDK identifier for the SDK package that generated this Event.
+     * Gets the identifier of the SDK package that generated this event.
      *
      * @return string
      *
@@ -179,7 +179,7 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Sets the SDK identifier for the SDK package that generated this Event.
+     * Sets the identifier of the SDK package that generated this event.
      *
      * @param string $sdkIdentifier
      *

--- a/src/Event.php
+++ b/src/Event.php
@@ -138,11 +138,6 @@ final class Event implements \JsonSerializable
     private $sdkVersion;
 
     /**
-     * @var array The official SDK packages detected as installed
-     */
-    private static $sdkPackages;
-
-    /**
      * Event constructor.
      *
      * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
@@ -552,24 +547,6 @@ final class Event implements \JsonSerializable
         $this->stacktrace = $stacktrace;
     }
 
-    private static function getSdkPackages(): array
-    {
-        if (null === self::$sdkPackages) {
-            self::$sdkPackages = [];
-
-            foreach (Versions::VERSIONS as $package => $version) {
-                if (0 === strpos($package, 'sentry/')) {
-                    self::$sdkPackages[] = [
-                        'name' => $package,
-                        'version' => PrettyVersions::getVersion($package)->getPrettyVersion(),
-                    ];
-                }
-            }
-        }
-
-        return self::$sdkPackages;
-    }
-
     /**
      * Gets the event as an array.
      *
@@ -585,7 +562,6 @@ final class Event implements \JsonSerializable
             'sdk' => [
                 'name' => $this->sdkIdentifier,
                 'version' => $this->getSdkVersion(),
-                'packages' => self::getSdkPackages(),
             ],
         ];
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -152,7 +152,6 @@ final class Event implements \JsonSerializable
     public function __construct()
     {
         $this->sdkIdentifier = Client::SDK_IDENTIFIER;
-        $this->setSdkVersionByPackageName('sentry/sentry');
         $this->id = Uuid::uuid4();
         $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $this->level = Severity::error();
@@ -200,6 +199,10 @@ final class Event implements \JsonSerializable
      */
     public function getSdkVersion(): string
     {
+        if (null === $this->sdkVersion) {
+            $this->sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
+        }
+
         return $this->sdkVersion;
     }
 
@@ -211,16 +214,6 @@ final class Event implements \JsonSerializable
     public function setSdkVersion(string $sdkVersion): void
     {
         $this->sdkVersion = $sdkVersion;
-    }
-
-    /**
-     * Sets the version of the SDK package that generated this Event using the Packagist name.
-     *
-     * @param string $packageName
-     */
-    public function setSdkVersionByPackageName(string $packageName): void
-    {
-        $this->sdkVersion = PrettyVersions::getVersion($packageName)->getPrettyVersion();
     }
 
     /**
@@ -591,7 +584,7 @@ final class Event implements \JsonSerializable
             'platform' => 'php',
             'sdk' => [
                 'name' => $this->sdkIdentifier,
-                'version' => $this->sdkVersion,
+                'version' => $this->getSdkVersion(),
                 'packages' => self::getSdkPackages(),
             ],
         ];

--- a/src/Event.php
+++ b/src/Event.php
@@ -133,6 +133,11 @@ final class Event implements \JsonSerializable
     private $sdkIdentifier;
 
     /**
+     * @var string The Sentry SDK version
+     */
+    private $sdkVersion;
+
+    /**
      * @var array The official SDK packages detected as installed
      */
     private static $sdkPackages;
@@ -147,6 +152,7 @@ final class Event implements \JsonSerializable
     public function __construct()
     {
         $this->sdkIdentifier = Client::SDK_IDENTIFIER;
+        $this->setSdkVersionByPackageName('sentry/sentry');
         $this->id = Uuid::uuid4();
         $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $this->level = Severity::error();
@@ -168,6 +174,8 @@ final class Event implements \JsonSerializable
     }
 
     /**
+     * Gets the SDK identifier for the SDK package that generated this Event.
+     *
      * @return string
      */
     public function getSdkIdentifier(): string
@@ -176,13 +184,43 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * @internal
+     * Sets the SDK identifier for the SDK package that generated this Event.
      *
      * @param string $sdkIdentifier
      */
     public function setSdkIdentifier(string $sdkIdentifier): void
     {
         $this->sdkIdentifier = $sdkIdentifier;
+    }
+
+    /**
+     * Gets the version of the SDK package that generated this Event.
+     *
+     * @return string
+     */
+    public function getSdkVersion(): string
+    {
+        return $this->sdkVersion;
+    }
+
+    /**
+     * Sets the version of the SDK package that generated this Event.
+     *
+     * @param string $sdkVersion
+     */
+    public function setSdkVersion(string $sdkVersion): void
+    {
+        $this->sdkVersion = $sdkVersion;
+    }
+
+    /**
+     * Sets the version of the SDK package that generated this Event using the Packagist name.
+     *
+     * @param string $packageName
+     */
+    public function setSdkVersionByPackageName(string $packageName): void
+    {
+        $this->sdkVersion = PrettyVersions::getVersion($packageName)->getPrettyVersion();
     }
 
     /**
@@ -553,7 +591,7 @@ final class Event implements \JsonSerializable
             'platform' => 'php',
             'sdk' => [
                 'name' => $this->sdkIdentifier,
-                'version' => Client::VERSION,
+                'version' => $this->sdkVersion,
                 'packages' => self::getSdkPackages(),
             ],
         ];

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -31,19 +31,26 @@ final class EventFactory
     private $sdkIdentifier;
 
     /**
+     * @var string the SDK version of the Client
+     */
+    private $sdkVersion;
+
+    /**
      * EventFactory constructor.
      *
      * @param SerializerInterface               $serializer               The serializer
      * @param RepresentationSerializerInterface $representationSerializer The serializer for function arguments
      * @param Options                           $options                  The SDK configuration options
      * @param string                            $sdkIdentifier            The Sentry SDK identifier
+     * @param string                            $sdkVersion               The Sentry SDK version
      */
-    public function __construct(SerializerInterface $serializer, RepresentationSerializerInterface $representationSerializer, Options $options, string $sdkIdentifier)
+    public function __construct(SerializerInterface $serializer, RepresentationSerializerInterface $representationSerializer, Options $options, string $sdkIdentifier, string $sdkVersion)
     {
         $this->serializer = $serializer;
         $this->representationSerializer = $representationSerializer;
         $this->options = $options;
         $this->sdkIdentifier = $sdkIdentifier;
+        $this->sdkVersion = $sdkVersion;
     }
 
     /**
@@ -77,6 +84,7 @@ final class EventFactory
         }
 
         $event->setSdkIdentifier($this->sdkIdentifier);
+        $event->setSdkVersion($this->sdkVersion);
         $event->setServerName($this->options->getServerName());
         $event->setRelease($this->options->getRelease());
         $event->getTagsContext()->merge($this->options->getTags());

--- a/src/HttpClient/Authentication/SentryAuth.php
+++ b/src/HttpClient/Authentication/SentryAuth.php
@@ -28,15 +28,22 @@ final class SentryAuth implements Authentication
     private $sdkIdentifier;
 
     /**
+     * @var string The SDK version
+     */
+    private $sdkVersion;
+
+    /**
      * Constructor.
      *
      * @param Options $options       The Sentry client configuration
-     * @param string  $sdkIdentifier The Sentry SDK identifier to be used
+     * @param string  $sdkIdentifier The Sentry SDK identifier in use
+     * @param string  $sdkVersion    The Sentry SDK version in use
      */
-    public function __construct(Options $options, string $sdkIdentifier)
+    public function __construct(Options $options, string $sdkIdentifier, string $sdkVersion)
     {
         $this->options = $options;
         $this->sdkIdentifier = $sdkIdentifier;
+        $this->sdkVersion = $sdkVersion;
     }
 
     /**
@@ -46,7 +53,7 @@ final class SentryAuth implements Authentication
     {
         $data = [
             'sentry_version' => Client::PROTOCOL_VERSION,
-            'sentry_client' => $this->sdkIdentifier . '/' . Client::VERSION,
+            'sentry_client' => $this->sdkIdentifier . '/' . $this->sdkVersion,
             'sentry_timestamp' => sprintf('%F', microtime(true)),
             'sentry_key' => $this->options->getPublicKey(),
         ];

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -21,13 +21,6 @@ final class ModulesIntegration implements IntegrationInterface
      */
     private static $loadedModules = [];
 
-    public function __construct()
-    {
-        if (!class_exists(PrettyVersions::class)) {
-            throw new \LogicException('You need the "jean85/pretty-package-versions" package in order to use this integration.');
-        }
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -9,11 +9,14 @@ use Http\Client\Common\PluginClient;
 use Http\Client\HttpAsyncClient;
 use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
+use Jean85\PrettyVersions;
+use PackageVersions\Versions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Sentry\Client;
 use Sentry\ClientBuilder;
+use Sentry\Event;
 use Sentry\Integration\ErrorHandlerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\RequestIntegration;
@@ -244,6 +247,26 @@ final class ClientBuilderTest extends TestCase
             ['setTags', ['foo', 'bar']],
             ['setErrorTypes', 0],
         ];
+    }
+
+    public function testSdkIdentifierAndVersionDefaultValues(): void
+    {
+        $options = new Options(['dsn' => 'http://public:secret@example.com/sentry/1']);
+        $called = false;
+        $expectedVersion = PrettyVersions::getVersion(Versions::ROOT_PACKAGE_NAME)->getPrettyVersion();
+
+        $clientBuilder = new ClientBuilder();
+        $clientBuilder->setBeforeSendCallback(function (Event $event) use ($expectedVersion, &$called) {
+            $called = true;
+
+            $this->assertSame(Client::SDK_IDENTIFIER, $event->getSdkIdentifier());
+            $this->assertSame($expectedVersion, $event->getSdkVersion());
+
+            return null;
+        });
+        $clientBuilder->getClient()->captureMessage('test');
+
+        $this->assertTrue($called, 'Callback not invoked, no assertions performed');
     }
 
     /**

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -10,7 +10,6 @@ use Http\Client\HttpAsyncClient;
 use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Jean85\PrettyVersions;
-use PackageVersions\Versions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -253,7 +252,7 @@ final class ClientBuilderTest extends TestCase
     {
         $options = new Options(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $called = false;
-        $expectedVersion = PrettyVersions::getVersion(Versions::ROOT_PACKAGE_NAME)->getPrettyVersion();
+        $expectedVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
 
         $clientBuilder = new ClientBuilder();
         $clientBuilder->setBeforeSendCallback(function (Event $event) use ($expectedVersion, &$called) {

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -250,22 +250,22 @@ final class ClientBuilderTest extends TestCase
 
     public function testSdkIdentifierAndVersionDefaultValues(): void
     {
-        $options = new Options(['dsn' => 'http://public:secret@example.com/sentry/1']);
-        $called = false;
+        $callbackCalled = false;
         $expectedVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
 
         $clientBuilder = new ClientBuilder();
-        $clientBuilder->setBeforeSendCallback(function (Event $event) use ($expectedVersion, &$called) {
-            $called = true;
+        $clientBuilder->setBeforeSendCallback(function (Event $event) use ($expectedVersion, &$callbackCalled) {
+            $callbackCalled = true;
 
             $this->assertSame(Client::SDK_IDENTIFIER, $event->getSdkIdentifier());
             $this->assertSame($expectedVersion, $event->getSdkVersion());
 
             return null;
         });
+
         $clientBuilder->getClient()->captureMessage('test');
 
-        $this->assertTrue($called, 'Callback not invoked, no assertions performed');
+        $this->assertTrue($callbackCalled, 'Callback not invoked, no assertions performed');
     }
 
     /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -478,7 +478,8 @@ class ClientTest extends TestCase
             $this->createMock(SerializerInterface::class),
             $this->createMock(RepresentationSerializerInterface::class),
             $this->createMock(Options::class),
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
     }
 }

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -30,11 +30,14 @@ class EventFactoryTest extends TestCase
             $this->createMock(SerializerInterface::class),
             $this->createMock(RepresentationSerializerInterface::class),
             $options,
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
 
         $event = $eventFactory->create([]);
 
+        $this->assertSame('sentry.sdk.identifier', $event->getSdkIdentifier());
+        $this->assertSame('1.2.3', $event->getSdkVersion());
         $this->assertSame($options->getServerName(), $event->getServerName());
         $this->assertSame($options->getRelease(), $event->getRelease());
         $this->assertSame($options->getTags(), $event->getTagsContext()->toArray());
@@ -52,7 +55,8 @@ class EventFactoryTest extends TestCase
             $this->createMock(SerializerInterface::class),
             $this->createMock(RepresentationSerializerInterface::class),
             new Options(),
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
 
         $event = $eventFactory->create($payload);
@@ -97,7 +101,8 @@ class EventFactoryTest extends TestCase
             $this->createMock(SerializerInterface::class),
             $this->createMock(RepresentationSerializerInterface::class),
             new Options(),
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
 
         $event = $eventFactory->create([]);
@@ -114,7 +119,8 @@ class EventFactoryTest extends TestCase
             new Serializer(),
             $this->createMock(RepresentationSerializerInterface::class),
             new Options(),
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
 
         $event = $eventFactory->create(['exception' => $exception]);
@@ -144,7 +150,8 @@ class EventFactoryTest extends TestCase
             new Serializer(),
             $this->createMock(RepresentationSerializerInterface::class),
             new Options(),
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
 
         $event = $eventFactory->create(['exception' => $exception]);
@@ -161,7 +168,8 @@ class EventFactoryTest extends TestCase
             $this->createMock(SerializerInterface::class),
             $this->createMock(RepresentationSerializerInterface::class),
             $options,
-            'sentry.sdk.identifier'
+            'sentry.sdk.identifier',
+            '1.2.3'
         );
 
         $event = $eventFactory->createWithStacktrace([]);

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use Jean85\PrettyVersions;
-use PackageVersions\Versions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -93,7 +92,7 @@ final class EventTest extends TestCase
     public function testToArray(): void
     {
         $this->options->setRelease('1.2.3-dev');
-        $sentryPrettyVersion = PrettyVersions::getVersion(Versions::ROOT_PACKAGE_NAME)->getPrettyVersion();
+        $sentryPrettyVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
 
         $expected = [
             'event_id' => str_replace('-', '', static::GENERATED_UUID[0]),

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -102,12 +102,6 @@ final class EventTest extends TestCase
             'sdk' => [
                 'name' => Client::SDK_IDENTIFIER,
                 'version' => $sentryPrettyVersion,
-                'packages' => [
-                    [
-                        'name' => 'sentry/sentry',
-                        'version' => $sentryPrettyVersion,
-                    ],
-                ],
             ],
             'contexts' => [
                 'os' => [

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -241,17 +241,6 @@ final class EventTest extends TestCase
         ];
     }
 
-    public function testSetSdkVersionByPackageName(): void
-    {
-        $packageName = 'phpunit/phpunit';
-        $prettyVersion = PrettyVersions::getVersion($packageName)->getPrettyVersion();
-        $event = new Event();
-        $event->setSdkVersionByPackageName($packageName);
-
-        $this->assertSame($prettyVersion, $event->getSdkVersion());
-        $this->assertArraySubset(['sdk' => ['version' => $prettyVersion]], $event->toArray());
-    }
-
     public function testEventJsonSerialization(): void
     {
         $event = new Event();

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Tests;
 
+use Jean85\PrettyVersions;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
@@ -100,6 +101,12 @@ final class EventTest extends TestCase
             'sdk' => [
                 'name' => Client::SDK_IDENTIFIER,
                 'version' => Client::VERSION,
+                'packages' => [
+                    [
+                        'name' => 'sentry/sentry',
+                        'version' => PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion(),
+                    ],
+                ],
             ],
             'contexts' => [
                 'os' => [

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -91,9 +91,6 @@ final class EventTest extends TestCase
 
     public function testToArray(): void
     {
-        $this->options->setRelease('1.2.3-dev');
-        $sentryPrettyVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
-
         $expected = [
             'event_id' => str_replace('-', '', static::GENERATED_UUID[0]),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
@@ -101,7 +98,7 @@ final class EventTest extends TestCase
             'platform' => 'php',
             'sdk' => [
                 'name' => Client::SDK_IDENTIFIER,
-                'version' => $sentryPrettyVersion,
+                'version' => PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion(),
             ],
             'contexts' => [
                 'os' => [

--- a/tests/HttpClient/Authentication/SentryAuthTest.php
+++ b/tests/HttpClient/Authentication/SentryAuthTest.php
@@ -19,7 +19,7 @@ final class SentryAuthTest extends TestCase
     public function testAuthenticate(): void
     {
         $configuration = new Options(['dsn' => 'http://public:secret@example.com/']);
-        $authentication = new SentryAuth($configuration, 'sentry.php.test');
+        $authentication = new SentryAuth($configuration, 'sentry.php.test', '1.2.3');
 
         /** @var RequestInterface|MockObject $request */
         $request = $this->getMockBuilder(RequestInterface::class)
@@ -32,7 +32,7 @@ final class SentryAuthTest extends TestCase
         $headerValue = sprintf(
             'Sentry sentry_version=%s, sentry_client=%s, sentry_timestamp=%F, sentry_key=public, sentry_secret=secret',
             Client::PROTOCOL_VERSION,
-            'sentry.php.test/' . Client::VERSION,
+            'sentry.php.test/1.2.3',
             microtime(true)
         );
 
@@ -47,7 +47,7 @@ final class SentryAuthTest extends TestCase
     public function testAuthenticateWithNoSecretKey(): void
     {
         $configuration = new Options(['dsn' => 'http://public@example.com/']);
-        $authentication = new SentryAuth($configuration, 'sentry.php.test');
+        $authentication = new SentryAuth($configuration, 'sentry.php.test', '2.0.0');
 
         /** @var RequestInterface|MockObject $request */
         $request = $this->getMockBuilder(RequestInterface::class)
@@ -60,7 +60,7 @@ final class SentryAuthTest extends TestCase
         $headerValue = sprintf(
             'Sentry sentry_version=%s, sentry_client=%s, sentry_timestamp=%F, sentry_key=public',
             Client::PROTOCOL_VERSION,
-            'sentry.php.test/' . Client::VERSION,
+            'sentry.php.test/2.0.0',
             microtime(true)
         );
 


### PR DESCRIPTION
THIS IS A WIP/PoC, it starts from #716 (and targets that PR, not the base branch).

This is to show how I would like to address https://github.com/getsentry/sentry-php/pull/716#issuecomment-443620896, so we can send more reliable info about SDK and integrations package versions. This would work out of the box in official integrations too.

I'm thinking about adding an official maps of integrations, so we could have something like:
```php
switch($packageName) {
    case 'sentry/sentry':
        return 'sentry.php';
    case 'sentry/symfony':
        return 'sentry.php.symfony';
```

etc. WDYT?