### PR TITLE
Fix exception in Monolog handler when extra data has numeric array keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
+
 ## 2.1.1 (2019-06-13)
 
 - Fix the behavior of the `excluded_exceptions` option: now it's used to skip capture of exceptions, not to purge the 

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -59,7 +59,7 @@ final class Handler extends AbstractProcessingHandler
 
             if (isset($record['context']['extra']) && \is_array($record['context']['extra'])) {
                 foreach ($record['context']['extra'] as $key => $value) {
-                    $scope->setExtra((string)$key, $value);
+                    $scope->setExtra((string) $key, $value);
                 }
             }
 

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -59,7 +59,7 @@ final class Handler extends AbstractProcessingHandler
 
             if (isset($record['context']['extra']) && \is_array($record['context']['extra'])) {
                 foreach ($record['context']['extra'] as $key => $value) {
-                    $scope->setExtra($key, $value);
+                    $scope->setExtra((string)$key, $value);
                 }
             }
 

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -281,5 +281,30 @@ final class HandlerTest extends TestCase
                 'bar.tag' => 'bar tag value',
             ],
         ];
+
+        yield [
+            [
+                'message' => 'foo bar',
+                'level' => Logger::INFO,
+                'level_name' => Logger::getLevelName(Logger::INFO),
+                'channel' => 'channel.foo',
+                'context' => [
+                    'extra' => [
+                        1 => 'numeric key',
+                    ],
+                ],
+                'extra' => [],
+            ],
+            [
+                'level' => Severity::info(),
+                'message' => 'foo bar',
+            ],
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::INFO),
+                1 => 'numeric key',
+            ],
+            [],
+        ];
     }
 }

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -302,7 +302,7 @@ final class HandlerTest extends TestCase
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::INFO),
-                1 => 'numeric key',
+                '1' => 'numeric key',
             ],
             [],
         ];


### PR DESCRIPTION
This fixes issue #833. A TypeError is raised if $key is numeric (either if the array key was an integer, or if the string was convertible to integer).