### PR TITLE
Change the behavior of excluded_exceptions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Fix the behavior of the `excluded_exceptions` option: now it's used to skip capture of exceptions, not to purge the `exception` data of the event, which resulted in broken or empty chains of exceptions in reported events (#822) 
+
 ## 2.1.0 (2019-05-22)
 
 - Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (#786)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Fix the behavior of the `excluded_exceptions` option: now it's used to skip capture of exceptions, not to purge the `exception` data of the event, which resulted in broken or empty chains of exceptions in reported events (#822) 
+- Fix the behavior of the `excluded_exceptions` option: now it's used to skip capture of exceptions, not to purge the 
+`exception` data of the event, which resulted in broken or empty chains of exceptions in reported events (#822) 
 
 ## 2.1.0 (2019-05-22)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -91,6 +91,10 @@ final class Client implements ClientInterface
      */
     public function captureException(\Throwable $exception, ?Scope $scope = null): ?string
     {
+        if ($this->options->isExcludedException($exception)) {
+            return null;
+        }
+
         $payload['exception'] = $exception;
 
         return $this->captureEvent($payload, $scope);

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -145,10 +145,6 @@ final class EventFactory implements EventFactoryInterface
         $currentException = $exception;
 
         do {
-            if ($this->options->isExcludedException($currentException)) {
-                continue;
-            }
-
             $data = [
                 'type' => \get_class($currentException),
                 'value' => $this->serializer->serialize($currentException->getMessage()),

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -133,18 +133,18 @@ class ClientTest extends TestCase
     {
         return [
             [
-                true, 
-                \Exception::class, 
+                true,
+                \Exception::class,
                 new \Error(),
             ],
             [
-                false, 
-                \Exception::class, 
+                false,
+                \Exception::class,
                 new \LogicException(),
             ],
             [
-                false, 
-                \Throwable::class, 
+                false,
+                \Throwable::class,
                 new \Error(),
             ],
         ];

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -107,6 +107,42 @@ class ClientTest extends TestCase
         $client->captureException($exception);
     }
 
+    /**
+     * @dataProvider captureExceptionWithExcludedExceptionsDataProvider
+     */
+    public function testCaptureExceptionWithExcludedExceptions(bool $shouldCapture, string $excluded, \Throwable $thrown): void
+    {
+        $transport = $this->createMock(TransportInterface::class);
+
+        $transport->expects($shouldCapture ? $this->once() : $this->never())
+            ->method('send')
+            ->with($this->callback(function (Event $event) use ($thrown): bool {
+                $this->assertCount(1, $event->getExceptions());
+
+                $exceptionData = $event->getExceptions()[0];
+
+                $this->assertSame(\get_class($thrown), $exceptionData['type']);
+                $this->assertSame($thrown->getMessage(), $exceptionData['value']);
+
+                return true;
+            }));
+
+        $client = ClientBuilder::create(['excluded_exceptions' => [$excluded]])
+            ->setTransport($transport)
+            ->getClient();
+
+        $client->captureException($thrown);
+    }
+
+    public function captureExceptionWithExcludedExceptionsDataProvider(): array
+    {
+        return [
+            [true, \Exception::class, new \Error()],
+            [false, \Exception::class, new \LogicException()],
+            [false, \Throwable::class, new \Error()],
+        ];
+    }
+
     public function testCapture(): void
     {
         /** @var TransportInterface|MockObject $transport */
@@ -258,7 +294,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider convertExceptionDataProvider
      */
-    public function testConvertException(\Exception $exception, array $clientConfig, array $expectedResult): void
+    public function testConvertException(\Exception $exception, array $expectedResult): void
     {
         /** @var TransportInterface|MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
@@ -277,7 +313,7 @@ class ClientTest extends TestCase
                 return true;
             }));
 
-        $client = ClientBuilder::create($clientConfig)
+        $client = ClientBuilder::create()
             ->setTransport($transport)
             ->getClient();
 
@@ -289,7 +325,6 @@ class ClientTest extends TestCase
         return [
             [
                 new \RuntimeException('foo'),
-                [],
                 [
                     'level' => Severity::ERROR,
                     'exception' => [
@@ -304,7 +339,6 @@ class ClientTest extends TestCase
             ],
             [
                 new \ErrorException('foo', 0, E_USER_WARNING),
-                [],
                 [
                     'level' => Severity::WARNING,
                     'exception' => [
@@ -312,27 +346,6 @@ class ClientTest extends TestCase
                             [
                                 'type' => \ErrorException::class,
                                 'value' => 'foo',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-            [
-                new \BadMethodCallException('baz', 0, new \BadFunctionCallException('bar', 0, new \LogicException('foo', 0))),
-                [
-                    'excluded_exceptions' => [\BadMethodCallException::class],
-                ],
-                [
-                    'level' => Severity::ERROR,
-                    'exception' => [
-                        'values' => [
-                            [
-                                'type' => \LogicException::class,
-                                'value' => 'foo',
-                            ],
-                            [
-                                'type' => \BadFunctionCallException::class,
-                                'value' => 'bar',
                             ],
                         ],
                     ],

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -108,21 +108,16 @@ class ClientTest extends TestCase
     }
 
     /**
-     * @dataProvider captureExceptionWithExcludedExceptionsDataProvider
+     * @dataProvider captureExceptionDoesNothingIfExcludedExceptionsOptionMatchesDataProvider
      */
-    public function testCaptureExceptionWithExcludedExceptions(bool $shouldCapture, string $excluded, \Throwable $thrown): void
+    public function testCaptureExceptionDoesNothingIfExcludedExceptionsOptionMatches(bool $shouldCapture, string $excluded, \Throwable $thrown): void
     {
         $transport = $this->createMock(TransportInterface::class);
 
         $transport->expects($shouldCapture ? $this->once() : $this->never())
             ->method('send')
-            ->with($this->callback(function (Event $event) use ($thrown): bool {
-                $this->assertCount(1, $event->getExceptions());
-
-                $exceptionData = $event->getExceptions()[0];
-
-                $this->assertSame(\get_class($thrown), $exceptionData['type']);
-                $this->assertSame($thrown->getMessage(), $exceptionData['value']);
+            ->with($this->callback(function (Event $event): bool {
+                $this->assertNotEmpty($event->getExceptions());
 
                 return true;
             }));
@@ -134,12 +129,24 @@ class ClientTest extends TestCase
         $client->captureException($thrown);
     }
 
-    public function captureExceptionWithExcludedExceptionsDataProvider(): array
+    public function captureExceptionDoesNothingIfExcludedExceptionsOptionMatchesDataProvider(): array
     {
         return [
-            [true, \Exception::class, new \Error()],
-            [false, \Exception::class, new \LogicException()],
-            [false, \Throwable::class, new \Error()],
+            [
+                true, 
+                \Exception::class, 
+                new \Error(),
+            ],
+            [
+                false, 
+                \Exception::class, 
+                new \LogicException(),
+            ],
+            [
+                false, 
+                \Throwable::class, 
+                new \Error(),
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR stems/fixes #820 and the related getsentry/sentry-symfony#216.

The current behavior of the `excluded_exceptions` option is broken, since it just excludes exceptions from the `exception` key in the event payload, which results in broken or empty exception chains reported.

Instead, the correct behavior should be ignoring the automatic capturing of a set of exceptions, like excluding 404 exceptions from frameworks.