### PR TITLE
Add Breadcrumb::fromArray constructional helper function

### DIFF
--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -14,6 +14,11 @@ use Sentry\Exception\InvalidArgumentException;
 final class Breadcrumb implements \JsonSerializable
 {
     /**
+     * This constant defines the default breadcrumb type.
+     */
+    public const TYPE_DEFAULT = 'default';
+
+    /**
      * This constant defines the http breadcrumb type.
      */
     public const TYPE_HTTP = 'http';
@@ -355,6 +360,22 @@ final class Breadcrumb implements \JsonSerializable
             'timestamp' => $this->timestamp,
             'data' => $this->metadata,
         ];
+    }
+
+    /**
+     * Helper method to create an instance of this class from an array of data.
+     *
+     * @param array $data Data used to populate the breadcrumb
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data['level'],
+            $data['type'] ?? self::TYPE_DEFAULT,
+            $data['category'],
+            $data['message'] ?? null,
+            $data['data'] ?? []
+        );
     }
 
     /**

--- a/tests/BreadcrumbTest.php
+++ b/tests/BreadcrumbTest.php
@@ -43,6 +43,52 @@ final class BreadcrumbTest extends TestCase
         $this->assertEquals(microtime(true), $breadcrumb->getTimestamp());
     }
 
+    /**
+     * @dataProvider fromArrayDataProvider
+     */
+    public function testFromArray(array $requestData, array $expectedResult): void
+    {
+        $expectedResult['timestamp'] = microtime(true);
+        $breadcrumb = Breadcrumb::fromArray($requestData);
+
+        $this->assertEquals($expectedResult, $breadcrumb->toArray());
+    }
+
+    public function fromArrayDataProvider(): array
+    {
+        return [
+            [
+                [
+                    'level' => Breadcrumb::LEVEL_INFO,
+                    'type' => Breadcrumb::TYPE_USER,
+                    'category' => 'foo',
+                    'message' => 'foo bar',
+                    'data' => ['baz'],
+                ],
+                [
+                    'level' => Breadcrumb::LEVEL_INFO,
+                    'type' => Breadcrumb::TYPE_USER,
+                    'category' => 'foo',
+                    'message' => 'foo bar',
+                    'data' => ['baz'],
+                ],
+            ],
+            [
+                [
+                    'level' => Breadcrumb::LEVEL_INFO,
+                    'category' => 'foo',
+                ],
+                [
+                    'level' => Breadcrumb::LEVEL_INFO,
+                    'type' => Breadcrumb::TYPE_DEFAULT,
+                    'category' => 'foo',
+                    'message' => null,
+                    'data' => [],
+                ],
+            ],
+        ];
+    }
+
     public function testWithCategory(): void
     {
         $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::TYPE_USER, 'foo');


### PR DESCRIPTION
If a Breadcrumb object is passed, do as it does today.

If an associative array is passed, use specific array items to create a new Breadcrumb (applying some defaults if needed).

Also added TYPE_DEFAULT to the Breadcrumb object, which appeared to be missing.

Added a test to SdkTest.php to include creation using new array argument option.


[Link to forum item which provides some background on this](https://forum.sentry.io/t/php-sdk-2-0-breadcrumb-creation-improvements/6350)