### PR TITLE
add: breadcrumbs to monolog handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
         "phpunit/phpunit": "^7.0",
         "symfony/phpunit-bridge": "^4.1.6"
     },
+    "suggest": {
+        "monolog/monolog": "If you want to use the monolog sentry handler."
+    },
     "conflict": {
         "php-http/client-common": "1.8.0",
         "raven/raven": "*"


### PR DESCRIPTION
It's very convenient when combined with finger_crossed and/or buffer handler as it gives more context to the error.

Let me know what you think about this idea. I will be happy to add tests and fix comments if you are ok with it.