### PR TITLE
Allow formatted message to be passed in event payload

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -119,7 +119,7 @@ class Context implements \ArrayAccess, \JsonSerializable, \IteratorAggregate
      */
     public function offsetExists($offset): bool
     {
-        return isset($this->data[$offset]) || array_key_exists($offset, $this->data);
+        return isset($this->data[$offset]) || \array_key_exists($offset, $this->data);
     }
 
     /**

--- a/src/Event.php
+++ b/src/Event.php
@@ -62,6 +62,11 @@ final class Event implements \JsonSerializable
     private $message;
 
     /**
+     * @var string|null The formatted error message
+     */
+    private $messageFormatted;
+
+    /**
      * @var array The parameters to use to format the message
      */
     private $messageParams = [];
@@ -340,6 +345,16 @@ final class Event implements \JsonSerializable
     }
 
     /**
+     * Gets the formatted message.
+     *
+     * @return string|null
+     */
+    public function getMessageFormatted(): ?string
+    {
+        return $this->messageFormatted;
+    }
+
+    /**
      * Gets the parameters to use to format the message.
      *
      * @return string[]
@@ -352,13 +367,15 @@ final class Event implements \JsonSerializable
     /**
      * Sets the error message.
      *
-     * @param string $message The message
-     * @param array  $params  The parameters to use to format the message
+     * @param string      $message   The message
+     * @param array       $params    The parameters to use to format the message
+     * @param string|null $formatted The formatted message
      */
-    public function setMessage(string $message, array $params = []): void
+    public function setMessage(string $message, array $params = [], string $formatted = null): void
     {
         $this->message = $message;
         $this->messageParams = $params;
+        $this->messageFormatted = $formatted;
     }
 
     /**
@@ -659,7 +676,7 @@ final class Event implements \JsonSerializable
                 $data['message'] = [
                     'message' => $this->message,
                     'params' => $this->messageParams,
-                    'formatted' => vsprintf($this->message, $this->messageParams),
+                    'formatted' => $this->messageFormatted ?? vsprintf($this->message, $this->messageParams),
                 ];
             }
         }

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -106,12 +106,12 @@ final class EventFactory implements EventFactoryInterface
             $event->setLogger($payload['logger']);
         }
 
-        $message = $payload['message'] ?? null;
+        $message = isset($payload['message']) ? mb_substr($payload['message'], 0, $this->options->getMaxValueLength()) : null;
         $messageParams = $payload['message_params'] ?? [];
         $messageFormatted = isset($payload['message_formatted']) ? mb_substr($payload['message_formatted'], 0, $this->options->getMaxValueLength()) : null;
 
         if (null !== $message) {
-            $event->setMessage(mb_substr($message, 0, $this->options->getMaxValueLength()), $messageParams, $messageFormatted);
+            $event->setMessage($message, $messageParams, $messageFormatted);
         }
 
         if (isset($payload['exception']) && $payload['exception'] instanceof \Throwable) {

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -108,9 +108,10 @@ final class EventFactory implements EventFactoryInterface
 
         $message = $payload['message'] ?? null;
         $messageParams = $payload['message_params'] ?? [];
+        $messageFormatted = isset($payload['message_formatted']) ? mb_substr($payload['message_formatted'], 0, $this->options->getMaxValueLength()) : null;
 
         if (null !== $message) {
-            $event->setMessage(substr($message, 0, $this->options->getMaxValueLength()), $messageParams);
+            $event->setMessage(mb_substr($message, 0, $this->options->getMaxValueLength()), $messageParams, $messageFormatted);
         }
 
         if (isset($payload['exception']) && $payload['exception'] instanceof \Throwable) {

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -94,14 +94,14 @@ class EventFactoryTest extends TestCase
             ],
             [
                 [
-                    'message' => 'testMessage @param',
-                    'message_params' => ['@param' => 'param'],
+                    'message' => 'testMessage %foo',
+                    'message_params' => ['%foo' => 'param'],
                     'message_formatted' => 'testMessage param',
                 ],
                 [
                     'message' => [
-                        'message' => 'testMessage @param',
-                        'params' => ['@param' => 'param'],
+                        'message' => 'testMessage %foo',
+                        'params' => ['%foo' => 'param'],
                         'formatted' => 'testMessage param',
                     ],
                 ],

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -92,6 +92,20 @@ class EventFactoryTest extends TestCase
                     ],
                 ],
             ],
+            [
+                [
+                    'message' => 'testMessage @param',
+                    'message_params' => ['@param' => 'param'],
+                    'message_formatted' => 'testMessage param',
+                ],
+                [
+                    'message' => [
+                        'message' => 'testMessage @param',
+                        'params' => ['@param' => 'param'],
+                        'formatted' => 'testMessage param',
+                    ],
+                ],
+            ],
         ];
     }
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -122,10 +122,11 @@ final class EventTest extends TestCase
     /**
      * @dataProvider toArrayWithMessageDataProvider
      */
