### PR TITLE
Hotfix: Non-static method XXX::YYY should not be called statically (callable serialization issue)

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -210,7 +210,7 @@ abstract class AbstractSerializer
      *
      * @return string
      */
-    protected function serializeCallable(callable $callable): string
+    protected function serializeCallable($callable): string
     {
         try {
             if (\is_array($callable)) {

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -357,6 +357,7 @@ abstract class AbstractSerializerTest extends TestCase
         $filename = \dirname(__DIR__) . '/resources/callable_without_namespace.inc';
         $this->assertFileExists($filename);
         $callableWithoutNamespaces = require $filename;
+        $pseudoStaticMethod = 'Sentry\Tests\Serializer\AbstractSerializerTest::serializableCallableProvider';
 
         return [
             [
@@ -455,13 +456,17 @@ abstract class AbstractSerializerTest extends TestCase
                 'callable' => $callableWithoutNamespaces,
                 'expected' => 'Lambda void {closure} [int|null param1_70ns]',
             ],
+            [
+                'callable' => $pseudoStaticMethod,
+                'expected' => '{unserializable callable, reflection error}',
+            ],
         ];
     }
 
     /**
      * @dataProvider serializableCallableProvider
      */
-    public function testSerializeCallable(callable $callable, string $expected): void
+    public function testSerializeCallable($callable, string $expected): void
     {
         $serializer = $this->createSerializer();
         $actual = $this->invokeSerialization($serializer, $callable);


### PR DESCRIPTION
Hi Team! There is a weird behavior conceived to ` __METHOD__` constant when we pass it through argument in our code. I'll try to explain.
This piece of code:
https://github.com/getsentry/sentry-php/blob/master/src/Serializer/AbstractSerializer.php#L110
Guides to this method:
https://github.com/getsentry/sentry-php/blob/master/src/Serializer/AbstractSerializer.php#L213

The `callable` typehint will work incorrectly if ` __METHOD__` refers to dynamic method. It will throw an error, and then this error will spoil the original stacktrace. That's not good at all.
This snippet will show You the whole picture: http://sandbox.onlinephpfunctions.com/code/fba854e73f595f1fe78596f6bcc56371eba500b2
The error is:
```
<b>Deprecated</b>:  Non-static method AAA::get() should not be called statically in <b>[...][...]</b> on line <b>23</b><br />
```
How is it related to Sentry? If we enable Sentry for this code, and there will be an exception inside `demonstrate2`, we will have one more exception in stacktrace while serializing the stacktrace, so it will be spoiled with weird internal error. Why? Because PHP will try to execute the callable if typehint is used. No idea why.

### TL;DR: the `callable` typehint must be disabled for safety.

Thanks for attention!