### PR TITLE
Remove unused 'serialize_all_object' option

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -61,8 +61,7 @@
 
 - The `install_default_breadcrumb_handlers` option has been removed.
 
-- The `serialize_all_object` option has been added to configure whether all the
-  object instances should be serialized.
+- The `serialize_all_object` option has been removed.
 
 - The `context_lines` option has been added to configure the number of lines of
   code context to capture.

--- a/src/Options.php
+++ b/src/Options.php
@@ -612,7 +612,6 @@ final class Options
             'default_integrations' => true,
             'send_attempts' => 6,
             'prefixes' => explode(PATH_SEPARATOR, get_include_path()),
-            'serialize_all_object' => false,
             'sample_rate' => 1,
             'mb_detect_order' => null,
             'attach_stacktrace' => false,
@@ -640,7 +639,6 @@ final class Options
 
         $resolver->setAllowedTypes('send_attempts', 'int');
         $resolver->setAllowedTypes('prefixes', 'array');
-        $resolver->setAllowedTypes('serialize_all_object', 'bool');
         $resolver->setAllowedTypes('sample_rate', ['int', 'float']);
         $resolver->setAllowedTypes('mb_detect_order', ['null', 'array', 'string']);
         $resolver->setAllowedTypes('attach_stacktrace', 'bool');


### PR DESCRIPTION
While working on the Symfony integration I've found this relic, left over from 1.x.