### PR TITLE
Read REMOTE_ADDR from server parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix the behavior of the `excluded_exceptions` option: now it's used to skip capture of exceptions, not to purge the 
 `exception` data of the event, which resulted in broken or empty chains of exceptions in reported events (#822) 
 - Fix handling of uploaded files in the `RequestIntegration`, to respect the PSR-7 spec fully (#827)
+- Fix use of `REMOTE_ADDR` server variable rather than HTTP header
 
 ## 2.1.0 (2019-05-22)
 

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -96,8 +96,9 @@ final class RequestIntegration implements IntegrationInterface
         }
 
         if ($self->options->shouldSendDefaultPii()) {
-            if ($request->hasHeader('REMOTE_ADDR')) {
-                $requestData['env']['REMOTE_ADDR'] = $request->getHeaderLine('REMOTE_ADDR');
+            $server = $request->getServerParams();
+            if (isset($server['REMOTE_ADDR'])) {
+                $requestData['env']['REMOTE_ADDR'] = $server['REMOTE_ADDR'];
             }
 
             $requestData['cookies'] = $request->getCookieParams();
@@ -105,8 +106,8 @@ final class RequestIntegration implements IntegrationInterface
 
             $userContext = $event->getUserContext();
 
-            if (null === $userContext->getIpAddress() && $request->hasHeader('REMOTE_ADDR')) {
-                $userContext->setIpAddress($request->getHeaderLine('REMOTE_ADDR'));
+            if (null === $userContext->getIpAddress() && isset($server['REMOTE_ADDR'])) {
+                $userContext->setIpAddress($server['REMOTE_ADDR']);
             }
         } else {
             $requestData['headers'] = $self->removePiiFromHeaders($request->getHeaders());

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -96,9 +96,10 @@ final class RequestIntegration implements IntegrationInterface
         }
 
         if ($self->options->shouldSendDefaultPii()) {
-            $server = $request->getServerParams();
-            if (isset($server['REMOTE_ADDR'])) {
-                $requestData['env']['REMOTE_ADDR'] = $server['REMOTE_ADDR'];
+            $serverParams = $request->getServerParams();
+
+            if (isset($serverParams['REMOTE_ADDR'])) {
+                $requestData['env']['REMOTE_ADDR'] = $serverParams['REMOTE_ADDR'];
             }
 
             $requestData['cookies'] = $request->getCookieParams();
@@ -106,8 +107,8 @@ final class RequestIntegration implements IntegrationInterface
 
             $userContext = $event->getUserContext();
 
-            if (null === $userContext->getIpAddress() && isset($server['REMOTE_ADDR'])) {
-                $userContext->setIpAddress($server['REMOTE_ADDR']);
+            if (null === $userContext->getIpAddress() && isset($serverParams['REMOTE_ADDR'])) {
+                $userContext->setIpAddress($serverParams['REMOTE_ADDR']);
             }
         } else {
             $requestData['headers'] = $self->removePiiFromHeaders($request->getHeaders());

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -25,8 +25,7 @@ final class RequestIntegrationTest extends TestCase
         $event = new Event();
         $event->getUserContext()->setData(['foo' => 'bar']);
 
-        $request = new ServerRequest();
-        $request = $request->withHeader('REMOTE_ADDR', '127.0.0.1');
+        $request = new ServerRequest(['REMOTE_ADDR' => '127.0.0.1']);
 
         $this->assertInstanceOf(ServerRequestInterface::class, $request);
 
@@ -140,11 +139,10 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => true,
             ],
-            (new ServerRequest())
+            (new ServerRequest(['REMOTE_ADDR' => '127.0.0.1']))
                 ->withUri(new Uri('http://www.example.com/foo?foo=bar&bar=baz'))
                 ->withMethod('GET')
                 ->withHeader('Host', 'www.example.com')
-                ->withHeader('REMOTE_ADDR', '127.0.0.1')
                 ->withHeader('Authorization', 'foo')
                 ->withHeader('Cookie', 'bar')
                 ->withHeader('Set-Cookie', 'baz'),
@@ -155,7 +153,6 @@ final class RequestIntegrationTest extends TestCase
                 'cookies' => [],
                 'headers' => [
                     'Host' => ['www.example.com'],
-                    'REMOTE_ADDR' => ['127.0.0.1'],
                     'Authorization' => ['foo'],
                     'Cookie' => ['bar'],
                     'Set-Cookie' => ['baz'],
@@ -170,11 +167,10 @@ final class RequestIntegrationTest extends TestCase
             [
                 'send_default_pii' => false,
             ],
-            (new ServerRequest())
+            (new ServerRequest(['REMOTE_ADDR' => '127.0.0.1']))
                 ->withUri(new Uri('http://www.example.com/foo?foo=bar&bar=baz'))
                 ->withMethod('GET')
                 ->withHeader('Host', 'www.example.com')
-                ->withHeader('REMOTE_ADDR', '127.0.0.1')
                 ->withHeader('Authorization', 'foo')
                 ->withHeader('Cookie', 'bar')
                 ->withHeader('Set-Cookie', 'baz'),


### PR DESCRIPTION
Currently server IP is reported in a _User IP_ field because the library is checking for `REMOTE_ADDR` HTTP header.

`REMOTE_ADDR` is not an HTTP header, but rather a server variable.

This PR reads IP from the right place.