### PR TITLE
Capture the body of the request and do a best effort to decode it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for `SENTRY_ENVRIONMENT` and `SENTRY_RELEASE` environment variables (#810)
 - Fix the default value of the `$exceptions` property of the Event class (#806)
 - Add a Monolog handler (#808)
+- Allow capturing the body of an HTTP request (#807)
 
 ## 2.0.1 (2019-03-01)
 

--- a/src/Exception/JsonException.php
+++ b/src/Exception/JsonException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Exception;
+
+final class JsonException extends \Exception
+{
+}

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -24,15 +24,15 @@ final class RequestIntegration implements IntegrationInterface
 {
     /**
      * This constant represents the size limit in bytes beyond which the body
-     * of the request is not captured when the `request_bodies` option is set
-     * to `small`.
+     * of the request is not captured when the `max_request_body_size` option
+     * is set to `small`.
      */
     private const REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH = 10 ** 3;
 
     /**
      * This constant represents the size limit in bytes beyond which the body
-     * of the request is not captured when the `request_bodies` option is set
-     * to `medium`.
+     * of the request is not captured when the `max_request_body_size` option
+     * is set to `medium`.
      */
     private const REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH = 10 ** 4;
 
@@ -153,10 +153,14 @@ final class RequestIntegration implements IntegrationInterface
      */
     private function captureRequestBody(ServerRequestInterface $serverRequest)
     {
-        $maxRequestBodySize = $this->options->getRequestBodies();
+        $maxRequestBodySize = $this->options->getMaxRequestBodySize();
         $requestBody = $serverRequest->getBody();
 
-        if ('none' === $maxRequestBodySize || ('small' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH) || ('medium' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH)) {
+        if (
+            'none' === $maxRequestBodySize ||
+            ('small' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH) ||
+            ('medium' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH)
+        ) {
             return null;
         }
 

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\UploadedFileInterface;
 use Sentry\Event;
+use Sentry\Exception\JsonException;
 use Sentry\Options;
 use Sentry\State\Hub;
 use Sentry\State\Scope;
+use Sentry\Util\JSON;
 use Zend\Diactoros\ServerRequestFactory;
 
 /**
@@ -20,14 +23,28 @@ use Zend\Diactoros\ServerRequestFactory;
 final class RequestIntegration implements IntegrationInterface
 {
     /**
+     * This constant represents the size limit in bytes beyond which the body
+     * of the request is not captured when the `request_bodies` option is set
+     * to `small`.
+     */
+    private const REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH = 10 ** 3;
+
+    /**
+     * This constant represents the size limit in bytes beyond which the body
+     * of the request is not captured when the `request_bodies` option is set
+     * to `medium`.
+     */
+    private const REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH = 10 ** 4;
+
+    /**
      * @var Options The client options
      */
     private $options;
 
     /**
-     * RequestIntegration constructor.
+     * Constructor.
      *
-     * @param Options $options The Client Options
+     * @param Options $options The client options
      */
     public function __construct(Options $options)
     {
@@ -55,7 +72,7 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * Applies the information gathered by the this integration to the event.
      *
-     * @param self                        $self    The current instance of RequestIntegration
+     * @param self                        $self    The current instance of the integration
      * @param Event                       $event   The event that will be enriched with a request
      * @param ServerRequestInterface|null $request The Request that will be processed and added to the event
      */
@@ -95,6 +112,12 @@ final class RequestIntegration implements IntegrationInterface
             $requestData['headers'] = $self->removePiiFromHeaders($request->getHeaders());
         }
 
+        $requestBody = $self->captureRequestBody($request);
+
+        if (!empty($requestBody)) {
+            $requestData['data'] = $requestBody;
+        }
+
         $event->setRequest($requestData);
     }
 
@@ -109,8 +132,64 @@ final class RequestIntegration implements IntegrationInterface
     {
         $keysToRemove = ['authorization', 'cookie', 'set-cookie', 'remote_addr'];
 
-        return array_filter($headers, function ($key) use ($keysToRemove) {
-            return !\in_array(strtolower($key), $keysToRemove, true);
-        }, ARRAY_FILTER_USE_KEY);
+        return array_filter(
+            $headers,
+            static function (string $key) use ($keysToRemove): bool {
+                return !\in_array(strtolower($key), $keysToRemove, true);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+    }
+
+    /**
+     * Gets the decoded body of the request, if available. If the Content-Type
+     * header contains "application/json" then the content is decoded and if
+     * the parsing fails then the raw data is returned. If there are submitted
+     * fields or files, all of their information are parsed and returned.
+     *
+     * @param ServerRequestInterface $serverRequest The server request
+     *
+     * @return mixed
+     */
+    private function captureRequestBody(ServerRequestInterface $serverRequest)
+    {
+        $maxRequestBodySize = $this->options->getRequestBodies();
+        $requestBody = $serverRequest->getBody();
+
+        if ('none' === $maxRequestBodySize || ('small' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH) || ('medium' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH)) {
+            return null;
+        }
+
+        $requestData = $serverRequest->getParsedBody();
+        $requestData = \is_array($requestData) ? $requestData : [];
+
+        foreach ($serverRequest->getUploadedFiles() as $fieldName => $uploadedFiles) {
+            if (!\is_array($uploadedFiles)) {
+                $uploadedFiles = [$uploadedFiles];
+            }
+
+            /** @var UploadedFileInterface $uploadedFile */
+            foreach ($uploadedFiles as $uploadedFile) {
+                $requestData[$fieldName][] = [
+                    'client_filename' => $uploadedFile->getClientFilename(),
+                    'client_media_type' => $uploadedFile->getClientMediaType(),
+                    'size' => $uploadedFile->getSize(),
+                ];
+            }
+        }
+
+        if (!empty($requestData)) {
+            return $requestData;
+        }
+
+        if ('application/json' === $serverRequest->getHeaderLine('Content-Type')) {
+            try {
+                return JSON::decode($requestBody->getContents());
+            } catch (JsonException $exception) {
+                // Fallback to returning the raw data from the request body
+            }
+        }
+
+        return $requestBody->getContents();
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -666,6 +666,40 @@ final class Options
     }
 
     /**
+     * Gets whether integrations should capture HTTP request bodies.
+     *
+     * @return string
+     */
+    public function getRequestBodies(): string
+    {
+        return $this->options['request_bodies'];
+    }
+
+    /**
+     * Sets whether integrations should capture HTTP request bodies.
+     *
+     * @param string $requestBodies The limit up to which request body are
+     *                              captured. It can be set to one of the
+     *                              following values:
+     *
+     *                               - never: request bodies are never sent
+     *                               - small: only small request bodies will
+     *                                 be captured where the cutoff for small
+     *                                 depends on the SDK (typically 4KB)
+     *                               - medium: medium-sized requests and small
+     *                                 requests will be captured. (typically 10KB)
+     *                               - always: the SDK will always capture the
+     *                                 request body for as long as sentry can make
+     *                                 sense of it
+     */
+    public function setRequestBodies(string $requestBodies): void
+    {
+        $options = array_merge($this->options, ['request_bodies' => $requestBodies]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -705,6 +739,7 @@ final class Options
             'max_value_length' => 1024,
             'http_proxy' => null,
             'capture_silenced_errors' => false,
+            'request_bodies' => 'none',
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -732,7 +767,9 @@ final class Options
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
+        $resolver->setAllowedTypes('request_bodies', 'string');
 
+        $resolver->setAllowedValues('request_bodies', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -666,35 +666,37 @@ final class Options
     }
 
     /**
-     * Gets whether integrations should capture HTTP request bodies.
+     * Gets the limit up to which integrations should capture the HTTP request
+     * body.
      *
      * @return string
      */
-    public function getRequestBodies(): string
+    public function getMaxRequestBodySize(): string
     {
-        return $this->options['request_bodies'];
+        return $this->options['max_request_body_size'];
     }
 
     /**
-     * Sets whether integrations should capture HTTP request bodies.
+     * Sets the limit up to which integrations should capture the HTTP request
+     * body.
      *
-     * @param string $requestBodies The limit up to which request body are
-     *                              captured. It can be set to one of the
-     *                              following values:
+     * @param string $maxRequestBodySize The limit up to which request body are
+     *                                   captured. It can be set to one of the
+     *                                   following values:
      *
-     *                               - never: request bodies are never sent
-     *                               - small: only small request bodies will
-     *                                 be captured where the cutoff for small
-     *                                 depends on the SDK (typically 4KB)
-     *                               - medium: medium-sized requests and small
-     *                                 requests will be captured. (typically 10KB)
-     *                               - always: the SDK will always capture the
-     *                                 request body for as long as sentry can make
-     *                                 sense of it
+     *                                    - never: request bodies are never sent
+     *                                    - small: only small request bodies will
+     *                                      be captured where the cutoff for small
+     *                                      depends on the SDK (typically 4KB)
+     *                                    - medium: medium-sized requests and small
+     *                                      requests will be captured. (typically 10KB)
+     *                                    - always: the SDK will always capture the
+     *                                      request body for as long as sentry can
+     *                                      make sense of it
      */
-    public function setRequestBodies(string $requestBodies): void
+    public function setMaxRequestBodySize(string $maxRequestBodySize): void
     {
-        $options = array_merge($this->options, ['request_bodies' => $requestBodies]);
+        $options = array_merge($this->options, ['max_request_body_size' => $maxRequestBodySize]);
 
         $this->options = $this->resolver->resolve($options);
     }
@@ -739,7 +741,7 @@ final class Options
             'max_value_length' => 1024,
             'http_proxy' => null,
             'capture_silenced_errors' => false,
-            'request_bodies' => 'none',
+            'max_request_body_size' => 'none',
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -767,9 +769,9 @@ final class Options
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
-        $resolver->setAllowedTypes('request_bodies', 'string');
+        $resolver->setAllowedTypes('max_request_body_size', 'string');
 
-        $resolver->setAllowedValues('request_bodies', ['none', 'small', 'medium', 'always']);
+        $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -741,7 +741,7 @@ final class Options
             'max_value_length' => 1024,
             'http_proxy' => null,
             'capture_silenced_errors' => false,
-            'max_request_body_size' => 'none',
+            'max_request_body_size' => 'medium',
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry\Util;
 
+use Sentry\Exception\JsonException;
+
 /**
  * This class provides some utility methods to encode/decode JSON data.
  *
@@ -18,16 +20,36 @@ final class JSON
      *
      * @return string
      *
-     * @throws \InvalidArgumentException If the encoding failed
+     * @throws JsonException If the encoding failed
      */
     public static function encode($data): string
     {
         $encodedData = json_encode($data, JSON_UNESCAPED_UNICODE);
 
         if (JSON_ERROR_NONE !== json_last_error() || false === $encodedData) {
-            throw new \InvalidArgumentException(sprintf('Could not encode value into JSON format. Error was: "%s".', json_last_error_msg()));
+            throw new JsonException(sprintf('Could not encode value into JSON format. Error was: "%s".', json_last_error_msg()));
         }
 
         return $encodedData;
+    }
+
+    /**
+     * Decodes the given data from JSON.
+     *
+     * @param string $data The data to decode
+     *
+     * @return mixed
+     *
+     * @throws JsonException If the decoding failed
+     */
+    public static function decode(string $data)
+    {
+        $decodedData = json_decode($data, true);
+
+        if (JSON_ERROR_NONE !== json_last_error()) {
+            throw new JsonException(sprintf('Could not decode value from JSON format. Error was: "%s".', json_last_error_msg()));
+        }
+
+        return $decodedData;
     }
 }

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -190,7 +190,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'none',
+                'max_request_body_size' => 'none',
             ],
             (new ServerRequest())
                 ->withParsedBody([
@@ -211,7 +211,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'small',
+                'max_request_body_size' => 'small',
             ],
             (new ServerRequest())
                 ->withParsedBody([
@@ -236,7 +236,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'small',
+                'max_request_body_size' => 'small',
             ],
             (new ServerRequest())
                 ->withParsedBody([
@@ -257,7 +257,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'medium',
+                'max_request_body_size' => 'medium',
             ],
             (new ServerRequest())
                 ->withParsedBody([
@@ -282,7 +282,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'medium',
+                'max_request_body_size' => 'medium',
             ],
             (new ServerRequest())
                 ->withParsedBody([
@@ -303,7 +303,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'always',
+                'max_request_body_size' => 'always',
             ],
             (new ServerRequest())
                 ->withUploadedFiles([
@@ -331,7 +331,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'always',
+                'max_request_body_size' => 'always',
             ],
             (new ServerRequest())
                 ->withUploadedFiles([
@@ -367,7 +367,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'always',
+                'max_request_body_size' => 'always',
             ],
             (new ServerRequest())
                 ->withUploadedFiles([
@@ -403,7 +403,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'always',
+                'max_request_body_size' => 'always',
             ],
             (new ServerRequest())
                 ->withUri(new Uri('http://www.example.com/foo'))
@@ -425,7 +425,7 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'request_bodies' => 'always',
+                'max_request_body_size' => 'always',
             ],
             (new ServerRequest())
                 ->withUri(new Uri('http://www.example.com/foo'))

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\Integration;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Sentry\Event;
 use Sentry\Integration\RequestIntegration;
 use Sentry\Options;
 use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\UploadedFile;
 use Zend\Diactoros\Uri;
 
 final class RequestIntegrationTest extends TestCase
 {
     /**
-     * @dataProvider invokeUserContextPiiDataProvider
+     * @dataProvider applyToEventWithRequestHavingIpAddressDataProvider
      */
     public function testInvokeWithRequestHavingIpAddress(bool $shouldSendPii, array $expectedValue): void
     {
@@ -34,7 +37,7 @@ final class RequestIntegrationTest extends TestCase
         $this->assertEquals($expectedValue, $event->getUserContext()->toArray());
     }
 
-    public function invokeUserContextPiiDataProvider(): array
+    public function applyToEventWithRequestHavingIpAddressDataProvider(): array
     {
         return [
             [
@@ -49,162 +52,410 @@ final class RequestIntegrationTest extends TestCase
     }
 
     /**
-     * @dataProvider invokeDataProvider
+     * @dataProvider applyToEventDataProvider
      */
-    public function testInvoke(bool $shouldSendPii, array $requestData, array $expectedResult): void
+    public function testApplyToEvent(array $options, ServerRequestInterface $request, array $expectedResult): void
     {
         $event = new Event();
-
-        $request = new ServerRequest();
-        $request = $request->withCookieParams($requestData['cookies']);
-        $request = $request->withUri(new Uri($requestData['uri']));
-        $request = $request->withMethod($requestData['method']);
-
-        foreach ($requestData['headers'] as $name => $value) {
-            $request = $request->withHeader($name, $value);
-        }
-
-        $this->assertInstanceOf(ServerRequestInterface::class, $request);
-
-        $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
+        $integration = new RequestIntegration(new Options($options));
 
         RequestIntegration::applyToEvent($integration, $event, $request);
 
         $this->assertEquals($expectedResult, $event->getRequest());
     }
 
-    public function invokeDataProvider(): array
+    public function applyToEventDataProvider(): \Generator
     {
-        return [
+        yield [
             [
-                true,
-                [
-                    'uri' => 'http://www.example.com/foo',
-                    'method' => 'GET',
-                    'cookies' => [
-                        'foo' => 'bar',
-                    ],
-                    'headers' => [],
+                'send_default_pii' => true,
+            ],
+            (new ServerRequest())
+                ->withCookieParams(['foo' => 'bar'])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('GET'),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'GET',
+                'cookies' => [
+                    'foo' => 'bar',
                 ],
-                [
-                    'url' => 'http://www.example.com/foo',
-                    'method' => 'GET',
-                    'cookies' => [
-                        'foo' => 'bar',
-                    ],
-                    'headers' => [
-                        'Host' => ['www.example.com'],
-                    ],
+                'headers' => [
+                    'Host' => ['www.example.com'],
                 ],
             ],
-            [
-                false,
-                [
-                    'uri' => 'http://www.example.com/foo',
-                    'method' => 'GET',
-                    'cookies' => [
-                        'foo' => 'bar',
-                    ],
-                    'headers' => [],
-                ],
-                [
-                    'url' => 'http://www.example.com/foo',
-                    'method' => 'GET',
-                    'headers' => [
-                        'Host' => ['www.example.com'],
-                    ],
-                ],
-            ],
-            [
-                true,
-                [
-                    'uri' => 'http://www.example.com:123/foo',
-                    'method' => 'GET',
-                    'cookies' => [],
-                    'headers' => [],
-                ],
-                [
-                    'url' => 'http://www.example.com:123/foo',
-                    'method' => 'GET',
-                    'cookies' => [],
-                    'headers' => [
-                        'Host' => ['www.example.com:123'],
-                    ],
-                ],
-            ],
+        ];
 
+        yield [
             [
-                false,
-                [
-                    'uri' => 'http://www.example.com:123/foo',
-                    'method' => 'GET',
-                    'cookies' => [],
-                    'headers' => [],
-                ],
-                [
-                    'url' => 'http://www.example.com:123/foo',
-                    'method' => 'GET',
-                    'headers' => [
-                        'Host' => ['www.example.com:123'],
-                    ],
+                'send_default_pii' => false,
+            ],
+            (new ServerRequest())
+                ->withCookieParams(['foo' => 'bar'])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('GET'),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'GET',
+                'headers' => [
+                    'Host' => ['www.example.com'],
                 ],
             ],
+        ];
 
+        yield [
             [
-                true,
-                [
-                    'uri' => 'http://www.example.com/foo?foo=bar&bar=baz',
-                    'method' => 'GET',
-                    'cookies' => [],
-                    'headers' => [
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                        'Authorization' => 'x',
-                        'Cookie' => 'y',
-                        'Set-Cookie' => 'z',
-                    ],
-                ],
-                [
-                    'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
-                    'method' => 'GET',
-                    'query_string' => 'foo=bar&bar=baz',
-                    'cookies' => [],
-                    'headers' => [
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                        'Authorization' => ['x'],
-                        'Cookie' => ['y'],
-                        'Set-Cookie' => ['z'],
-                    ],
-                    'env' => [
-                        'REMOTE_ADDR' => '127.0.0.1',
-                    ],
+                'send_default_pii' => true,
+            ],
+            (new ServerRequest())
+                ->withUri(new Uri('http://www.example.com:1234/foo'))
+                ->withMethod('GET'),
+            [
+                'url' => 'http://www.example.com:1234/foo',
+                'method' => 'GET',
+                'cookies' => [],
+                'headers' => [
+                    'Host' => ['www.example.com:1234'],
                 ],
             ],
+        ];
 
+        yield [
             [
-                false,
-                [
-                    'uri' => 'http://www.example.com/foo?foo=bar&bar=baz',
-                    'method' => 'GET',
-                    'cookies' => [],
-                    'headers' => [
-                        'Host' => ['www.example.com'],
-                        'REMOTE_ADDR' => ['127.0.0.1'],
-                        'Authorization' => 'x',
-                        'Cookie' => 'y',
-                        'Set-Cookie' => 'z',
-                    ],
+                'send_default_pii' => false,
+            ],
+            (new ServerRequest())
+                ->withUri(new Uri('http://www.example.com:1234/foo'))
+                ->withMethod('GET'),
+            [
+                'url' => 'http://www.example.com:1234/foo',
+                'method' => 'GET',
+                'headers' => [
+                    'Host' => ['www.example.com:1234'],
                 ],
-                [
-                    'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
-                    'method' => 'GET',
-                    'query_string' => 'foo=bar&bar=baz',
-                    'headers' => [
-                        'Host' => ['www.example.com'],
+            ],
+        ];
+
+        yield [
+            [
+                'send_default_pii' => true,
+            ],
+            (new ServerRequest())
+                ->withUri(new Uri('http://www.example.com/foo?foo=bar&bar=baz'))
+                ->withMethod('GET')
+                ->withHeader('Host', 'www.example.com')
+                ->withHeader('REMOTE_ADDR', '127.0.0.1')
+                ->withHeader('Authorization', 'foo')
+                ->withHeader('Cookie', 'bar')
+                ->withHeader('Set-Cookie', 'baz'),
+            [
+                'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
+                'method' => 'GET',
+                'query_string' => 'foo=bar&bar=baz',
+                'cookies' => [],
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'REMOTE_ADDR' => ['127.0.0.1'],
+                    'Authorization' => ['foo'],
+                    'Cookie' => ['bar'],
+                    'Set-Cookie' => ['baz'],
+                ],
+                'env' => [
+                    'REMOTE_ADDR' => '127.0.0.1',
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'send_default_pii' => false,
+            ],
+            (new ServerRequest())
+                ->withUri(new Uri('http://www.example.com/foo?foo=bar&bar=baz'))
+                ->withMethod('GET')
+                ->withHeader('Host', 'www.example.com')
+                ->withHeader('REMOTE_ADDR', '127.0.0.1')
+                ->withHeader('Authorization', 'foo')
+                ->withHeader('Cookie', 'bar')
+                ->withHeader('Set-Cookie', 'baz'),
+            [
+                'url' => 'http://www.example.com/foo?foo=bar&bar=baz',
+                'method' => 'GET',
+                'query_string' => 'foo=bar&bar=baz',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'none',
+            ],
+            (new ServerRequest())
+                ->withParsedBody([
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withBody($this->getStreamMock(1)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'small',
+            ],
+            (new ServerRequest())
+                ->withParsedBody([
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withBody($this->getStreamMock(10 ** 3)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+                'data' => [
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'small',
+            ],
+            (new ServerRequest())
+                ->withParsedBody([
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withBody($this->getStreamMock(10 ** 3 + 1)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'medium',
+            ],
+            (new ServerRequest())
+                ->withParsedBody([
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withBody($this->getStreamMock(10 ** 4)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+                'data' => [
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'medium',
+            ],
+            (new ServerRequest())
+                ->withParsedBody([
+                    'foo' => 'foo value',
+                    'bar' => 'bar value',
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withBody($this->getStreamMock(10 ** 4 + 1)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'always',
+            ],
+            (new ServerRequest())
+                ->withUploadedFiles([
+                    'foo' => new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST'),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+                'data' => [
+                    'foo' => [
+                        [
+                            'client_filename' => 'foo.ext',
+                            'client_media_type' => 'application/text',
+                            'size' => 123,
+                        ],
                     ],
                 ],
             ],
         ];
+
+        yield [
+            [
+                'request_bodies' => 'always',
+            ],
+            (new ServerRequest())
+                ->withUploadedFiles([
+                    'foo' => [
+                        new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
+                        new UploadedFile('bar content', 321, UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
+                    ],
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST'),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+                'data' => [
+                    'foo' => [
+                        [
+                            'client_filename' => 'foo.ext',
+                            'client_media_type' => 'application/text',
+                            'size' => 123,
+                        ],
+                        [
+                            'client_filename' => 'bar.ext',
+                            'client_media_type' => 'application/octet-stream',
+                            'size' => 321,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'always',
+            ],
+            (new ServerRequest())
+                ->withUploadedFiles([
+                    'foo' => [
+                        new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
+                        new UploadedFile('bar content', 321, UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
+                    ],
+                ])
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST'),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                ],
+                'data' => [
+                    'foo' => [
+                        [
+                            'client_filename' => 'foo.ext',
+                            'client_media_type' => 'application/text',
+                            'size' => 123,
+                        ],
+                        [
+                            'client_filename' => 'bar.ext',
+                            'client_media_type' => 'application/octet-stream',
+                            'size' => 321,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'always',
+            ],
+            (new ServerRequest())
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->getStreamMock(13, '{"foo":"bar"}')),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Content-Type' => ['application/json'],
+                ],
+                'data' => [
+                    'foo' => 'bar',
+                ],
+            ],
+        ];
+
+        yield [
+            [
+                'request_bodies' => 'always',
+            ],
+            (new ServerRequest())
+                ->withUri(new Uri('http://www.example.com/foo'))
+                ->withMethod('POST')
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->getStreamMock(1, '{')),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Content-Type' => ['application/json'],
+                ],
+                'data' => '{',
+            ],
+        ];
+    }
+
+    private function getStreamMock(int $size, string $content = ''): StreamInterface
+    {
+        /** @var MockObject|StreamInterface $stream */
+        $stream = $this->createMock(StreamInterface::class);
+        $stream->expects($this->any())
+            ->method('getSize')
+            ->willReturn($size);
+
+        $stream->expects($this->any())
+            ->method('getContents')
+            ->willReturn($content);
+
+        return $stream;
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -60,6 +60,7 @@ final class OptionsTest extends TestCase
             ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
             ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
             ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
+            ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
         ];
     }
 

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -14,9 +14,9 @@ final class JSONTest extends TestCase
     /**
      * @dataProvider encodeDataProvider
      */
-    public function testEncode($value, $expectedResult): void
+    public function testEncode($value, string $expectedResult): void
     {
-        $this->assertEquals($expectedResult, JSON::encode($value));
+        $this->assertSame($expectedResult, JSON::encode($value));
     }
 
     public function encodeDataProvider(): array
@@ -58,7 +58,7 @@ final class JSONTest extends TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \Sentry\Exception\JsonException
      * @expectedExceptionMessage Could not encode value into JSON format. Error was: "Type is not supported".
      */
     public function testEncodeThrowsIfValueIsResource(): void
@@ -70,5 +70,46 @@ final class JSONTest extends TestCase
         fclose($resource);
 
         JSON::encode($resource);
+    }
+
+    /**
+     * @dataProvider decodeDataProvider
+     */
+    public function testDecode(string $value, $expectedResult): void
+    {
+        $this->assertSame($expectedResult, JSON::decode($value));
+    }
+
+    public function decodeDataProvider(): array
+    {
+        return [
+            [
+                '{"key":"value"}',
+                [
+                    'key' => 'value',
+                ],
+            ],
+            [
+                '"string"',
+                'string',
+            ],
+            [
+                '123.45',
+                123.45,
+            ],
+            [
+                'null',
+                null,
+            ],
+        ];
+    }
+
+    /**
+     * @expectedException \Sentry\Exception\JsonException
+     * @expectedExceptionMessage Could not decode value from JSON format. Error was: "Syntax error".
+     */
+    public function testDecodeThrowsIfValueIsNotValidJson(): void
+    {
+        JSON::decode('foo');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This is both a new feature and an improvement of one that already exists (the `RequestIntegration`). Infact, this is a porting of the same feature available in the Python SDK that solves #803. The integration does a best effort to deserialize the data, be it a submitted form or a JSON content. If it fails the RAW data is returned. There is also an option to configure the limit up to which the request data is captured.