### PR TITLE
Allow user to await async transports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
         "phpcs": [
             "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
         ],
+        "fix-cs": [
+            "vendor/bin/php-cs-fixer fix --config=.php_cs"
+        ],
         "phpstan": [
             "vendor/bin/phpstan analyse"
         ]

--- a/src/Client.php
+++ b/src/Client.php
@@ -70,7 +70,9 @@ final class Client implements ClientInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Returns the transport of the client.
+     *
+     * @return TransportInterface
      */
     public function getTransport(): TransportInterface
     {

--- a/src/Client.php
+++ b/src/Client.php
@@ -72,6 +72,14 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
+    public function getTransport(): TransportInterface
+    {
+        return $this->transport;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?string
     {
         $payload = [

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ namespace Sentry;
 use Sentry\Integration\Handler;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\State\Scope;
+use Sentry\Transport\AsyncTransportInterface;
 use Sentry\Transport\TransportInterface;
 
 /**
@@ -70,13 +71,13 @@ final class Client implements ClientInterface
     }
 
     /**
-     * Returns the transport of the client.
-     *
-     * @return TransportInterface
+     * Flush the event queue and make sure all events are sent if possible.
      */
-    public function getTransport(): TransportInterface
+    public function flush(): void
     {
-        return $this->transport;
+        if ($this->transport instanceof AsyncTransportInterface) {
+            $this->transport->flush();
+        }
     }
 
     /**

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -6,9 +6,10 @@ namespace Sentry;
 
 use Sentry\Integration\IntegrationInterface;
 use Sentry\State\Scope;
+use Sentry\Transport\TransportInterface;
 
 /**
- * This interface must be implemented by all Raven client classes.
+ * This interface must be implemented by all Sentry client classes.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
@@ -20,6 +21,13 @@ interface ClientInterface
      * @return Options
      */
     public function getOptions(): Options;
+
+    /**
+     * Returns the transport of the client.
+     *
+     * @return TransportInterface
+     */
+    public function getTransport(): TransportInterface;
 
     /**
      * Logs a message.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -6,7 +6,6 @@ namespace Sentry;
 
 use Sentry\Integration\IntegrationInterface;
 use Sentry\State\Scope;
-use Sentry\Transport\TransportInterface;
 
 /**
  * This interface must be implemented by all Sentry client classes.
@@ -21,13 +20,6 @@ interface ClientInterface
      * @return Options
      */
     public function getOptions(): Options;
-
-    /**
-     * Returns the transport of the client.
-     *
-     * @return TransportInterface
-     */
-    public function getTransport(): TransportInterface;
 
     /**
      * Logs a message.

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -9,7 +9,7 @@ use Sentry\Exception\SilencedErrorException;
 
 /**
  * This class implements a simple error handler that catches all configured
- * error types and logs them using a certain Raven client. Registering more
+ * error types and logs them using a certain Sentry client. Registering more
  * than once this error handler is not supported and will lead to nasty problems.
  * The code is based on the Symfony Debug component.
  *
@@ -329,7 +329,7 @@ final class ErrorHandler
     }
 
     /**
-     * Handles errors by capturing them through the Raven client according to
+     * Handles errors by capturing them through the Sentry client according to
      * the configured bit field.
      *
      * @param int    $level   The level of the error raised, represented by one
@@ -365,7 +365,7 @@ final class ErrorHandler
     }
 
     /**
-     * Handles fatal errors by capturing them through the Raven client. This
+     * Handles fatal errors by capturing them through the Sentry client. This
      * method is used as callback of a shutdown function.
      *
      * @param array|null $error The error details as returned by error_get_last()

--- a/src/Spool/MemorySpool.php
+++ b/src/Spool/MemorySpool.php
@@ -34,10 +34,6 @@ final class MemorySpool implements SpoolInterface
      */
     public function flushQueue(TransportInterface $transport): void
     {
-        if (empty($this->events)) {
-            return;
-        }
-
         while ($event = array_pop($this->events)) {
             $transport->send($event);
         }

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -204,22 +204,6 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function await(): void
-    {
-        $client = $this->getClient();
-
-        if ($client instanceof Client) {
-            $transport = $client->getTransport();
-
-            if ($transport instanceof AsyncTransportInterface) {
-                $transport->await();
-            }
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public static function getCurrent(): HubInterface
     {
         if (null === self::$currentHub) {

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\State;
 
 use Sentry\Breadcrumb;
+use Sentry\Client;
 use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
@@ -205,10 +206,14 @@ final class Hub implements HubInterface
      */
     public function await(): void
     {
-        $transport = $this->getClient()->getTransport();
+        $client = $this->getClient();
 
-        if ($transport instanceof AsyncTransportInterface) {
-            $transport->await();
+        if ($client instanceof Client) {
+            $transport = $client->getTransport();
+
+            if ($transport instanceof AsyncTransportInterface) {
+                $transport->await();
+            }
         }
     }
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -8,6 +8,7 @@ use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
+use Sentry\Transport\AsyncTransportInterface;
 
 /**
  * This class is a basic implementation of the {@see HubInterface} interface.
@@ -197,6 +198,18 @@ final class Hub implements HubInterface
         }
 
         return null !== $breadcrumb;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function await(): void
+    {
+        $transport = $this->getClient()->getTransport();
+
+        if ($transport instanceof AsyncTransportInterface) {
+            $transport->await();
+        }
     }
 
     /**

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -120,6 +120,12 @@ interface HubInterface
     public function addBreadcrumb(Breadcrumb $breadcrumb): bool;
 
     /**
+     * Await all async transports, this effectively forces all async event to be
+     * transported immediately.
+     */
+    public function await(): void;
+
+    /**
      * Returns the current global Hub.
      *
      * @return self

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -120,12 +120,6 @@ interface HubInterface
     public function addBreadcrumb(Breadcrumb $breadcrumb): bool;
 
     /**
-     * Await all async transports, this effectively forces all async event to be
-     * transported immediately.
-     */
-    public function await(): void;
-
-    /**
      * Returns the current global Hub.
      *
      * @return self

--- a/src/Transport/AsyncTransportInterface.php
+++ b/src/Transport/AsyncTransportInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Transport;
+
+/**
+ * This interface must be implemented by all classes willing to provide a way
+ * of sending events to a Sentry server in an async matter.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+interface AsyncTransportInterface extends TransportInterface
+{
+    /**
+     * Wait for all events to be transported.
+     */
+    public function await(): void;
+}

--- a/src/Transport/AsyncTransportInterface.php
+++ b/src/Transport/AsyncTransportInterface.php
@@ -15,5 +15,5 @@ interface AsyncTransportInterface extends TransportInterface
     /**
      * Wait for all events to be transported.
      */
-    public function await(): void;
+    public function flush(): void;
 }

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -104,10 +104,6 @@ final class HttpTransport implements AsyncTransportInterface
      */
     public function await(): void
     {
-        if (empty($this->pendingRequests)) {
-            return;
-        }
-
         while ($pendingRequest = array_pop($this->pendingRequests)) {
             try {
                 $pendingRequest->wait();

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -19,7 +19,7 @@ use Sentry\Util\JSON;
 final class HttpTransport implements AsyncTransportInterface
 {
     /**
-     * @var Options The Raven client configuration
+     * @var Options The Sentry client configuration
      */
     private $config;
 
@@ -41,7 +41,7 @@ final class HttpTransport implements AsyncTransportInterface
     /**
      * Constructor.
      *
-     * @param Options         $config         The Raven client configuration
+     * @param Options         $config         The Sentry client configuration
      * @param HttpAsyncClient $httpClient     The HTTP client
      * @param RequestFactory  $requestFactory The PSR-7 request factory
      */

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -17,6 +17,7 @@ use Sentry\Serializer\Serializer;
 use Sentry\Serializer\SerializerInterface;
 use Sentry\Severity;
 use Sentry\Stacktrace;
+use Sentry\Transport\AsyncTransportInterface;
 use Sentry\Transport\TransportInterface;
 
 class ClientTest extends TestCase
@@ -429,6 +430,21 @@ class ClientTest extends TestCase
             ->getClient();
 
         $client->captureEvent([]);
+    }
+
+    public function testClientFlushEvents(): void
+    {
+        /** @var AsyncTransportInterface|MockObject $asyncTransport */
+        $asyncTransport = $this->createMock(AsyncTransportInterface::class);
+        $asyncTransport->expects($this->once())
+                       ->method('flush');
+
+        /** @var Client $client */
+        $client = ClientBuilder::create()
+                               ->setTransport($asyncTransport)
+                               ->getClient();
+
+        $client->flush();
     }
 
     /**

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -7,6 +7,7 @@ namespace Sentry\Tests\State;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
+use Sentry\Client;
 use Sentry\ClientBuilder;
 use Sentry\ClientInterface;
 use Sentry\Severity;
@@ -296,38 +297,19 @@ final class HubTest extends TestCase
         $this->assertEquals('2b867534eead412cbdb882fd5d441690', $hub->captureEvent(['message' => 'test']));
     }
 
-    public function testClientAwait(): void
-    {
-        /** @var ClientInterface|MockObject $asyncTransport */
-        $transport = $this->createMock(TransportInterface::class);
-
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $hub = new Hub($client);
-
-        $client->expects($this->once())
-               ->method('getTransport')
-               ->willReturn($transport);
-
-        $hub->await();
-    }
-
     public function testClientAwaitAsync(): void
     {
-        /** @var ClientInterface|MockObject $asyncTransport */
+        /** @var AsyncTransportInterface|MockObject $asyncTransport */
         $asyncTransport = $this->createMock(AsyncTransportInterface::class);
-
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $hub = new Hub($client);
-
-        $client->expects($this->once())
-               ->method('getTransport')
-               ->willReturn($asyncTransport);
-
         $asyncTransport->expects($this->once())
-                       ->method('await');
+            ->method('await');
 
+        /** @var Client $client */
+        $client = ClientBuilder::create()
+            ->setTransport($asyncTransport)
+            ->getClient();
+
+        $hub = new Hub($client);
         $hub->await();
     }
 

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -15,7 +15,6 @@ use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Sentry\Transport\AsyncTransportInterface;
-use Sentry\Transport\TransportInterface;
 
 final class HubTest extends TestCase
 {

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -296,22 +296,6 @@ final class HubTest extends TestCase
         $this->assertEquals('2b867534eead412cbdb882fd5d441690', $hub->captureEvent(['message' => 'test']));
     }
 
-    public function testClientAwaitAsync(): void
-    {
-        /** @var AsyncTransportInterface|MockObject $asyncTransport */
-        $asyncTransport = $this->createMock(AsyncTransportInterface::class);
-        $asyncTransport->expects($this->once())
-            ->method('await');
-
-        /** @var Client $client */
-        $client = ClientBuilder::create()
-            ->setTransport($asyncTransport)
-            ->getClient();
-
-        $hub = new Hub($client);
-        $hub->await();
-    }
-
     private function getScope(HubInterface $hub): Scope
     {
         $method = new \ReflectionMethod($hub, 'getScope');

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -70,7 +70,7 @@ final class HttpTransportTest extends TestCase
 
         $this->assertAttributeNotEmpty('pendingRequests', $transport);
 
-        $transport->await();
+        $transport->flush();
     }
 
     public function testSendFailureCleanupPendingRequests(): void

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -70,10 +70,7 @@ final class HttpTransportTest extends TestCase
 
         $this->assertAttributeNotEmpty('pendingRequests', $transport);
 
-        $reflectionMethod = new \ReflectionMethod(HttpTransport::class, 'cleanupPendingRequests');
-        $reflectionMethod->setAccessible(true);
-        $reflectionMethod->invoke($transport);
-        $reflectionMethod->setAccessible(false);
+        $transport->await();
     }
 
     public function testSendFailureCleanupPendingRequests(): void


### PR DESCRIPTION
I wanted to open this PR to have a discussion about how to implement this and if this is the way to go but we need to come up with a solution of some sorts.

The problem is that the HttpTransport uses an async client that because of how php works never actually starts the sending of the events until `->wait` is called. Previously in 1.x this was fixed by an `sendUnsentErrors` and this attempts to replace that with `Hub::getCurrent()->await()` that a user or a framework integration can use to send unsent errors (if there are any).

We can for now go with not changing the `Client` interface so this is a non-bc and we can release it sooner so we can fix the problems people might encounter in longer running processes like a Laravel queue worker.

My intention is to get a fix/workaround for this issue crafted sooner rather than later if possible, it ofcourse doesn't have to be this exact way but also doesn't need to take use a few week to come up with a decent solution :)