### PR TITLE
Add PHP 7.3 to Travis CI build and support EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+charset = utf-8
+end_of_line = LF
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+max_line_length = 80
+
+[COMMIT_EDITMSG]
+max_line_length = 0

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,6 +1,6 @@
 tools:
     external_code_coverage:
-        runs: 1
+        timeout: 600
 
 build:
     nodes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,70 +1,56 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - php: nightly
+    - 7.1
+    - 7.2
+    - 7.3
+    - nightly
 
 env:
-  - REMOVE_XDEBUG="0"
-  - REMOVE_XDEBUG="1"
+    - dependencies=lowest
+    - dependencies=highest
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - php: nightly
 
 cache:
-  directories:
-    - $HOME/.composer/cache
+    directories:
+        - $HOME/.composer/cache
 
-before_install:
-  - if [ "$REMOVE_XDEBUG" = "1" ]; then phpenv config-rm xdebug.ini; fi
-
-install: travis_retry composer install --no-interaction
-
-script:
-  - composer tests
+stages:
+    - Code style & static analysis
+    - Test
+    - Code coverage
 
 jobs:
-  include:
-    - stage: Test
-      php: 7.2
-      env:
-        REMOVE_XDEBUG: "0"
-        COVERAGE: true
-      script:
-      - vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-clover tests/clover.xml
-      - wget https://scrutinizer-ci.com/ocular.phar
-      - php ocular.phar code-coverage:upload --format=php-clover tests/clover.xml --revision=$TRAVIS_COMMIT
-    - php: 7.1
-      env: 
-        COMPOSER_OPTIONS: "--prefer-lowest"
-        REMOVE_XDEBUG: "1"
-      install: travis_retry composer update --no-interaction --prefer-lowest
-    - php: nightly
-      allow_failure: true
-      before_install:
-        - composer remove --dev friendsofphp/php-cs-fixer
-      env: 
-        REMOVE_XDEBUG: "0"
-    - stage: Code style & static analysis
-      env: 
-        CS-FIXER: true
-        REMOVE_XDEBUG: "1"
-      script: 
-        - composer phpcs
-    - env: 
-        PHPSTAN: true
-        REMOVE_XDEBUG: "1"
-      script: 
-        - composer phpstan
+    include:
+        - stage: Code style & static analysis
+          name: PHP CS Fixer
+          script: composer phpcs
+        - script: composer phpstan
+          name: PHPStan
+        - stage: Code coverage
+          php: 7.3
+          env: dependencies=highest
+          script:
+              - vendor/bin/phpunit --verbose --coverage-clover=build/logs/clover.xml
+              - wget https://scrutinizer-ci.com/ocular.phar
+              - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml --revision=$TRAVIS_COMMIT
+          after_success:
+              - travis_retry php vendor/bin/php-coveralls --verbose
+
+install:
+    - if [ "$dependencies" = "lowest" ]; then composer update --no-interaction --prefer-lowest --prefer-dist; fi;
+    - if [ "$dependencies" = "highest" ]; then composer update --no-interaction --prefer-dist; fi;
 
 notifications:
-  webhooks:
-    urls:
-    - https://zeus.ci/hooks/cf8597c4-ffba-11e7-89c9-0a580a281308/public/provider/travis/webhook
-    on_success: always
-    on_failure: always
-    on_start: always
-    on_cancel: always
-    on_error: always
+    webhooks:
+        urls:
+            - https://zeus.ci/hooks/cf8597c4-ffba-11e7-89c9-0a580a281308/public/provider/travis/webhook
+        on_success: always
+        on_failure: always
+        on_start: always
+        on_cancel: always
+        on_error: always

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -19,7 +19,7 @@ use Http\Discovery\UriFactoryDiscovery;
 use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Jean85\PrettyVersions;
-use Sentry\HttpClient\Authentication\SentryAuth;
+use Sentry\HttpClient\Authentication\SentryAuthentication;
 use Sentry\Integration\ErrorHandlerIntegration;
 use Sentry\Integration\RequestIntegration;
 use Sentry\Serializer\RepresentationSerializer;
@@ -287,7 +287,7 @@ final class ClientBuilder implements ClientBuilderInterface
         }
 
         $this->addHttpClientPlugin(new HeaderSetPlugin(['User-Agent' => $this->sdkIdentifier . '/' . $this->getSdkVersion()]));
