### PR TITLE
Handle silenced errors gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
+- Do no longer report silenced errors by default (#785)
+- New option `capture_silenced_error` to enable reporting of silenced errors, disabled by default (#785)
 
 ## 2.0.0 (2019-02-25)
 

--- a/src/Exception/SilencedErrorException.php
+++ b/src/Exception/SilencedErrorException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Exception;
+
+class SilencedErrorException extends \ErrorException
+{
+}

--- a/src/Exception/SilencedErrorException.php
+++ b/src/Exception/SilencedErrorException.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Exception;
 
-class SilencedErrorException extends \ErrorException
+/**
+ * Error that has been captured by the {@see ErrorHandler}, but that was silenced
+ * with `@` in the source code.
+ */
+final class SilencedErrorException extends \ErrorException
 {
 }

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Sentry\ErrorHandler;
+use Sentry\Exception\SilencedErrorException;
 use Sentry\Options;
 use Sentry\State\Hub;
 
@@ -35,6 +36,10 @@ final class ErrorListenerIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         ErrorHandler::addErrorListener(function (\ErrorException $error): void {
+            if ($error instanceof SilencedErrorException) {
+                return;
+            }
+
             if ($this->options->getErrorTypes() & $error->getSeverity()) {
                 Hub::getCurrent()->captureException($error);
             }

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -36,7 +36,7 @@ final class ErrorListenerIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         ErrorHandler::addErrorListener(function (\ErrorException $error): void {
-            if ($error instanceof SilencedErrorException) {
+            if ($error instanceof SilencedErrorException && !$this->options->shouldCaptureSilencedErrors()) {
                 return;
             }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -642,10 +642,10 @@ final class Options
     }
 
     /**
-     * Return the capture_silenced_errors option
-     * 
-     * @return bool If true, errors silenced through the @ operator will be reported,
-     * ignored otherwise.
+     * Return the capture_silenced_errors option.
+     *
+     * @return bool if true, errors silenced through the @ operator will be reported,
+     *              ignored otherwise
      */
     public function shouldCaptureSilencedErrors(): bool
     {
@@ -654,9 +654,9 @@ final class Options
 
     /**
      * Sets the capture_silenced_errors option.
-     * 
-     * @param bool $shouldCapture If set to true, errors silenced through the @
-     * operator will be reported, ignored otherwise.
+     *
+     * @param bool $shouldCapture if set to true, errors silenced through the @
+     *                            operator will be reported, ignored otherwise
      */
     public function setCaptureSilencedErrors(bool $shouldCapture): void
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -642,6 +642,30 @@ final class Options
     }
 
     /**
+     * Return the capture_silenced_errors option
+     * 
+     * @return bool If true, errors silenced through the @ operator will be reported,
+     * ignored otherwise.
+     */
+    public function shouldCaptureSilencedErrors(): bool
+    {
+        return $this->options['capture_silenced_errors'];
+    }
+
+    /**
+     * Sets the capture_silenced_errors option.
+     * 
+     * @param bool $shouldCapture If set to true, errors silenced through the @
+     * operator will be reported, ignored otherwise.
+     */
+    public function setCaptureSilencedErrors(bool $shouldCapture): void
+    {
+        $options = array_merge($this->options, ['capture_silenced_errors' => $shouldCapture]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -680,6 +704,7 @@ final class Options
             'send_default_pii' => false,
             'max_value_length' => 1024,
             'http_proxy' => null,
+            'capture_silenced_errors' => false,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -706,6 +731,7 @@ final class Options
         $resolver->setAllowedTypes('default_integrations', 'bool');
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
+        $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
 
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -642,9 +642,9 @@ final class Options
     }
 
     /**
-     * Return the capture_silenced_errors option.
+     * Gets whether the silenced errors should be captured or not.
      *
-     * @return bool if true, errors silenced through the @ operator will be reported,
+     * @return bool If true, errors silenced through the @ operator will be reported,
      *              ignored otherwise
      */
     public function shouldCaptureSilencedErrors(): bool
@@ -653,9 +653,9 @@ final class Options
     }
 
     /**
-     * Sets the capture_silenced_errors option.
+     * Sets whether the silenced errors should be captured or not.
      *
-     * @param bool $shouldCapture if set to true, errors silenced through the @
+     * @param bool $shouldCapture If set to true, errors silenced through the @
      *                            operator will be reported, ignored otherwise
      */
     public function setCaptureSilencedErrors(bool $shouldCapture): void

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -59,6 +59,7 @@ final class OptionsTest extends TestCase
             ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
             ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
             ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
+            ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
         ];
     }
 

--- a/tests/phpt/silenced_errors.phpt
+++ b/tests/phpt/silenced_errors.phpt
@@ -5,8 +5,7 @@ Test that the error handler ignores silenced errors
 
 namespace Sentry\Tests;
 
-use Sentry\ErrorHandler;
-use Sentry\Tests\Fixtures\classes\StubErrorListener;
+use function Sentry\init;
 
 $vendor = __DIR__;
 
@@ -16,9 +15,11 @@ while (!file_exists($vendor . '/vendor')) {
 
 require $vendor . '/vendor/autoload.php';
 
-ErrorHandler::addErrorListener(new StubErrorListener(function () {
-    echo 'Callback invoked' . PHP_EOL;
-}));
+init([
+    'before_send' => function () {
+        echo 'Event captured' . PHP_EOL;
+    }    
+]);
 
 echo 'Triggering silenced error' . PHP_EOL;
 @$a['missing'];

--- a/tests/phpt/silenced_errors.phpt
+++ b/tests/phpt/silenced_errors.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Test that the error handler ignores silenced errors
+--FILE--
+<?php
+
+namespace Sentry\Tests;
+
+use Sentry\ErrorHandler;
+use Sentry\Tests\Fixtures\classes\StubErrorListener;
+
+$vendor = __DIR__;
+
+while (!file_exists($vendor . '/vendor')) {
+    $vendor = \dirname($vendor);
+}
+
+require $vendor . '/vendor/autoload.php';
+
+ErrorHandler::addErrorListener(new StubErrorListener(function () {
+    echo 'Callback invoked' . PHP_EOL;
+}));
+
+echo 'Triggering silenced error' . PHP_EOL;
+@$a['missing'];
+echo 'End'
+?>
+--EXPECTF--
+Triggering silenced error
+End

--- a/tests/phpt/silenced_errors.phpt
+++ b/tests/phpt/silenced_errors.phpt
@@ -17,25 +17,25 @@ while (!file_exists($vendor . '/vendor')) {
 require $vendor . '/vendor/autoload.php';
 
 init([
-    'before_send' => function () {
+    'before_send' => static function () {
         echo 'Event captured' . PHP_EOL;
     }    
 ]);
 
 echo 'Triggering silenced error' . PHP_EOL;
 @$a['missing'];
-echo 'End first test' . PHP_EOL;
+
 Hub::getCurrent()
     ->getClient()
     ->getOptions()
     ->setCaptureSilencedErrors(true);
+
 echo 'Triggering silenced error' . PHP_EOL;
 @$a['missing'];
 echo 'End'
 ?>
---EXPECTF--
+--EXPECT--
 Triggering silenced error
-End first test
 Triggering silenced error
 Event captured
 End

--- a/tests/phpt/silenced_errors.phpt
+++ b/tests/phpt/silenced_errors.phpt
@@ -1,11 +1,12 @@
 --TEST--
-Test that the error handler ignores silenced errors
+Test that the error handler ignores silenced errors by default, but it reports them with the appropriate option enabled.
 --FILE--
 <?php
 
 namespace Sentry\Tests;
 
 use function Sentry\init;
+use Sentry\State\Hub;
 
 $vendor = __DIR__;
 
@@ -23,8 +24,18 @@ init([
 
 echo 'Triggering silenced error' . PHP_EOL;
 @$a['missing'];
+echo 'End first test' . PHP_EOL;
+Hub::getCurrent()
+    ->getClient()
+    ->getOptions()
+    ->setCaptureSilencedErrors(true);
+echo 'Triggering silenced error' . PHP_EOL;
+@$a['missing'];
 echo 'End'
 ?>
 --EXPECTF--
 Triggering silenced error
+End first test
+Triggering silenced error
+Event captured
 End


### PR DESCRIPTION
This should solve #784.

I'm basically capturing silenced errors as `SilencedErrorException`, so we can handle them gracefully in the listener. I will add a `capture_silenced_error` option too, so the capture will be opt-in.