### PR TITLE
Remove link to unmaintained Nette community integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following integrations are fully supported and maintained by the Sentry team
 
 The following integrations are available and maintained by members of the Sentry community.
 
-- [Nette](https://github.com/Salamek/raven-nette)
+- [Nette](https://github.com/Kdyby/Monolog)
 - [ZendFramework](https://github.com/facile-it/sentry-module)
 - [WordPress](https://wordpress.org/plugins/wp-sentry-integration/)
 - [Drupal](https://www.drupal.org/project/raven)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ The following integrations are fully supported and maintained by the Sentry team
 
 The following integrations are available and maintained by members of the Sentry community.
 
-- [Nette](https://github.com/Kdyby/Monolog)
 - [ZendFramework](https://github.com/facile-it/sentry-module)
 - [WordPress](https://wordpress.org/plugins/wp-sentry-integration/)
 - [Drupal](https://www.drupal.org/project/raven)


### PR DESCRIPTION
Salamek/raven-nette is abandoned package and can be replaced by kdyby/monolog