### PR TITLE
feat: Add .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,11 @@
+minVersion: '0.7.0'
+github:
+  owner: getsentry
+  repo: sentry-php
+changelogPolicy: simple
+targets:
+  - name: github
+  - name: registry
+    type: sdk
+    config:
+      canonical: 'composer:sentry/sentry'

--- a/.craft.yml
+++ b/.craft.yml
@@ -1,11 +1,11 @@
 minVersion: '0.7.0'
 github:
-  owner: getsentry
-  repo: sentry-php
+    owner: getsentry
+    repo: sentry-php
 changelogPolicy: simple
 targets:
-  - name: github
-  - name: registry
-    type: sdk
-    config:
-      canonical: 'composer:sentry/sentry'
+    - name: github
+    - name: registry
+      type: sdk
+      config:
+          canonical: 'composer:sentry/sentry'


### PR DESCRIPTION
This adds the config file https://github.com/getsentry/craft needs to make releases.

We have the composer integration in this repo is setup so as soon as a tag is pushed to this repo it will sync with https://packagist.org/packages/sentry/sentry so for now we don't need composer support in craft.