### PR TITLE
Lower the default send_attempts option to 3

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -632,7 +632,7 @@ final class Options
         $resolver->setDefaults([
             'integrations' => [],
             'default_integrations' => true,
-            'send_attempts' => 6,
+            'send_attempts' => 3,
             'prefixes' => explode(PATH_SEPARATOR, get_include_path()),
             'sample_rate' => 1,
             'attach_stacktrace' => false,


### PR DESCRIPTION
Because we use the [RetryPlugin](https://github.com/php-http/client-common/blob/master/src/Plugin/RetryPlugin.php#L148-L162) to handle the send attempts we should consider lowering this since it has an exponential backoff and with the 6 retries I think (if I'm reading it correctly) the total time it tries to send a request (ignoring the time it takes to fail the request) is about 32 seconds which is way to long (since default request timeout in php is 30 seconds).

Retry backoff calculation converted to seconds:

```
>>> (pow(2, 0) * 500000) / 1000000
=> 0.5
>>> (pow(2, 1) * 500000) / 1000000
=> 1
>>> (pow(2, 2) * 500000) / 1000000
=> 2
>>> (pow(2, 3) * 500000) / 1000000
=> 4
>>> (pow(2, 4) * 500000) / 1000000
=> 8
>>> (pow(2, 5) * 500000) / 1000000
=> 16
```

The 3,5 seconds backoff with 3 retries seems way more sensible to me considering the request also takes some time to actually timeout or generate an error.

I'm also not sure what the current request timeout even is since we no longer have a option for that it seems... might need to limit that to give a 30s PHP request timeout a chance to cleanly exit after submitting an event to Sentry fails.