### PR TITLE
A non-numeric value encountered in Stacktrace.php

### DIFF
--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -311,7 +311,7 @@ class Stacktrace implements \JsonSerializable
             $result = array_map([$this, 'serializeArgument'], $frame['args']);
         } else {
             foreach (array_values($frame['args']) as $index => $argument) {
-                $result['param' . ($index + 1)] = $this->serializeArgument($argument);
+                $result['param' . ((int)$index + 1)] = $this->serializeArgument($argument);
             }
         }
 


### PR DESCRIPTION
I get string $index and observe "A non-numeric value encountered" error

![7abf0c17e8](https://user-images.githubusercontent.com/6638145/57370513-fface780-7198-11e9-8b34-9312c325b583.jpg)

Please, take a look at my solution. I'm not sure that this is correct fix and the root of the problem