### PR TITLE
fix: Mark Sentry internal frames for attach_stacktrace to in_app false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (786)
+
 ## 2.0.1 (2019-03-01)
 
 - Do no longer report silenced errors by default (#785)

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -138,6 +138,11 @@ class Stacktrace implements \JsonSerializable
             $frame->setPostContext($sourceCodeExcerpt['post_context']);
         }
 
+        // In case it's an Sentry internal frame, we mark it as in_app false
+        if (null !== $functionName && 0 === strpos($functionName, 'Sentry\\')) {
+            $frame->setIsInApp(false);
+        }
+
         if (null !== $this->options->getProjectRoot()) {
             $excludedAppPaths = $this->options->getInAppExcludedPaths();
             $absoluteFilePath = @realpath($file) ?: $file;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -424,6 +424,8 @@ class ClientTest extends TestCase
 
                 $this->assertInstanceOf(Stacktrace::class, $result);
                 $this->assertNotEmpty($result->getFrames());
+                $this->assertTrue($result->getFrames()[0]->isInApp());
+                $this->assertFalse($result->getFrames()[\count($result->getFrames()) - 1]->isInApp());
 
                 return true;
             }));

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -423,9 +423,12 @@ class ClientTest extends TestCase
                 $result = $event->getStacktrace();
 
                 $this->assertInstanceOf(Stacktrace::class, $result);
-                $this->assertNotEmpty($result->getFrames());
-                $this->assertTrue($result->getFrames()[0]->isInApp());
-                $this->assertFalse($result->getFrames()[\count($result->getFrames()) - 1]->isInApp());
+
+                $frames = $result->getFrames();
+
+                $this->assertNotEmpty($frames);
+                $this->assertTrue($frames[0]->isInApp());
+                $this->assertFalse($frames[\count($frames) - 1]->isInApp());
 
                 return true;
             }));


### PR DESCRIPTION
This marks Sentry internal frames when using `attach_stacktrace` to `in_app` `false` to have better grouping and stack trace.

Before:
![image](https://user-images.githubusercontent.com/363802/53824178-39a70680-3f28-11e9-9790-a2218fa74a4d.png)

After:
![image](https://user-images.githubusercontent.com/363802/53824212-4af01300-3f28-11e9-90a6-9d7e8d51857a.png)

