### PR TITLE
Fix exception, open_basedir restriction in effect

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,7 @@
          bootstrap="tests/bootstrap.php"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak_vendors" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     </php>
 
     <testsuites>

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -224,7 +224,7 @@ class Stacktrace implements \JsonSerializable
      */
     protected function getSourceCodeExcerpt(string $path, int $lineNumber, int $maxLinesToFetch): array
     {
-        if (!is_file($path) || !is_readable($path)) {
+        if ($path === '[internal]' | !is_file($path) || !is_readable($path)) {
             return [];
         }
 

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -224,7 +224,7 @@ class Stacktrace implements \JsonSerializable
      */
     protected function getSourceCodeExcerpt(string $path, int $lineNumber, int $maxLinesToFetch): array
     {
-        if ($path === '[internal]' | !is_file($path) || !is_readable($path)) {
+        if (@!is_readable($path) || !is_file($path)) {
             return [];
         }
 


### PR DESCRIPTION
this is a *VERY* crude fix for this exception `is_file(): open_basedir restriction in effect. File([internal]) is not within the allowed path(s)`