### PR TITLE
Make Raven_Breadcrumbs_MonologHandler::write() compatible with AbstractProcessingHandler

### DIFF
--- a/lib/Raven/Breadcrumbs/MonologHandler.php
+++ b/lib/Raven/Breadcrumbs/MonologHandler.php
@@ -54,7 +54,7 @@ class Raven_Breadcrumbs_MonologHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(array $record) : void
     {
         // sentry uses the 'nobreadcrumb' attribute to skip reporting
         if (!empty($record['context']['nobreadcrumb'])) {


### PR DESCRIPTION
Annotation of return type missing in function write().

Declaration of Raven_Breadcrumbs_MonologHandler::write(array $record) must be compatible with Monolog\Handler\AbstractProcessingHandler::write(array $record): void in /home/patrick/Projects/Booka/vendor/sentry/sentry/lib/Raven/Breadcrumbs/MonologHandler.php