### PR TITLE
Remap E_RECOVERABLE_ERROR to Severity::ERROR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (786)
+- Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (#786)
+- Increase default severity of `E_RECOVERABLE_ERROR` to `Severity::ERROR`, instead of warning (#792)
 
 ## 2.0.1 (2019-03-01)
 

--- a/src/Severity.php
+++ b/src/Severity.php
@@ -14,31 +14,37 @@ final class Severity
 {
     /**
      * This constant represents the "debug" severity level.
+     * @internal
      */
     public const DEBUG = 'debug';
 
     /**
      * This constant represents the "info" severity level.
+     * @internal
      */
     public const INFO = 'info';
 
     /**
      * This constant represents the "warning" severity level.
+     * @internal
      */
     public const WARNING = 'warning';
 
     /**
      * This constant represents the "error" severity level.
+     * @internal
      */
     public const ERROR = 'error';
 
     /**
      * This constant represents the "fatal" severity level.
+     * @internal
      */
     public const FATAL = 'fatal';
 
     /**
      * This constant contains the list of allowed enum values.
+     * @internal 
      */
     public const ALLOWED_SEVERITIES = [
         self::DEBUG,

--- a/src/Severity.php
+++ b/src/Severity.php
@@ -14,37 +14,43 @@ final class Severity
 {
     /**
      * This constant represents the "debug" severity level.
+     *
      * @internal
      */
     public const DEBUG = 'debug';
 
     /**
      * This constant represents the "info" severity level.
+     *
      * @internal
      */
     public const INFO = 'info';
 
     /**
      * This constant represents the "warning" severity level.
+     *
      * @internal
      */
     public const WARNING = 'warning';
 
     /**
      * This constant represents the "error" severity level.
+     *
      * @internal
      */
     public const ERROR = 'error';
 
     /**
      * This constant represents the "fatal" severity level.
+     *
      * @internal
      */
     public const FATAL = 'fatal';
 
     /**
      * This constant contains the list of allowed enum values.
-     * @internal 
+     *
+     * @internal
      */
     public const ALLOWED_SEVERITIES = [
         self::DEBUG,

--- a/src/Severity.php
+++ b/src/Severity.php
@@ -81,7 +81,6 @@ final class Severity
              case E_USER_DEPRECATED:
              case E_WARNING:
              case E_USER_WARNING:
-             case E_RECOVERABLE_ERROR:
                  return self::warning();
              case E_ERROR:
              case E_PARSE:
@@ -90,6 +89,7 @@ final class Severity
              case E_COMPILE_ERROR:
              case E_COMPILE_WARNING:
                  return self::fatal();
+             case E_RECOVERABLE_ERROR:
              case E_USER_ERROR:
                  return self::error();
              case E_NOTICE:

--- a/tests/SeverityTest.php
+++ b/tests/SeverityTest.php
@@ -62,4 +62,37 @@ final class SeverityTest extends TestCase
         $this->assertTrue($severity1->isEqualTo($severity2));
         $this->assertFalse($severity1->isEqualTo($severity3));
     }
+
+    /**
+     * @dataProvider fromErrorDataProvider
+     */
+    public function testFromError(int $errorLevel, string $expectedSeverity): void
+    {
+        $this->assertSame($expectedSeverity, Severity::fromError($errorLevel)->__toString());
+    }
+
+    public function fromErrorDataProvider(): array
+    {
+        return [
+            // Warning
+            [E_DEPRECATED, Severity::WARNING],
+            [E_USER_DEPRECATED, Severity::WARNING],
+            [E_WARNING, Severity::WARNING],
+            [E_USER_WARNING, Severity::WARNING],
+            // Fatal
+            [E_ERROR, Severity::FATAL],
+            [E_PARSE, Severity::FATAL],
+            [E_CORE_ERROR, Severity::FATAL],
+            [E_CORE_WARNING, Severity::FATAL],
+            [E_COMPILE_ERROR, Severity::FATAL],
+            [E_COMPILE_WARNING, Severity::FATAL],
+            // Error
+            [E_RECOVERABLE_ERROR, Severity::ERROR],
+            [E_USER_ERROR, Severity::ERROR],
+            // Info
+            [E_NOTICE, Severity::INFO],
+            [E_USER_NOTICE, Severity::INFO],
+            [E_STRICT, Severity::INFO],
+        ];
+    }
 }

--- a/tests/SeverityTest.php
+++ b/tests/SeverityTest.php
@@ -18,39 +18,31 @@ final class SeverityTest extends TestCase
         new Severity('foo');
     }
 
-    public function testDebug(): void
+    /**
+     * @dataProvider constantsDataProvider
+     */
+    public function testConstructor(Severity $severity, string $expectedStringRepresentation): void
     {
-        $severity = Severity::debug();
-
-        $this->assertSame(Severity::DEBUG, (string) $severity);
+        $this->assertTrue($severity->isEqualTo(new Severity($expectedStringRepresentation)));
     }
 
-    public function testInfo(): void
+    /**
+     * @dataProvider constantsDataProvider
+     */
+    public function testToString(Severity $severity, string $expectedStringRepresentation): void
     {
-        $severity = Severity::info();
-
-        $this->assertSame(Severity::INFO, (string) $severity);
+        $this->assertSame($expectedStringRepresentation, (string) $severity);
     }
 
-    public function testWarning(): void
+    public function constantsDataProvider(): array
     {
-        $severity = Severity::warning();
-
-        $this->assertSame(Severity::WARNING, (string) $severity);
-    }
-
-    public function testError(): void
-    {
-        $severity = Severity::error();
-
-        $this->assertSame(Severity::ERROR, (string) $severity);
-    }
-
-    public function testFatal(): void
-    {
-        $severity = Severity::fatal();
-
-        $this->assertSame(Severity::FATAL, (string) $severity);
+        return [
+            [Severity::debug(), 'debug'],
+            [Severity::info(), 'info'],
+            [Severity::warning(), 'warning'],
+            [Severity::error(), 'error'],
+            [Severity::fatal(), 'fatal'],
+        ];
     }
 
     public function testIsEqualTo(): void
@@ -64,35 +56,35 @@ final class SeverityTest extends TestCase
     }
 
     /**
-     * @dataProvider fromErrorDataProvider
+     * @dataProvider levelsDataProvider
      */
     public function testFromError(int $errorLevel, string $expectedSeverity): void
     {
-        $this->assertSame($expectedSeverity, Severity::fromError($errorLevel)->__toString());
+        $this->assertSame($expectedSeverity, (string) Severity::fromError($errorLevel));
     }
 
-    public function fromErrorDataProvider(): array
+    public function levelsDataProvider(): array
     {
         return [
             // Warning
-            [E_DEPRECATED, Severity::WARNING],
-            [E_USER_DEPRECATED, Severity::WARNING],
-            [E_WARNING, Severity::WARNING],
-            [E_USER_WARNING, Severity::WARNING],
+            [E_DEPRECATED, 'warning'],
+            [E_USER_DEPRECATED, 'warning'],
+            [E_WARNING, 'warning'],
+            [E_USER_WARNING, 'warning'],
             // Fatal
-            [E_ERROR, Severity::FATAL],
-            [E_PARSE, Severity::FATAL],
-            [E_CORE_ERROR, Severity::FATAL],
-            [E_CORE_WARNING, Severity::FATAL],
-            [E_COMPILE_ERROR, Severity::FATAL],
-            [E_COMPILE_WARNING, Severity::FATAL],
+            [E_ERROR, 'fatal'],
+            [E_PARSE, 'fatal'],
+            [E_CORE_ERROR, 'fatal'],
+            [E_CORE_WARNING, 'fatal'],
+            [E_COMPILE_ERROR, 'fatal'],
+            [E_COMPILE_WARNING, 'fatal'],
             // Error
-            [E_RECOVERABLE_ERROR, Severity::ERROR],
-            [E_USER_ERROR, Severity::ERROR],
+            [E_RECOVERABLE_ERROR, 'error'],
+            [E_USER_ERROR, 'error'],
             // Info
-            [E_NOTICE, Severity::INFO],
-            [E_USER_NOTICE, Severity::INFO],
-            [E_STRICT, Severity::INFO],
+            [E_NOTICE, 'info'],
+            [E_USER_NOTICE, 'info'],
+            [E_STRICT, 'info'],
         ];
     }
 }


### PR DESCRIPTION
This has surfaced during the Symfony integration development, where a `\TypeError` is mapped as `E_RECOVERABLE_ERROR`.

Since we don't know if the error is coming from an user-submitted report or as a crash, is safer to assume the latter and map it as an error, not as a warning.