### PR TITLE
Implement support for flushable clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Changed type hint for both parameter and return value of `HubInterface::getCurrentHub` and `HubInterface::setCurrentHub()` methods (#849)
 - Add the `setTags`, `setExtras` and `clearBreadcrumbs` methods to the `Scope` class (#852)
 - Silently cast numeric values to strings when trying to set the tags instead of throwing (#858)
+- Support force sending events on-demand and fix sending of events in long-running processes (#813)
 
 ## 2.1.1 (2019-06-13)
 

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "php": "^7.1",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "guzzlehttp/promises": "^1.3",
         "jean85/pretty-package-versions": "^1.2",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",

--- a/src/FlushableClientInterface.php
+++ b/src/FlushableClientInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+use GuzzleHttp\Promise\PromiseInterface;
+
+/**
+ * This interface can be implemented by clients to support flushing of events
+ * on-demand.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+interface FlushableClientInterface extends ClientInterface
+{
+    /**
+     * Flushes the queue of events pending to be sent. If a timeout is provided
+     * and the queue takes longer to drain, the promise resolves with `false`.
+     *
+     * @param int|null $timeout Maximum time in seconds the client should wait
+     *
+     * @return PromiseInterface
+     */
+    public function flush(?int $timeout = null): PromiseInterface;
+}

--- a/src/Transport/ClosableTransportInterface.php
+++ b/src/Transport/ClosableTransportInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Transport;
+
+use GuzzleHttp\Promise\PromiseInterface;
+
+/**
+ * All classes implementing this interface will support sending events on-demand.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+interface ClosableTransportInterface
+{
+    /**
+     * Waits until all pending requests have been sent or the timeout expires.
+     *
+     * @param int|null $timeout Maximum time in seconds before the sending
+     *                          operation is interrupted
+     *
+     * @return PromiseInterface
+     */
+    public function close(?int $timeout = null): PromiseInterface;
+}

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace Sentry\Transport;
 
-use Http\Client\HttpAsyncClient;
-use Http\Message\RequestFactory;
-use Http\Promise\Promise;
+use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
+use Http\Message\RequestFactory as RequestFactoryInterface;
+use Http\Promise\Promise as PromiseInterface;
 use Sentry\Event;
 use Sentry\Options;
 use Sentry\Util\JSON;
 
 /**
- * This transport sends the events using an HTTP client.
+ * This transport sends the events using a syncronous HTTP client that will
+ * delay sending of the requests until the shutdown of the application.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
@@ -24,32 +25,47 @@ final class HttpTransport implements TransportInterface
     private $config;
 
     /**
-     * @var HttpAsyncClient The HTTP client
+     * @var HttpAsyncClientInterface The HTTP client
      */
     private $httpClient;
 
     /**
-     * @var RequestFactory The PSR-7 request factory
+     * @var RequestFactoryInterface The PSR-7 request factory
      */
     private $requestFactory;
 
     /**
-     * @var Promise[] The list of pending requests
+     * @var PromiseInterface[] The list of pending promises
      */
     private $pendingRequests = [];
 
     /**
+     * @var bool Flag indicating whether the sending of the events should be
+     *           delayed until the shutdown of the application
+     */
+    private $delaySendingUntilShutdown = false;
+
+    /**
      * Constructor.
      *
-     * @param Options         $config         The Raven client configuration
-     * @param HttpAsyncClient $httpClient     The HTTP client
-     * @param RequestFactory  $requestFactory The PSR-7 request factory
+     * @param Options                  $config                    The Raven client configuration
+     * @param HttpAsyncClientInterface $httpClient                The HTTP client
+     * @param RequestFactoryInterface  $requestFactory            The PSR-7 request factory
+     * @param bool                     $delaySendingUntilShutdown This flag controls whether to delay
+     *                                                            sending of the events until the shutdown
+     *                                                            of the application. This is a legacy feature
+     *                                                            that will stop working in version 3.0.
      */
-    public function __construct(Options $config, HttpAsyncClient $httpClient, RequestFactory $requestFactory)
+    public function __construct(Options $config, HttpAsyncClientInterface $httpClient, RequestFactoryInterface $requestFactory, bool $delaySendingUntilShutdown = true)
     {
+        if ($delaySendingUntilShutdown) {
+            @trigger_error(sprintf('Delaying the sending of the events using the "%s" class is deprecated since version 2.2 and will not work in 3.0.', __CLASS__), E_USER_DEPRECATED);
+        }
+
         $this->config = $config;
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
+        $this->delaySendingUntilShutdown = $delaySendingUntilShutdown;
 
         // By calling the cleanupPendingRequests function from a shutdown function
         // registered inside another shutdown function we can be confident that it
@@ -80,37 +96,23 @@ final class HttpTransport implements TransportInterface
 
         $promise = $this->httpClient->sendAsyncRequest($request);
 
-        // This function is defined in-line so it doesn't show up for type-hinting
-        $cleanupPromiseCallback = function ($responseOrException) use ($promise) {
-            $index = array_search($promise, $this->pendingRequests, true);
-
-            if (false !== $index) {
-                unset($this->pendingRequests[$index]);
-            }
-
-            return $responseOrException;
-        };
-
-        $promise->then($cleanupPromiseCallback, $cleanupPromiseCallback);
-
-        $this->pendingRequests[] = $promise;
+        if ($this->delaySendingUntilShutdown) {
+            $this->pendingRequests[] = $promise;
+        } else {
+            $promise->wait(false);
+        }
 
         return $event->getId();
     }
 
     /**
-     * Cleanups the pending requests by forcing them to be sent. Any error that
-     * occurs will be ignored.
+     * Cleanups the pending promises by awaiting for them. Any error that occurs
+     * will be ignored.
      */
     private function cleanupPendingRequests(): void
     {
-        foreach ($this->pendingRequests as $pendingRequest) {
-            try {
-                $pendingRequest->wait();
-            } catch (\Throwable $exception) {
-                // Do nothing because an exception thrown from a destructor
-                // can't be catched in PHP (see http://php.net/manual/en/language.oop5.decon.php#language.oop5.decon.destructor)
-            }
+        while ($promise = array_pop($this->pendingRequests)) {
+            $promise->wait(false);
         }
     }
 }

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -29,13 +29,10 @@ use Sentry\Transport\TransportInterface;
 
 final class ClientBuilderTest extends TestCase
 {
-    public function testCreate(): void
-    {
-        $clientBuilder = ClientBuilder::create();
-
-        $this->assertInstanceOf(ClientBuilder::class, $clientBuilder);
-    }
-
+    /**
+     * @group legacy
+     * @expectedDeprecation Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
+     */
     public function testHttpTransportIsUsedWhenServeIsConfigured(): void
     {
         $clientBuilder = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/sentry/1']);
@@ -65,6 +62,10 @@ final class ClientBuilderTest extends TestCase
         $this->assertAttributeSame($uriFactory, 'uriFactory', $clientBuilder);
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
+     */
     public function testSetMessageFactory(): void
     {
         /** @var MessageFactory|MockObject $messageFactory */
@@ -92,6 +93,10 @@ final class ClientBuilderTest extends TestCase
         $this->assertAttributeSame($transport, 'transport', $clientBuilder->getClient());
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
+     */
     public function testSetHttpClient(): void
     {
         /** @var HttpAsyncClient|MockObject $httpClient */
@@ -141,6 +146,10 @@ final class ClientBuilderTest extends TestCase
         $this->assertSame($plugin2, reset($plugins));
     }
 
+    /**
+     * @group legacy
+     * @expectedDeprecation Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
+     */
     public function testGetClient(): void
     {
         $clientBuilder = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/sentry/1']);
@@ -258,11 +267,15 @@ final class ClientBuilderTest extends TestCase
 
     /**
      * @dataProvider getClientTogglesCompressionPluginInHttpClientDataProvider
+     *
+     * @group legacy
+     * @expectedDeprecation Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
      */
     public function testGetClientTogglesCompressionPluginInHttpClient(bool $enabled): void
     {
         $options = new Options(['dsn' => 'http://public:secret@example.com/sentry/1']);
         $options->setEnableCompression($enabled);
+
         $builder = new ClientBuilder($options);
         $builder->getClient();
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Tests;
 
+use Http\Discovery\MessageFactoryDiscovery;
 use Http\Mock\Client as MockClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,7 @@ use Sentry\Serializer\Serializer;
 use Sentry\Serializer\SerializerInterface;
 use Sentry\Severity;
 use Sentry\Stacktrace;
+use Sentry\Transport\HttpTransport;
 use Sentry\Transport\TransportInterface;
 
 class ClientTest extends TestCase
@@ -268,12 +270,11 @@ class ClientTest extends TestCase
     public function testSampleRateAbsolute(float $sampleRate): void
     {
         $httpClient = new MockClient();
-
         $options = new Options(['dsn' => 'http://public:secret@example.com/1']);
         $options->setSampleRate($sampleRate);
 
         $client = (new ClientBuilder($options))
-            ->setHttpClient($httpClient)
+            ->setTransport(new HttpTransport($options, $httpClient, MessageFactoryDiscovery::find(), false))
             ->getClient();
 
         for ($i = 0; $i < 10; ++$i) {

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\Transport;
 
-use Http\Client\Exception\HttpException;
 use Http\Client\HttpAsyncClient;
 use Http\Discovery\MessageFactoryDiscovery;
-use Http\Promise\Promise;
+use Http\Promise\FulfilledPromise;
+use Http\Promise\RejectedPromise;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\Event;
@@ -16,12 +16,14 @@ use Sentry\Transport\HttpTransport;
 
 final class HttpTransportTest extends TestCase
 {
-    public function testDestructor(): void
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecationMessage Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
+     */
+    public function testSendDelaysExecutionUntilShutdown(): void
     {
-        /** @var Promise|MockObject $promise1 */
-        $promise = $this->createMock(Promise::class);
-        $promise->expects($this->once())
-            ->method('wait');
+        $promise = new FulfilledPromise('foo');
 
         /** @var HttpAsyncClient|MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
@@ -29,43 +31,11 @@ final class HttpTransportTest extends TestCase
             ->method('sendAsyncRequest')
             ->willReturn($promise);
 
-        $config = new Options();
-        $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find());
-
-        $transport->send(new Event());
-
-        // In PHP calling the destructor manually does not destroy the object,
-        // but for testing we will do it anyway because otherwise we could not
-        // test the cleanup code of the class if not all references to its
-        // instance are released
-        $transport->__destruct();
-    }
-
-    public function testCleanupPendingRequests(): void
-    {
-        /** @var Promise|MockObject $promise1 */
-        $promise1 = $this->createMock(Promise::class);
-        $promise1->expects($this->once())
-            ->method('wait')
-            ->willThrowException(new \Exception());
-
-        /** @var Promise|MockObject $promise2 */
-        $promise2 = $this->createMock(Promise::class);
-        $promise2->expects($this->once())
-            ->method('wait');
-
-        /** @var HttpAsyncClient|MockObject $httpClient */
-        $httpClient = $this->createMock(HttpAsyncClient::class);
-        $httpClient->expects($this->exactly(2))
-            ->method('sendAsyncRequest')
-            ->willReturnOnConsecutiveCalls($promise1, $promise2);
-
-        $config = new Options();
+        $config = new Options(['dsn' => 'http://public@example.com/sentry/1']);
         $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find());
 
         $this->assertAttributeEmpty('pendingRequests', $transport);
 
-        $transport->send(new Event());
         $transport->send(new Event());
 
         $this->assertAttributeNotEmpty('pendingRequests', $transport);
@@ -74,14 +44,13 @@ final class HttpTransportTest extends TestCase
         $reflectionMethod->setAccessible(true);
         $reflectionMethod->invoke($transport);
         $reflectionMethod->setAccessible(false);
+
+        $this->assertAttributeEmpty('pendingRequests', $transport);
     }
 
-    public function testSendFailureCleanupPendingRequests(): void
+    public function testSendDoesNotDelayExecutionUntilShutdownWhenConfiguredToNotDoIt(): void
     {
-        /** @var HttpException|MockObject $exception */
-        $exception = $this->createMock(HttpException::class);
-
-        $promise = new PromiseMock($exception, PromiseMock::REJECTED);
+        $promise = new RejectedPromise(new \Exception());
 
         /** @var HttpAsyncClient|MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
@@ -89,68 +58,11 @@ final class HttpTransportTest extends TestCase
             ->method('sendAsyncRequest')
             ->willReturn($promise);
 
-        $config = new Options();
-        $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find());
+        $config = new Options(['dsn' => 'http://public@example.com/sentry/1']);
+        $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find(), false);
 
         $transport->send(new Event());
 
-        $this->assertAttributeNotEmpty('pendingRequests', $transport);
-        $this->assertSame($exception, $promise->wait(true));
         $this->assertAttributeEmpty('pendingRequests', $transport);
-    }
-}
-
-final class PromiseMock implements Promise
-{
-    private $result;
-
-    private $state;
-
-    private $onFullfilledCallbacks = [];
-
-    private $onRejectedCallbacks = [];
-
-    public function __construct($result, $state = self::FULFILLED)
-    {
-        $this->result = $result;
-        $this->state = $state;
-    }
-
-    public function then(callable $onFulfilled = null, callable $onRejected = null)
-    {
-        if (null !== $onFulfilled) {
-            $this->onFullfilledCallbacks[] = $onFulfilled;
-        }
-
-        if (null !== $onRejected) {
-            $this->onRejectedCallbacks[] = $onRejected;
-        }
-
-        return $this;
-    }
-
-    public function getState()
-    {
-        return $this->state;
-    }
-
-    public function wait($unwrap = true)
-    {
-        switch ($this->state) {
-            case self::FULFILLED:
-                foreach ($this->onFullfilledCallbacks as $onFullfilledCallback) {
-                    $this->result = $onFullfilledCallback($this->result);
-                }
-
-                break;
-            case self::REJECTED:
-                foreach ($this->onRejectedCallbacks as $onRejectedCallback) {
-                    $this->result = $onRejectedCallback($this->result);
-                }
-
-                break;
-        }
-
-        return $unwrap ? $this->result : null;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

This PR is another attempt other than #799 to fix #811 and getsentry/sentry-laravel#222. ~It involves much more changes and do not follow the unified API that expect some methods on the client like `flush` or `close`. Instead, it exposes new methods with the `Async` suffix that return promises and, depending on the implementation, these may be resolved immediatly when they are created (think about a syncronous transport) or at some point in time. The decision to not follow the unified API is because in PHP there is no concept of real async, so having such methods that internally resolves the promises like in the JavaScript SDK would just make them syncronous. There are also some libraries and frameworks like Swoople or ReactPHP that use an event loop (similar to NodeJS) that runs and can periodically tick a queue or advance a timer: this is what we are looking for. cURL can send requests in parallel but is not async at all. To do it in fact, you have to use a loop that will tick the internal queue of requests to send them a little at a time, but obviously this will block the code execution. This is why some HTTP clients like Guzzle have their own queue that can be ticked from the outside and this is what users must do by integrating such libraries with their own event-driven loop.~

It follows the specs of the Unified API and implements a `flush` method on the client that can be called by clients to drain the queue of events being sent on-demand. Since in PHP there is no concept of async out-of-the-box there is no implementation of an async client provided, thus the `$timeout` parameter is effectively ignored.