### PR TITLE
Ensure context lines option is used (fixes #740)

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -159,9 +159,9 @@ final class Options
     /**
      * Gets the number of lines of code context to capture, or null if none.
      *
-     * @return int|null
+     * @return int
      */
-    public function getContextLines(): ?int
+    public function getContextLines(): int
     {
         return $this->options['context_lines'];
     }
@@ -169,9 +169,9 @@ final class Options
     /**
      * Sets the number of lines of code context to capture, or null if none.
      *
-     * @param int|null $contextLines The number of lines of code
+     * @param int $contextLines The number of lines of code
      */
-    public function setContextLines(?int $contextLines): void
+    public function setContextLines(int $contextLines): void
     {
         $options = array_merge($this->options, ['context_lines' => $contextLines]);
 
@@ -636,7 +636,7 @@ final class Options
             'prefixes' => explode(PATH_SEPARATOR, get_include_path()),
             'sample_rate' => 1,
             'attach_stacktrace' => false,
-            'context_lines' => 3,
+            'context_lines' => 5,
             'enable_compression' => true,
             'environment' => null,
             'project_root' => null,

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -15,11 +15,6 @@ use Sentry\Serializer\SerializerInterface;
 class Stacktrace implements \JsonSerializable
 {
     /**
-     * This constant defines the default number of lines of code to include.
-     */
-    private const CONTEXT_NUM_LINES = 5;
-
-    /**
      * @var Options The client options
      */
     protected $options;
@@ -129,7 +124,7 @@ class Stacktrace implements \JsonSerializable
         }
 
         $frame = new Frame($functionName, $this->stripPrefixFromFilePath($file), $line);
-        $sourceCodeExcerpt = self::getSourceCodeExcerpt($file, $line, self::CONTEXT_NUM_LINES);
+        $sourceCodeExcerpt = $this->getSourceCodeExcerpt($file, $line, $this->options->getContextLines());
 
         if (isset($sourceCodeExcerpt['pre_context'])) {
             $frame->setPreContext($sourceCodeExcerpt['pre_context']);

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -143,7 +143,7 @@ final class StacktraceTest extends TestCase
      */
     public function testAddFrameRespectsContextLinesOption(string $fixture, int $lineNumber, ?int $contextLines, int $preContextCount, int $postContextCount): void
     {
-        if ($contextLines !== null) {
+        if (null !== $contextLines) {
             $this->options->setContextLines($contextLines);
         }
 

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -188,6 +188,34 @@ final class StacktraceTest extends TestCase
         }
     }
 
+    public function testAddFrameUsesOptionsContext(): void
+    {
+        $this->options->setContextLines(2);
+
+        $fileContent = explode("\n", $this->getFixture('code/LongFile.php'));
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+
+        $stacktrace->addFrame($this->getFixturePath('code/LongFile.php'), 8, [
+            'function' => '[unknown]',
+        ]);
+
+        $frames = $stacktrace->getFrames();
+
+        $this->assertCount(1, $frames);
+        $this->assertCount(2, $frames[0]->getPreContext());
+        $this->assertCount(2, $frames[0]->getPostContext());
+
+        for ($i = 0; $i < 2; ++$i) {
+            $this->assertEquals(rtrim($fileContent[$i + 5]), $frames[0]->getPreContext()[$i]);
+        }
+
+        $this->assertEquals(rtrim($fileContent[7]), $frames[0]->getContextLine());
+
+        for ($i = 0; $i < 2; ++$i) {
+            $this->assertEquals(rtrim($fileContent[$i + 8]), $frames[0]->getPostContext()[$i]);
+        }
+    }
+
     /**
      * @dataProvider removeFrameDataProvider
      */

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -139,11 +139,11 @@ final class StacktraceTest extends TestCase
     }
 
     /**
-     * @dataProvider contextDataProvider
+     * @dataProvider addFrameRespectsContextLinesOptionDataProvider
      */
-    public function testAddFrameWithDifferentContexts($fixture, $lineNumber, $contextLines, $preContextCount, $postContextCount)
+    public function testAddFrameRespectsContextLinesOption(string $fixture, int $lineNumber, ?int $contextLines, int $preContextCount, int $postContextCount): void
     {
-        if (isset($contextLines)) {
+        if ($contextLines !== null) {
             $this->options->setContextLines($contextLines);
         }
 
@@ -169,7 +169,7 @@ final class StacktraceTest extends TestCase
         }
     }
 
-    public function contextDataProvider()
+    public function addFrameRespectsContextLinesOptionDataProvider(): array
     {
         return [
             'read code from short file' => ['code/ShortFile.php', 3, 2, 2, 2],


### PR DESCRIPTION
Tests included, ensures that the context options that are set are used, rather than being hard-coded to a constant.