### PR TITLE
Fix documentation of error_types option

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -53,8 +53,6 @@ Please visit [our docs](https://docs.sentry.io/error-reporting/quickstart/?platf
 
 - The `ignore_server_port` option has been removed.
 
-- The `error_types` option has been removed.
-
 - The `trust_x_forwarded_proto` option has been removed.
 
 - The `mb_detect_order` option has been removed.

--- a/src/Options.php
+++ b/src/Options.php
@@ -462,7 +462,7 @@ final class Options
     }
 
     /**
-     * Gets a bit mask for error_reporting used in {@link ErrorHandler::handleError}.
+     * Gets a bit mask for error_reporting used in {@link ErrorListenerIntegration} to filter which errors to report.
      *
      * @return int
      */
@@ -472,7 +472,7 @@ final class Options
     }
 
     /**
-     * Sets a bit mask for error_reporting used in {@link ErrorHandler::handleError}.
+     * Sets a bit mask for error_reporting used in {@link ErrorListenerIntegration} to filter which errors to report.
      *
      * @param int $errorTypes The bit mask
      */


### PR DESCRIPTION
As brought up in #793, we were not documenting correctly the `error_types` option. This will fix that.