### PR TITLE
Catch serialization errors

### DIFF
--- a/tests/phpt/serialize_broken_class.phpt
+++ b/tests/phpt/serialize_broken_class.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test that requiring a broken class (with a parser error) will not explode during serialization
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use Sentry\ClientBuilder;
+use Sentry\Event;
+use Sentry\Integration\FatalErrorListenerIntegration;
+use Sentry\Options;
+use Sentry\Serializer\Serializer;
+use Sentry\State\Hub;
+use Sentry\Tests\resources\BrokenClass;
+use Sentry\Transport\TransportInterface;
+
+$vendor = __DIR__;
+
+while (!file_exists($vendor . '/vendor')) {
+    $vendor = dirname($vendor);
+}
+
+require $vendor . '/vendor/autoload.php';
+
+function testSerialization($value) {
+    $serializer = new Serializer(new Options());
+
+    echo $serializer->serialize($value);
+}
+
+testSerialization(BrokenClass::class . '::brokenMethod');
+
+?>
+--EXPECTF--
+Sentry\Tests\resources\BrokenClass::missingMethod

--- a/tests/phpt/serialize_broken_class.phpt
+++ b/tests/phpt/serialize_broken_class.phpt
@@ -31,7 +31,10 @@ function testSerialization($value) {
 }
 
 testSerialization(BrokenClass::class . '::brokenMethod');
+echo PHP_EOL;
+testSerialization([BrokenClass::class, 'brokenMethod']);
 
 ?>
---EXPECTF--
-Sentry\Tests\resources\BrokenClass::missingMethod
+--EXPECT--
+Sentry\Tests\resources\BrokenClass::brokenMethod {serialization error}
+{serialization error}

--- a/tests/resources/BrokenClass.php
+++ b/tests/resources/BrokenClass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Sentry\Tests\resources;
+
+class BrokenClass
+{
+    public function brokenMethod()
+    {
+        echo Class();
+    }
+}


### PR DESCRIPTION
This bug emerged in getsentry/sentry-symfony#63. It's pretty nasty, due to the fact that it happens when we serialize a callable that refers to a file that contains a parse error; but my solution should catch a lot of possible issues anyway.

This PR stems from 2.0.1, so we can merge this on a 2.0.x branch if we want to release a 2.0.2; otherwise, if it's nearly ready, we can pack it up in 2.1.