-    public function testToArrayWithMessage(array $message, $expectedValue): void
+    public function testToArrayWithMessage(array $setMessageArguments, $expectedValue): void
     {
         $event = new Event();
-        \call_user_func_array([$event, 'setMessage'], $message);
+
+        \call_user_func_array([$event, 'setMessage'], $setMessageArguments);
 
         $data = $event->toArray();
 
@@ -136,9 +137,18 @@ final class EventTest extends TestCase
     public function toArrayWithMessageDataProvider(): array
     {
         return [
-            [['foo bar'], 'foo bar'],
-            [['foo %s', ['bar']], ['message' => 'foo %s', 'params' => ['bar'], 'formatted' => 'foo bar']],
-            [['foo @bar', ['@bar' => 'bar'], 'foo bar'], ['message' => 'foo @bar', 'params' => ['@bar' => 'bar'], 'formatted' => 'foo bar']],
+            [
+                ['foo bar'],
+                'foo bar',
+            ],
+            [
+                ['foo %s', ['bar']],
+                ['message' => 'foo %s', 'params' => ['bar'], 'formatted' => 'foo bar'],
+            ],
+            [
+                ['foo %bar', ['%bar' => 'baz'], 'foo baz'],
+                ['message' => 'foo %bar', 'params' => ['%bar' => 'baz'], 'formatted' => 'foo baz'],
+            ],
         ];
     }
 
@@ -163,10 +173,11 @@ final class EventTest extends TestCase
     /**
      * @dataProvider getMessageDataProvider
      */
-    public function testGetMessage(array $message, array $expectedValue): void
+    public function testGetMessage(array $setMessageArguments, array $expectedValue): void
     {
         $event = new Event();
-        \call_user_func_array([$event, 'setMessage'], $message);
+
+        \call_user_func_array([$event, 'setMessage'], $setMessageArguments);
 
         $this->assertSame($expectedValue['message'], $event->getMessage());
         $this->assertSame($expectedValue['params'], $event->getMessageParams());
@@ -176,8 +187,14 @@ final class EventTest extends TestCase
     public function getMessageDataProvider(): array
     {
         return [
-            [['foo %s', ['bar']], ['message' => 'foo %s', 'params' => ['bar'], 'formatted' => null]],
-            [['foo @bar', ['@bar' => 'bar'], 'foo bar'], ['message' => 'foo @bar', 'params' => ['@bar' => 'bar'], 'formatted' => 'foo bar']],
+            [
+                ['foo %s', ['bar']],
+                ['message' => 'foo %s', 'params' => ['bar'], 'formatted' => null],
+            ],
+            [
+                ['foo %bar', ['%bar' => 'baz'], 'foo baz'],
+                ['message' => 'foo %bar', 'params' => ['%bar' => 'baz'], 'formatted' => 'foo baz'],
+            ],
         ];
     }
 

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -138,16 +138,41 @@ final class EventTest extends TestCase
     {
         return [
             [
-                ['foo bar'],
+                [
+                    'foo bar',
+                ],
                 'foo bar',
             ],
             [
-                ['foo %s', ['bar']],
-                ['message' => 'foo %s', 'params' => ['bar'], 'formatted' => 'foo bar'],
+                [
+                    'foo %s',
+                    [
+                        'bar',
+                    ],
+                ],
+                [
+                    'message' => 'foo %s',
+                    'params' => [
+                        'bar',
+                    ],
+                    'formatted' => 'foo bar',
+                ],
             ],
             [
-                ['foo %bar', ['%bar' => 'baz'], 'foo baz'],
-                ['message' => 'foo %bar', 'params' => ['%bar' => 'baz'], 'formatted' => 'foo baz'],
+                [
+                    'foo %bar',
+                    [
+                        '%bar' => 'baz',
+                    ],
+                    'foo baz',
+                ],
+                [
+                    'message' => 'foo %bar',
+                    'params' => [
+                        '%bar' => 'baz',
+                    ],
+                    'formatted' => 'foo baz',
+                ],
             ],
         ];
     }
@@ -188,12 +213,35 @@ final class EventTest extends TestCase
     {
         return [
             [
-                ['foo %s', ['bar']],
-                ['message' => 'foo %s', 'params' => ['bar'], 'formatted' => null],
+                [
+                    'foo %s',
+                    [
+                        'bar',
+                    ],
+                ],
+                [
+                    'message' => 'foo %s',
+                    'params' => [
+                        'bar',
+                    ],
+                    'formatted' => null,
+                ],
             ],
             [
-                ['foo %bar', ['%bar' => 'baz'], 'foo baz'],
-                ['message' => 'foo %bar', 'params' => ['%bar' => 'baz'], 'formatted' => 'foo baz'],
+                [
+                    'foo %bar',
+                    [
+                        '%bar' => 'baz',
+                    ],
+                    'foo baz',
+                ],
+                [
+                    'message' => 'foo %bar',
+                    'params' => [
+                        '%bar' => 'baz',
+                    ],
+                    'formatted' => 'foo baz',
+                ],
             ],
         ];
     }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -165,6 +165,38 @@ final class EventTest extends TestCase
         $this->assertSame($breadcrumbs, $data['breadcrumbs']['values']);
     }
 
+    public function testToArrayWithMessageWithFormatted(): void
+    {
+        $expected = [
+            'message' => 'foo @bar',
+            'params' => ['@bar' => 'bar'],
+            'formatted' => 'foo bar',
+        ];
+
+        $event = new Event();
+        $event->setMessage('foo @bar', ['@bar' => 'bar'], 'foo bar');
+
+        $data = $event->toArray();
+
+        $this->assertArrayHasKey('message', $data);
+        $this->assertSame($expected, $data['message']);
+    }
+
+    public function testGetMessage(): void
+    {
+        $event = new Event();
+        $event->setMessage('foo @bar', ['@bar' => 'bar'], 'foo bar');
+        $this->assertSame('foo @bar', $event->getMessage());
+        $this->assertSame(['@bar' => 'bar'], $event->getMessageParams());
+        $this->assertSame('foo bar', $event->getMessageFormatted());
+
+        $event = new Event();
+        $event->setMessage('foo %s', ['bar']);
+        $this->assertSame('foo %s', $event->getMessage());
+        $this->assertSame(['bar'], $event->getMessageParams());
+        $this->assertNull($event->getMessageFormatted());
+    }
+
     public function testGetServerOsContext(): void
     {
         $event = new Event();


### PR DESCRIPTION
Allow formatted message to be passed in event payload (fixes #750); use mb_substr (refs #727).

This PR will need to be updated after #745 is merged.