### PR TITLE
Update changelog for 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 - ...
 
+## 1.11.0 (2020-02-12)
+
+- Fixed array and string offset access syntax with curly braces deprecations (#975)
+- Fixed curl verify host for synchronous mode (#767)
+- Use `mb_substr` instead of `substr` if available (#734)
+- Make it possible to change `default_max_depth` in `Raven_Serializer` (#632)
+
 ## 1.10.0 (2018-11-09)
 
 - Added passing data from context in monolog breadcrumb handler (#683)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG
 
-## Unreleased
-
-- ...
-
 ## 1.11.0 (2020-02-12)
 
 - Fixed array and string offset access syntax with curly braces deprecations (#975)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 # Sentry for PHP
 
+> Please note that the `1.x` branch of the Sentry PHP SDK is no longer actively maintained and will only receive bug-fix and security updates.
+> 
+> For the most recent Sentry PHP SDK see the [default branch](https://github.com/getsentry/sentry-php).
+
+---
+
 [![Build Status](https://secure.travis-ci.org/getsentry/sentry-php.png?branch=master)](http://travis-ci.org/getsentry/sentry-php)
 [![Total Downloads](https://poser.pugx.org/sentry/sentry/downloads)](https://packagist.org/packages/sentry/sentry)
 [![Monthly Downloads](https://poser.pugx.org/sentry/sentry/d/monthly)](https://packagist.org/packages/sentry/sentry)


### PR DESCRIPTION
After this we should probably make a 1.11 release just to have it out :)

@HazAT you should update the data / version number as needed when you are ready to release.