### PR TITLE
Add Monolog handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ## Unreleased
 
 - Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (#786)
-- Increase default severity of `E_RECOVERABLE_ERROR` to `Severity::ERROR`, instead of warning (#792)
-- feat: Add Breadcrumb::fromArray (#798)
-- feat: Add support for SENTRY_ENVRIONMENT and SENTRY_RELEASE (#810)
-- fix: The default value of the $exceptions property of the Event class (#806)
+- Increase default severity of `E_RECOVERABLE_ERROR` to `Severity::ERROR`, instead
+  of `Severity::WARNING` (#792)
+- Add a static factory method to create a breadcrumb from an array of data (#798)
+- Add support for `SENTRY_ENVRIONMENT` and `SENTRY_RELEASE` environment variables (#810)
+- Fix the default value of the `$exceptions` property of the Event class (#806)
+- Add a Monolog handler (#808)
 
 ## 2.0.1 (2019-03-01)
 

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
-        "monolog/monolog": "^1.3",
+        "monolog/monolog": "^1.3|^2.0",
         "php-http/mock-client": "^1.0",
         "phpstan/phpstan-phpunit": "^0.10",
         "phpstan/phpstan": "^0.10.3",

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -80,8 +80,8 @@ final class EventFactory implements EventFactoryInterface
     {
         try {
             $event = new Event();
-        } catch (\Throwable $error) {
-            throw new EventCreationException($error);
+        } catch (\Throwable $exception) {
+            throw new EventCreationException($exception);
         }
 
         $event->setSdkIdentifier($this->sdkIdentifier);

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Monolog;
+
+use Monolog\Handler\AbstractProcessingHandler;
+use Monolog\Logger;
+use Sentry\Severity;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+
+/**
+ * This Monolog handler logs every message to a Sentry's server using the given
+ * hub instance.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class Handler extends AbstractProcessingHandler
+{
+    /**
+     * @var HubInterface
+     */
+    private $hub;
+
+    /**
+     * Constructor.
+     *
+     * @param HubInterface $hub    The hub to which errors are reported
+     * @param int          $level  The minimum logging level at which this
+     *                             handler will be triggered
+     * @param bool         $bubble Whether the messages that are handled can
+     *                             bubble up the stack or not
+     */
+    public function __construct(HubInterface $hub, $level = Logger::DEBUG, bool $bubble = true)
+    {
+        $this->hub = $hub;
+
+        parent::__construct($level, $bubble);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function write(array $record): void
+    {
+        $payload = [
+            'level' => $this->getSeverityFromLevel($record['level']),
+            'message' => $record['message'],
+        ];
+
+        if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Throwable) {
+            $payload['exception'] = $record['context']['exception'];
+        }
+
+        $this->hub->withScope(function (Scope $scope) use ($record, $payload): void {
+            $scope->setExtra('monolog.channel', $record['channel']);
+            $scope->setExtra('monolog.level', $record['level_name']);
+
+            if (isset($record['context']['extra']) && \is_array($record['context']['extra'])) {
+                foreach ($record['context']['extra'] as $key => $value) {
+                    $scope->setExtra($key, $value);
+                }
+            }
+
+            if (isset($record['context']['tags']) && \is_array($record['context']['tags'])) {
+                foreach ($record['context']['tags'] as $key => $value) {
+                    $scope->setTag($key, $value);
+                }
+            }
+
+            $this->hub->captureEvent($payload);
+        });
+    }
+
+    /**
+     * Translates the Monolog level into the Sentry severity.
+     *
+     * @param int $level The Monolog log level
+     *
+     * @return Severity
+     */
+    private function getSeverityFromLevel(int $level): Severity
+    {
+        switch ($level) {
+            case Logger::DEBUG:
+                return Severity::debug();
+            case Logger::INFO:
+            case Logger::NOTICE:
+                return Severity::info();
+            case Logger::WARNING:
+                return Severity::warning();
+            case Logger::ERROR:
+                return Severity::error();
+            case Logger::CRITICAL:
+            case Logger::ALERT:
+            case Logger::EMERGENCY:
+                return Severity::fatal();
+            default:
+                return Severity::info();
+        }
+    }
+}

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Monolog;
+
+use Monolog\Logger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\Monolog\Handler;
+use Sentry\Severity;
+use Sentry\State\Hub;
+use Sentry\State\Scope;
+
+final class HandlerTest extends TestCase
+{
+    /**
+     * @var MockObject|ClientInterface
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(ClientInterface::class);
+    }
+
+    /**
+     * @dataProvider handleDataProvider
+     */
+    public function testHandle(array $record, array $expectedPayload, array $expectedExtra, array $expectedTags): void
+    {
+        $this->client->expects($this->once())
+            ->method('captureEvent')
+            ->with($expectedPayload, $this->callback(static function (Scope $scope) use ($expectedExtra, $expectedTags): bool {
+                if ($expectedExtra !== $scope->getExtra()) {
+                    return false;
+                }
+
+                if ($expectedTags !== $scope->getTags()) {
+                    return false;
+                }
+
+                return true;
+            }));
+
+        $handler = new Handler(new Hub($this->client));
+        $handler->handle($record);
+    }
+
+    public function handleDataProvider(): \Generator
+    {
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::DEBUG,
+                'level_name' => Logger::getLevelName(Logger::DEBUG),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::debug(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::DEBUG),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::INFO,
+                'level_name' => Logger::getLevelName(Logger::INFO),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::info(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::INFO),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::NOTICE,
+                'level_name' => Logger::getLevelName(Logger::NOTICE),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::info(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::NOTICE),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::WARNING,
+                'level_name' => Logger::getLevelName(Logger::WARNING),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::warning(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::WARNING),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::ERROR,
+                'level_name' => Logger::getLevelName(Logger::ERROR),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::error(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::ERROR),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::CRITICAL,
+                'level_name' => Logger::getLevelName(Logger::CRITICAL),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::fatal(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::CRITICAL),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::ALERT,
+                'level_name' => Logger::getLevelName(Logger::ALERT),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::fatal(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::ALERT),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::EMERGENCY,
+                'level_name' => Logger::getLevelName(Logger::EMERGENCY),
+                'channel' => 'channel.foo',
+                'context' => [],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::fatal(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::EMERGENCY),
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::WARNING,
+                'level_name' => Logger::getLevelName(Logger::WARNING),
+                'context' => [
+                    'extra' => [
+                        'foo.extra' => 'foo extra value',
+                        'bar.extra' => 'bar extra value',
+                    ],
+                    'tags' => [
+                        'foo.tag' => 'foo tag value',
+                        'bar.tag' => 'bar tag value',
+                    ],
+                ],
+                'channel' => 'channel.foo',
+                'datetime' => new \DateTimeImmutable(),
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::warning(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::WARNING),
+                'foo.extra' => 'foo extra value',
+                'bar.extra' => 'bar extra value',
+            ],
+            [
+                'foo.tag' => 'foo tag value',
+                'bar.tag' => 'bar tag value',
+            ],
+        ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::WARNING,
+                'level_name' => Logger::getLevelName(Logger::WARNING),
+                'context' => [
+                    'exception' => new \Exception('exception message'),
+                    'extra' => [
+                        'foo.extra' => 'foo extra value',
+                        'bar.extra' => 'bar extra value',
+                    ],
+                    'tags' => [
+                        'foo.tag' => 'foo tag value',
+                        'bar.tag' => 'bar tag value',
+                    ],
+                ],
+                'channel' => 'channel.foo',
+                'datetime' => new \DateTimeImmutable(),
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::warning(),
+                'message' => 'foo bar',
+                'exception' => new \Exception('exception message'),
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::WARNING),
+                'foo.extra' => 'foo extra value',
+                'bar.extra' => 'bar extra value',
+            ],
+            [
+                'foo.tag' => 'foo tag value',
+                'bar.tag' => 'bar tag value',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This PR implements a Monolog handler and closes #790, which is a highly requested feature. Code is a stripped down version of the one submitted by @HazAT in the official Monolog repository. There are a few questions to discuss before merging:

- Like in the original PR, the handler needs an hub instance to work, but since the current hub is something that can change during the lifecycle of an application (e.g. when the `Hub::setCurrent()` method is called) it's not clear how this should affect the handler itself: e.g. if the handler is binded to an old or different hub than the current one it will report errors to the wrong client (if it's different between hubs)
- Since Monolog is a logger library a message is likely to always be present along with the context that may include the exception and imho we want to log it regardless. Calling the `captureMessage` method provides no way to pass the exception while calling the `captureException` has no way to pass the message. To solve the issue, instead of calling those methods like in the original PR, I'm building the raw payload of data to build the event from and I'm using the `captureEvent` method directly. Since the two methods mentioned before have a slightly different behavior regarding the stacktrace capture (`attach_stacktrace` option), the same exact behavior cannot be accomplished with such way