### PR TITLE
Fix for #720 - prevent duplicate fatal error on PHP < 7 by checking for the older message format

### DIFF
--- a/lib/Raven/ErrorHandler.php
+++ b/lib/Raven/ErrorHandler.php
@@ -174,6 +174,18 @@ class Raven_ErrorHandler
                     return false;
                 }
             }
+        } elseif ($this->lastHandledException) {
+            if ($type === E_ERROR) {
+                $expectedMessage = 'Uncaught exception \''
+                    . \get_class($this->lastHandledException)
+                    . '\' with message \''
+                    . $this->lastHandledException->getMessage()
+                    . '\'';
+
+                if (strpos($message, $expectedMessage) === 0) {
+                    return false;
+                }
+            }
         }
 
         return (bool) ($type & $this->fatal_error_types);


### PR DESCRIPTION
Fix for #720 - prevent duplicate fatal error on PHP < 7 by checking for the older message format