-        $this->addHttpClientPlugin(new AuthenticationPlugin(new SentryAuth($this->options, $this->sdkIdentifier, $this->getSdkVersion())));
+        $this->addHttpClientPlugin(new AuthenticationPlugin(new SentryAuthentication($this->options, $this->sdkIdentifier, $this->getSdkVersion())));
         $this->addHttpClientPlugin(new RetryPlugin(['retries' => $this->options->getSendAttempts()]));
         $this->addHttpClientPlugin(new ErrorPlugin());
 

--- a/src/HttpClient/Authentication/SentryAuthentication.php
+++ b/src/HttpClient/Authentication/SentryAuthentication.php
@@ -15,7 +15,7 @@ use Sentry\Options;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class SentryAuth implements Authentication
+final class SentryAuthentication implements Authentication
 {
     /**
      * @var Options The Sentry client configuration
@@ -68,6 +68,9 @@ final class SentryAuth implements Authentication
             $headers[] = $headerKey . '=' . $headerValue;
         }
 
-        return $request->withHeader('X-Sentry-Auth', 'Sentry ' . implode(', ', $headers));
+        /** @var RequestInterface $request */
+        $request = $request->withHeader('X-Sentry-Auth', 'Sentry ' . implode(', ', $headers));
+
+        return $request;
     }
 }

--- a/tests/HttpClient/Authentication/SentryAuthenticationTest.php
+++ b/tests/HttpClient/Authentication/SentryAuthenticationTest.php
@@ -8,18 +8,18 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Sentry\Client;
-use Sentry\HttpClient\Authentication\SentryAuth;
+use Sentry\HttpClient\Authentication\SentryAuthentication;
 use Sentry\Options;
 
 /**
  * @group time-sensitive
  */
-final class SentryAuthTest extends TestCase
+final class SentryAuthenticationTest extends TestCase
 {
     public function testAuthenticate(): void
     {
         $configuration = new Options(['dsn' => 'http://public:secret@example.com/']);
-        $authentication = new SentryAuth($configuration, 'sentry.php.test', '1.2.3');
+        $authentication = new SentryAuthentication($configuration, 'sentry.php.test', '1.2.3');
 
         /** @var RequestInterface|MockObject $request */
         $request = $this->getMockBuilder(RequestInterface::class)
@@ -47,7 +47,7 @@ final class SentryAuthTest extends TestCase
     public function testAuthenticateWithNoSecretKey(): void
     {
         $configuration = new Options(['dsn' => 'http://public@example.com/']);
-        $authentication = new SentryAuth($configuration, 'sentry.php.test', '2.0.0');
+        $authentication = new SentryAuthentication($configuration, 'sentry.php.test', '2.0.0');
 
         /** @var RequestInterface|MockObject $request */
         $request = $this->getMockBuilder(RequestInterface::class)

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -6,16 +6,16 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use function Sentry\addBreadcrumb;
 use Sentry\Breadcrumb;
+use Sentry\ClientInterface;
+use Sentry\State\Hub;
+use function Sentry\addBreadcrumb;
 use function Sentry\captureEvent;
 use function Sentry\captureException;
 use function Sentry\captureLastError;
 use function Sentry\captureMessage;
-use Sentry\ClientInterface;
 use function Sentry\configureScope;
 use function Sentry\init;
-use Sentry\State\Hub;
 use function Sentry\withScope;
 
 class SdkTest extends TestCase

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -346,7 +346,7 @@ abstract class AbstractSerializerTest extends TestCase
 
         $this->assertNotFalse($filename, 'Temp file creation failed');
 
-        $resource = fopen($filename, 'w');
+        $resource = fopen($filename, 'wb');
 
         $result = $this->invokeSerialization($serializer, $resource);
 

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -63,7 +63,7 @@ final class JSONTest extends TestCase
      */
     public function testEncodeThrowsIfValueIsResource(): void
     {
-        $resource = fopen('php://memory', 'r');
+        $resource = fopen('php://memory', 'rb');
 
         $this->assertNotFalse($resource);
 


### PR DESCRIPTION
Since PHP 7.3 is out we can now add it to the TravisCI pipeline. I've also added support for EditorConfig and changed the steps order to ensure that PHPStan runs first. The reason why I decided to do it is that it makes sense for a static analysis tool to runs first since things that it reports are likely to be bugs that should be fixed regardless of the CI build result, so knowing that there is something wrong as soon as possible is better