### PR TITLE
Fix #805: Default type must be an array

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -124,7 +124,7 @@ final class Event implements \JsonSerializable
     /**
      * @var array The exceptions
      */
-    private $exceptions;
+    private $exceptions = [];
 
     /**
      * @var Stacktrace|null The stacktrace that generated this event
@@ -640,7 +640,7 @@ final class Event implements \JsonSerializable
             $data['breadcrumbs']['values'] = $this->breadcrumbs;
         }
 
-        if (null !== $this->exceptions) {
+        if (!empty($this->exceptions)) {
             $reversedException = array_reverse($this->exceptions);
 
             foreach ($reversedException as $exception) {

--- a/src/Event.php
+++ b/src/Event.php
@@ -640,23 +640,19 @@ final class Event implements \JsonSerializable
             $data['breadcrumbs']['values'] = $this->breadcrumbs;
         }
 
-        if (!empty($this->exceptions)) {
-            $reversedException = array_reverse($this->exceptions);
+        foreach (array_reverse($this->exceptions) as $exception) {
+            $exceptionData = [
+                'type' => $exception['type'],
+                'value' => $exception['value'],
+            ];
 
-            foreach ($reversedException as $exception) {
-                $exceptionData = [
-                    'type' => $exception['type'],
-                    'value' => $exception['value'],
+            if (isset($exception['stacktrace'])) {
+                $exceptionData['stacktrace'] = [
+                    'frames' => $exception['stacktrace']->toArray(),
                 ];
-
-                if (isset($exception['stacktrace'])) {
-                    $exceptionData['stacktrace'] = [
-                        'frames' => $exception['stacktrace']->toArray(),
-                    ];
-                }
-
-                $data['exception']['values'][] = $exceptionData;
             }
+
+            $data['exception']['values'][] = $exceptionData;
         }
 
         if (null !== $this->stacktrace) {


### PR DESCRIPTION
In `Event` class, the default value for `private $exceptions;` is implicit `null` must be an `array`