### PR TITLE
Switch CI from nightly to 7.4snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - nightly
+    - 7.4snapshot
 
 env:
     - dependencies=highest
@@ -18,7 +18,7 @@ env:
 matrix:
     fast_finish: true
     allow_failures:
-        - php: nightly
+        - php: 7.4snapshot
 
 cache:
     directories:


### PR DESCRIPTION
`nightly` now builds against the 8.0 branch, which is incompatible with us (and a pletora of our deps). This will test against 7.4 again.

For more details, see: https://travis-ci.community/t/add-php-7-4-branch-to-test-against/2179/5