### PR TITLE
Create necessary factories only when using HTTP transport

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -259,9 +259,6 @@ final class ClientBuilder implements ClientBuilderInterface
      */
     public function getClient(): ClientInterface
     {
-        $this->messageFactory = $this->messageFactory ?? MessageFactoryDiscovery::find();
-        $this->uriFactory = $this->uriFactory ?? UriFactoryDiscovery::find();
-        $this->httpClient = $this->httpClient ?? HttpAsyncClientDiscovery::find();
         $this->transport = $this->transport ?? $this->createTransportInstance();
 
         return new Client($this->options, $this->transport, $this->createEventFactory());
@@ -312,6 +309,10 @@ final class ClientBuilder implements ClientBuilderInterface
         if (null === $this->options->getDsn()) {
             return new NullTransport();
         }
+
+        $this->messageFactory = $this->messageFactory ?? MessageFactoryDiscovery::find();
+        $this->uriFactory = $this->uriFactory ?? UriFactoryDiscovery::find();
+        $this->httpClient = $this->httpClient ?? HttpAsyncClientDiscovery::find();
 
         if (null === $this->messageFactory) {
             throw new \RuntimeException('The PSR-7 message factory must be set.');


### PR DESCRIPTION
This PR does the changes discussed in #741.

When setting a custom transport, the client builder will not create any factories used by the HTTP transport anymore. These prevented using a custom transport which did not rely on HTTPlug (because these relied on class discovery).

Closes #741.