### PR TITLE
Use mb_* functions to handle serialization and unicode file paths

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -161,21 +161,15 @@ abstract class AbstractSerializer
     {
         $value = (string) $value;
 
-        if ($this->isMbStringEnabled()) {
-            // we always guarantee this is coerced, even if we can't detect encoding
-            if ($currentEncoding = mb_detect_encoding($value, $this->mbDetectOrder)) {
-                $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
-            } else {
-                $value = mb_convert_encoding($value, 'UTF-8');
-            }
-
-            if (mb_strlen($value) > $this->options->getMaxValueLength()) {
-                $value = mb_substr($value, 0, $this->options->getMaxValueLength() - 10, 'UTF-8') . ' {clipped}';
-            }
+        // we always guarantee this is coerced, even if we can't detect encoding
+        if ($currentEncoding = mb_detect_encoding($value, $this->mbDetectOrder)) {
+            $value = mb_convert_encoding($value, 'UTF-8', $currentEncoding);
         } else {
-            if (\strlen($value) > $this->options->getMaxValueLength()) {
-                $value = substr($value, 0, $this->options->getMaxValueLength() - 10) . ' {clipped}';
-            }
+            $value = mb_convert_encoding($value, 'UTF-8');
+        }
+
+        if (mb_strlen($value) > $this->options->getMaxValueLength()) {
+            $value = mb_substr($value, 0, $this->options->getMaxValueLength() - 10, 'UTF-8') . ' {clipped}';
         }
 
         return $value;
@@ -310,14 +304,5 @@ abstract class AbstractSerializer
     public function getSerializeAllObjects(): bool
     {
         return $this->serializeAllObjects;
-    }
-
-    private function isMbStringEnabled(): bool
-    {
-        if (null === $this->mbStringEnabled) {
-            $this->mbStringEnabled = \extension_loaded('mbstring');
-        }
-
-        return $this->mbStringEnabled;
     }
 }

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -145,7 +145,7 @@ class Stacktrace implements \JsonSerializable
 
             if ($isApplicationFile && !empty($excludedAppPaths)) {
                 foreach ($excludedAppPaths as $path) {
-                    if (0 === strpos($absoluteFilePath, $path)) {
+                    if (0 === mb_strpos($absoluteFilePath, $path)) {
                         $frame->setIsInApp(false);
 
                         break;
@@ -161,7 +161,7 @@ class Stacktrace implements \JsonSerializable
                 $argumentValue = $this->representationSerializer->representationSerialize($argumentValue);
 
                 if (\is_string($argumentValue) || is_numeric($argumentValue)) {
-                    $frameArguments[(string) $argumentName] = substr($argumentValue, 0, $this->options->getMaxValueLength());
+                    $frameArguments[(string) $argumentName] = mb_substr($argumentValue, 0, $this->options->getMaxValueLength());
                 } else {
                     $frameArguments[(string) $argumentName] = $argumentValue;
                 }
@@ -279,8 +279,8 @@ class Stacktrace implements \JsonSerializable
     protected function stripPrefixFromFilePath(string $filePath): string
     {
         foreach ($this->options->getPrefixes() as $prefix) {
-            if (0 === strpos($filePath, $prefix)) {
-                return substr($filePath, \strlen($prefix));
+            if (0 === mb_strpos($filePath, $prefix)) {
+                return mb_substr($filePath, mb_strlen($prefix));
             }
         }
 
@@ -398,7 +398,7 @@ class Stacktrace implements \JsonSerializable
 
             foreach ($arg as $key => $value) {
                 if (\is_string($value) || is_numeric($value)) {
-                    $result[$key] = substr((string) $value, 0, $maxValueLength);
+                    $result[$key] = mb_substr((string) $value, 0, $maxValueLength);
                 } else {
                     $result[$key] = $value;
                 }
@@ -406,7 +406,7 @@ class Stacktrace implements \JsonSerializable
 
             return $result;
         } elseif (\is_string($arg) || is_numeric($arg)) {
-            return substr((string) $arg, 0, $maxValueLength);
+            return mb_substr((string) $arg, 0, $maxValueLength);
         } else {
             return $arg;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.0
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This fixes #727 by using `mb_*` functions whenever possible. This is especially important while serializing the stacktrace and the frame arguments because if not encoded in UTF-8 the JSON serialization will fail. Also, Sentry server expects the data to be in that encoding anyway. I've also removed some conditional checks that verified if the `mbstring` extension was available since it's a requirement in the `composer.json`