### PR TITLE
Deprecate the methods on the HubInterface to get and set the current hub

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -7,7 +7,9 @@ return PhpCsFixer\Config::create()
         '@Symfony:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'one'],
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'imports_order' => ['class', 'function', 'const'],
+        ],
         'declare_strict_types' => true,
         'psr0' => true,
         'psr4' => true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Support force sending events on-demand and fix sending of events in long-running processes (#813)
 - Update PHPStan and introduce Psalm (#846)
 - Add an integration to set the transaction attribute of the event (#865)
+- Deprecate `Hub::getCurrent` and `Hub::setCurrent` methods to set the current hub instance (#847)
 
 ## 2.1.2 (2019-08-22)
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "autoload": {
         "files": [
-            "src/Sdk.php"
+            "src/functions.php"
         ],
         "psr-4" : {
             "Sentry\\" : "src/"
@@ -59,11 +59,8 @@
         "tests": [
             "vendor/bin/phpunit --verbose"
         ],
-        "tests-report": [
-            "vendor/bin/phpunit --verbose --configuration phpunit.xml.dist --coverage-html tests/html-report"
-        ],
         "phpcs": [
-            "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
+            "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run"
         ],
         "phpstan": [
             "vendor/bin/phpstan analyse"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,7 +8,6 @@ parameters:
         - '/Argument of an invalid type object supplied for foreach, only iterables are supported/'
         - '/Binary operation "\*" between array and 2 results in an error\./'
         - '/Http\\Client\\Curl\\Client/'
-        - '/^Call to method PHPUnit\\Framework\\Assert::assertSame\(\) with PHPUnit\\Framework\\MockObject\\MockObject&Sentry\\ClientInterface and null will always evaluate to false\.$/'
         - '/^Parameter #1 \$object of method ReflectionProperty::setValue\(\) expects object, null given\.$/' # https://github.com/phpstan/phpstan/pull/2340
         -
             message: /^Cannot assign offset 'os' to array\|string\.$/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
         - '/Argument of an invalid type object supplied for foreach, only iterables are supported/'
         - '/Binary operation "\*" between array and 2 results in an error\./'
         - '/Http\\Client\\Curl\\Client/'
+        - '/^Call to method PHPUnit\\Framework\\Assert::assertSame\(\) with PHPUnit\\Framework\\MockObject\\MockObject&Sentry\\ClientInterface and null will always evaluate to false\.$/'
         - '/^Parameter #1 \$object of method ReflectionProperty::setValue\(\) expects object, null given\.$/' # https://github.com/phpstan/phpstan/pull/2340
         -
             message: /^Cannot assign offset 'os' to array\|string\.$/

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -8,7 +8,7 @@ use Sentry\ErrorHandler;
 use Sentry\Exception\FatalErrorException;
 use Sentry\Exception\SilencedErrorException;
 use Sentry\Options;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 
 /**
  * This integration hooks into the global error handlers and emits events to
@@ -58,9 +58,8 @@ final class ErrorListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            $currentHub = Hub::getCurrent();
-            $integration = $currentHub->getIntegration(self::class);
-            $client = $currentHub->getClient();
+            $integration = SentrySdk::getIntegration(self::class);
+            $client = SentrySdk::getClient();
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
@@ -78,7 +77,7 @@ final class ErrorListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            $currentHub->captureException($exception);
+            SentrySdk::captureException($exception);
         });
     }
 }

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -58,8 +58,9 @@ final class ErrorListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            $integration = SentrySdk::getIntegration(self::class);
-            $client = SentrySdk::getClient();
+            $currentHub = SentrySdk::getCurrentHub();
+            $integration = $currentHub->getIntegration(self::class);
+            $client = $currentHub->getClient();
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
@@ -77,7 +78,7 @@ final class ErrorListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            SentrySdk::captureException($exception);
+            $currentHub->captureException($exception);
         });
     }
 }

--- a/src/Integration/ExceptionListenerIntegration.php
+++ b/src/Integration/ExceptionListenerIntegration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Sentry\ErrorHandler;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 
 /**
  * This integration hooks into the global error handlers and emits events to
@@ -21,8 +21,7 @@ final class ExceptionListenerIntegration implements IntegrationInterface
         /** @psalm-suppress DeprecatedMethod */
         $errorHandler = ErrorHandler::registerOnce(ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE, false);
         $errorHandler->addExceptionHandlerListener(static function (\Throwable $exception): void {
-            $currentHub = Hub::getCurrent();
-            $integration = $currentHub->getIntegration(self::class);
+            $integration = SentrySdk::getIntegration(self::class);
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
@@ -30,7 +29,7 @@ final class ExceptionListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            $currentHub->captureException($exception);
+            SentrySdk::captureException($exception);
         });
     }
 }

--- a/src/Integration/ExceptionListenerIntegration.php
+++ b/src/Integration/ExceptionListenerIntegration.php
@@ -21,7 +21,8 @@ final class ExceptionListenerIntegration implements IntegrationInterface
         /** @psalm-suppress DeprecatedMethod */
         $errorHandler = ErrorHandler::registerOnce(ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE, false);
         $errorHandler->addExceptionHandlerListener(static function (\Throwable $exception): void {
-            $integration = SentrySdk::getIntegration(self::class);
+            $currentHub = SentrySdk::getCurrentHub();
+            $integration = $currentHub->getIntegration(self::class);
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
@@ -29,7 +30,7 @@ final class ExceptionListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            SentrySdk::captureException($exception);
+            $currentHub->captureException($exception);
         });
     }
 }

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -42,8 +42,9 @@ final class FatalErrorListenerIntegration implements IntegrationInterface
     {
         $errorHandler = ErrorHandler::registerOnceFatalErrorHandler();
         $errorHandler->addFatalErrorHandlerListener(function (FatalErrorException $exception): void {
-            $integration = SentrySdk::getIntegration(self::class);
-            $client = SentrySdk::getClient();
+            $currentHub = SentrySdk::getCurrentHub();
+            $integration = $currentHub->getIntegration(self::class);
+            $client = $currentHub->getClient();
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
@@ -57,7 +58,7 @@ final class FatalErrorListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            SentrySdk::captureException($exception);
+            $currentHub->captureException($exception);
         });
     }
 }

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -7,7 +7,7 @@ namespace Sentry\Integration;
 use Sentry\ErrorHandler;
 use Sentry\Exception\FatalErrorException;
 use Sentry\Options;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 
 /**
  * This integration hooks into the error handler and captures fatal errors.
@@ -42,9 +42,8 @@ final class FatalErrorListenerIntegration implements IntegrationInterface
     {
         $errorHandler = ErrorHandler::registerOnceFatalErrorHandler();
         $errorHandler->addFatalErrorHandlerListener(function (FatalErrorException $exception): void {
-            $currentHub = Hub::getCurrent();
-            $integration = $currentHub->getIntegration(self::class);
-            $client = $currentHub->getClient();
+            $integration = SentrySdk::getIntegration(self::class);
+            $client = SentrySdk::getClient();
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
@@ -58,7 +57,7 @@ final class FatalErrorListenerIntegration implements IntegrationInterface
                 return;
             }
 
-            $currentHub->captureException($exception);
+            SentrySdk::captureException($exception);
         });
     }
 }

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -7,7 +7,7 @@ namespace Sentry\Integration;
 use Jean85\PrettyVersions;
 use PackageVersions\Versions;
 use Sentry\Event;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\State\Scope;
 
 /**
@@ -27,7 +27,7 @@ final class ModulesIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event) {
-            $integration = Hub::getCurrent()->getIntegration(self::class);
+            $integration = SentrySdk::getIntegration(self::class);
 
             // The integration could be bound to a client that is not the one
             // attached to the current hub. If this is the case, bail out

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -27,7 +27,7 @@ final class ModulesIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event) {
-            $integration = SentrySdk::getIntegration(self::class);
+            $integration = SentrySdk::getCurrentHub()->getIntegration(self::class);
 
             // The integration could be bound to a client that is not the one
             // attached to the current hub. If this is the case, bail out

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\UploadedFileInterface;
 use Sentry\Event;
 use Sentry\Exception\JsonException;
 use Sentry\Options;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Sentry\Util\JSON;
 use Zend\Diactoros\ServerRequestFactory;
@@ -61,9 +61,8 @@ final class RequestIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event): Event {
-            $currentHub = Hub::getCurrent();
-            $integration = $currentHub->getIntegration(self::class);
-            $client = $currentHub->getClient();
+            $integration = SentrySdk::getIntegration(self::class);
+            $client = SentrySdk::getClient();
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -61,8 +61,9 @@ final class RequestIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event): Event {
-            $integration = SentrySdk::getIntegration(self::class);
-            $client = SentrySdk::getClient();
+            $currentHub = SentrySdk::getCurrentHub();
+            $integration = $currentHub->getIntegration(self::class);
+            $client = $currentHub->getClient();
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out

--- a/src/Integration/TransactionIntegration.php
+++ b/src/Integration/TransactionIntegration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Sentry\Event;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\State\Scope;
 
 /**
@@ -23,8 +23,7 @@ final class TransactionIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(static function (Event $event, array $payload): Event {
-            $currentHub = Hub::getCurrent();
-            $integration = $currentHub->getIntegration(self::class);
+            $integration = SentrySdk::getCurrentHub()->getIntegration(self::class);
 
             // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out

--- a/src/SentrySdk.php
+++ b/src/SentrySdk.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+use Sentry\Integration\IntegrationInterface;
+use Sentry\State\Hub;
+use Sentry\State\HubInterface;
+use Sentry\State\Scope;
+
+/**
+ * This class is the main entry point for all the most common SDK features.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class SentrySdk
+{
+    /**
+     * @var HubInterface|null The current hub
+     */
+    private static $currentHub;
+
+    /**
+     * Constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Initializes the SDK by creating a new hub instance each time this method
+     * gets called.
+     *
+     * @return HubInterface
+     */
+    public static function init(): HubInterface
+    {
+        self::$currentHub = new Hub();
+
+        return self::$currentHub;
+    }
+
+    /**
+     * Gets the current hub. If it's not initialized then creates a new instance
+     * and sets it as current hub.
+     *
+     * @param bool $throwDeprecation Whether to throw a deprecation message when
+     *                               using this method. Internal only!
+     *
+     * @return HubInterface
+     *
+     * @deprecated since version 2.2, to be removed in 3.0
+     *
+     * @internal
+     */
+    public static function getCurrentHub(bool $throwDeprecation = true): HubInterface
+    {
+        if ($throwDeprecation) {
+            @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub;
+    }
+
+    /**
+     * Sets the current hub.
+     *
+     * @param HubInterface $hub              The hub to set
+     * @param bool         $throwDeprecation Whether to throw a deprecation message when
+     *                                       using this method. Internal only!
+     *
+     * @return HubInterface
+     *
+     * @deprecated since version 2.2, to be removed in 3.0
+     *
+     * @internal
+     */
+    public static function setCurrentHub(HubInterface $hub, bool $throwDeprecation = true): HubInterface
+    {
+        if ($throwDeprecation) {
+            @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
+        self::$currentHub = $hub;
+
+        return $hub;
+    }
+
+    /**
+     * Gets the client bound to the top of the stack.
+     *
+     * @return ClientInterface|null
+     */
+    public static function getClient(): ?ClientInterface
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->getClient();
+    }
+
+    /**
+     * Gets the ID of the last captured event.
+     *
+     * @return string|null
+     */
+    public static function getLastEventId(): ?string
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->getLastEventId();
+    }
+
+    /**
+     * Creates a new scope to store context information that will be layered on
+     * top of the current one. It is isolated, i.e. all breadcrumbs and context
+     * information added to this scope will be removed once the scope ends. Be
+     * sure to always remove this scope with {@see Hub::popScope} when the
+     * operation finishes or throws.
+     *
+     * @return Scope
+     */
+    public static function pushScope(): Scope
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->pushScope();
+    }
+
+    /**
+     * Removes a previously pushed scope from the stack. This restores the state
+     * before the scope was pushed. All breadcrumbs and context information added
+     * since the last call to {@see Hub::pushScope} are discarded.
+     *
+     * @return bool
+     */
+    public static function popScope(): bool
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->popScope();
+    }
+
+    /**
+     * Creates a new scope with and executes the given operation within. The scope
+     * is automatically removed once the operation finishes or throws.
+     *
+     * @param callable $callback The callback to be executed
+     */
+    public static function withScope(callable $callback): void
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        self::$currentHub->withScope($callback);
+    }
+
+    /**
+     * Calls the given callback passing to it the current scope so that any
+     * operation can be run within its context.
+     *
+     * @param callable $callback The callback to be executed
+     */
+    public static function configureScope(callable $callback): void
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        self::$currentHub->configureScope($callback);
+    }
+
+    /**
+     * Binds the given client to the current scope.
+     *
+     * @param ClientInterface $client The client
+     */
+    public static function bindClient(ClientInterface $client): void
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        self::$currentHub->bindClient($client);
+    }
+
+    /**
+     * Captures a message event and sends it to Sentry.
+     *
+     * @param string   $message The message
+     * @param Severity $level   The severity level of the message
+     *
+     * @return string|null
+     */
+    public static function captureMessage(string $message, ?Severity $level = null): ?string
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->captureMessage($message, $level);
+    }
+
+    /**
+     * Captures an exception event and sends it to Sentry.
+     *
+     * @param \Throwable $exception The exception
+     *
+     * @return string|null
+     */
+    public static function captureException(\Throwable $exception): ?string
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->captureException($exception);
+    }
+
+    /**
+     * Captures a new event using the provided data.
+     *
+     * @param array $payload The data of the event being captured
+     *
+     * @return string|null
+     */
+    public static function captureEvent(array $payload): ?string
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->captureEvent($payload);
+    }
+
+    /**
+     * Captures an event that logs the last occurred error.
+     *
+     * @return string|null
+     */
+    public static function captureLastError(): ?string
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->captureLastError();
+    }
+
+    /**
+     * Records a new breadcrumb which will be attached to future events. They
+     * will be added to subsequent events to provide more context on user's
+     * actions prior to an error or crash.
+     *
+     * @param Breadcrumb $breadcrumb The breadcrumb to record
+     *
+     * @return bool Whether the breadcrumb was actually added to the current scope
+     */
+    public static function addBreadcrumb(Breadcrumb $breadcrumb): bool
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->addBreadcrumb($breadcrumb);
+    }
+
+    /**
+     * Gets the integration whose FQCN matches the given one if it's available on the current client.
+     *
+     * @param string $className The FQCN of the integration
+     *
+     * @return IntegrationInterface|null
+     */
+    public static function getIntegration(string $className): ?IntegrationInterface
+    {
+        if (null === self::$currentHub) {
+            self::$currentHub = new Hub();
+        }
+
+        return self::$currentHub->getIntegration($className);
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.cloning.php#object.clone
+     */
+    public function __clone()
+    {
+        throw new \BadMethodCallException('Cloning is forbidden.');
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.wakeup
+     */
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Unserializing instances of this class is forbidden.');
+    }
+}

--- a/src/SentrySdk.php
+++ b/src/SentrySdk.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Sentry\Integration\IntegrationInterface;
 use Sentry\State\Hub;
 use Sentry\State\HubInterface;
-use Sentry\State\Scope;
 
 /**
  * This class is the main entry point for all the most common SDK features.
@@ -45,21 +43,10 @@ final class SentrySdk
      * Gets the current hub. If it's not initialized then creates a new instance
      * and sets it as current hub.
      *
-     * @param bool $throwDeprecation Whether to throw a deprecation message when
-     *                               using this method. Internal only!
-     *
      * @return HubInterface
-     *
-     * @deprecated since version 2.2, to be removed in 3.0
-     *
-     * @internal
      */
-    public static function getCurrentHub(bool $throwDeprecation = true): HubInterface
+    public static function getCurrentHub(): HubInterface
     {
-        if ($throwDeprecation) {
-            @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
-        }
-
         if (null === self::$currentHub) {
             self::$currentHub = new Hub();
         }
@@ -70,243 +57,14 @@ final class SentrySdk
     /**
      * Sets the current hub.
      *
-     * @param HubInterface $hub              The hub to set
-     * @param bool         $throwDeprecation Whether to throw a deprecation message when
-     *                                       using this method. Internal only!
+     * @param HubInterface $hub The hub to set
      *
      * @return HubInterface
-     *
-     * @deprecated since version 2.2, to be removed in 3.0
-     *
-     * @internal
      */
-    public static function setCurrentHub(HubInterface $hub, bool $throwDeprecation = true): HubInterface
+    public static function setCurrentHub(HubInterface $hub): HubInterface
     {
-        if ($throwDeprecation) {
-            @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
-        }
-
         self::$currentHub = $hub;
 
         return $hub;
-    }
-
-    /**
-     * Gets the client bound to the top of the stack.
-     *
-     * @return ClientInterface|null
-     */
-    public static function getClient(): ?ClientInterface
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->getClient();
-    }
-
-    /**
-     * Gets the ID of the last captured event.
-     *
-     * @return string|null
-     */
-    public static function getLastEventId(): ?string
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->getLastEventId();
-    }
-
-    /**
-     * Creates a new scope to store context information that will be layered on
-     * top of the current one. It is isolated, i.e. all breadcrumbs and context
-     * information added to this scope will be removed once the scope ends. Be
-     * sure to always remove this scope with {@see Hub::popScope} when the
-     * operation finishes or throws.
-     *
-     * @return Scope
-     */
-    public static function pushScope(): Scope
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->pushScope();
-    }
-
-    /**
-     * Removes a previously pushed scope from the stack. This restores the state
-     * before the scope was pushed. All breadcrumbs and context information added
-     * since the last call to {@see Hub::pushScope} are discarded.
-     *
-     * @return bool
-     */
-    public static function popScope(): bool
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->popScope();
-    }
-
-    /**
-     * Creates a new scope with and executes the given operation within. The scope
-     * is automatically removed once the operation finishes or throws.
-     *
-     * @param callable $callback The callback to be executed
-     */
-    public static function withScope(callable $callback): void
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        self::$currentHub->withScope($callback);
-    }
-
-    /**
-     * Calls the given callback passing to it the current scope so that any
-     * operation can be run within its context.
-     *
-     * @param callable $callback The callback to be executed
-     */
-    public static function configureScope(callable $callback): void
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        self::$currentHub->configureScope($callback);
-    }
-
-    /**
-     * Binds the given client to the current scope.
-     *
-     * @param ClientInterface $client The client
-     */
-    public static function bindClient(ClientInterface $client): void
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        self::$currentHub->bindClient($client);
-    }
-
-    /**
-     * Captures a message event and sends it to Sentry.
-     *
-     * @param string   $message The message
-     * @param Severity $level   The severity level of the message
-     *
-     * @return string|null
-     */
-    public static function captureMessage(string $message, ?Severity $level = null): ?string
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->captureMessage($message, $level);
-    }
-
-    /**
-     * Captures an exception event and sends it to Sentry.
-     *
-     * @param \Throwable $exception The exception
-     *
-     * @return string|null
-     */
-    public static function captureException(\Throwable $exception): ?string
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->captureException($exception);
-    }
-
-    /**
-     * Captures a new event using the provided data.
-     *
-     * @param array $payload The data of the event being captured
-     *
-     * @return string|null
-     */
-    public static function captureEvent(array $payload): ?string
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->captureEvent($payload);
-    }
-
-    /**
-     * Captures an event that logs the last occurred error.
-     *
-     * @return string|null
-     */
-    public static function captureLastError(): ?string
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->captureLastError();
-    }
-
-    /**
-     * Records a new breadcrumb which will be attached to future events. They
-     * will be added to subsequent events to provide more context on user's
-     * actions prior to an error or crash.
-     *
-     * @param Breadcrumb $breadcrumb The breadcrumb to record
-     *
-     * @return bool Whether the breadcrumb was actually added to the current scope
-     */
-    public static function addBreadcrumb(Breadcrumb $breadcrumb): bool
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->addBreadcrumb($breadcrumb);
-    }
-
-    /**
-     * Gets the integration whose FQCN matches the given one if it's available on the current client.
-     *
-     * @param string $className The FQCN of the integration
-     *
-     * @return IntegrationInterface|null
-     */
-    public static function getIntegration(string $className): ?IntegrationInterface
-    {
-        if (null === self::$currentHub) {
-            self::$currentHub = new Hub();
-        }
-
-        return self::$currentHub->getIntegration($className);
-    }
-
-    /**
-     * @see https://www.php.net/manual/en/language.oop5.cloning.php#object.clone
-     */
-    public function __clone()
-    {
-        throw new \BadMethodCallException('Cloning is forbidden.');
-    }
-
-    /**
-     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.wakeup
-     */
-    public function __wakeup()
-    {
-        throw new \BadMethodCallException('Unserializing instances of this class is forbidden.');
     }
 }

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -7,6 +7,7 @@ namespace Sentry\State;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
+use Sentry\SentrySdk;
 use Sentry\Severity;
 
 /**
@@ -25,11 +26,6 @@ final class Hub implements HubInterface
     private $lastEventId;
 
     /**
-     * @var HubInterface|null The hub that is set as the current one
-     */
-    private static $currentHub;
-
-    /**
      * Hub constructor.
      *
      * @param ClientInterface|null $client The client bound to the hub
@@ -37,11 +33,7 @@ final class Hub implements HubInterface
      */
     public function __construct(?ClientInterface $client = null, ?Scope $scope = null)
     {
-        if (null === $scope) {
-            $scope = new Scope();
-        }
-
-        $this->stack[] = new Layer($client, $scope);
+        $this->stack[] = new Layer($client, $scope ?? new Scope());
     }
 
     /**
@@ -204,11 +196,9 @@ final class Hub implements HubInterface
      */
     public static function getCurrent(): HubInterface
     {
-        if (null === self::$currentHub) {
-            self::$currentHub = new self();
-        }
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
-        return self::$currentHub;
+        return SentrySdk::getCurrentHub(false);
     }
 
     /**
@@ -216,7 +206,9 @@ final class Hub implements HubInterface
      */
     public static function setCurrent(HubInterface $hub): HubInterface
     {
-        self::$currentHub = $hub;
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+
+        SentrySdk::setCurrentHub($hub, false);
 
         return $hub;
     }

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -198,7 +198,7 @@ final class Hub implements HubInterface
     {
         @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
-        return SentrySdk::getCurrentHub(false);
+        return SentrySdk::getCurrentHub();
     }
 
     /**
@@ -208,7 +208,7 @@ final class Hub implements HubInterface
     {
         @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
-        SentrySdk::setCurrentHub($hub, false);
+        SentrySdk::setCurrentHub($hub);
 
         return $hub;
     }

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -196,7 +196,7 @@ final class Hub implements HubInterface
      */
     public static function getCurrent(): HubInterface
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::getCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
 
         return SentrySdk::getCurrentHub();
     }
@@ -206,7 +206,7 @@ final class Hub implements HubInterface
      */
     public static function setCurrent(HubInterface $hub): HubInterface
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::setCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
 
         SentrySdk::setCurrentHub($hub);
 

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -11,9 +11,8 @@ use Sentry\SentrySdk;
 use Sentry\Severity;
 
 /**
- * An implementation of {@see HubInterface} which forwards any call to {@see SentrySdk}.
- * This allows testing classes which otherwise would need to depend on it by
- * having them depend on the interface instead, which can be mocked.
+ * An implementation of {@see HubInterface} that uses {@see SentrySdk} internally
+ * to manage the current hub.
  */
 final class HubAdapter implements HubInterface
 {

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -49,7 +49,7 @@ final class HubAdapter implements HubInterface
      */
     public function getClient(): ?ClientInterface
     {
-        return SentrySdk::getClient();
+        return SentrySdk::getCurrentHub()->getClient();
     }
 
     /**
@@ -57,7 +57,7 @@ final class HubAdapter implements HubInterface
      */
     public function getLastEventId(): ?string
     {
-        return SentrySdk::getLastEventId();
+        return SentrySdk::getCurrentHub()->getLastEventId();
     }
 
     /**
@@ -65,7 +65,7 @@ final class HubAdapter implements HubInterface
      */
     public function pushScope(): Scope
     {
-        return SentrySdk::pushScope();
+        return SentrySdk::getCurrentHub()->pushScope();
     }
 
     /**
@@ -73,7 +73,7 @@ final class HubAdapter implements HubInterface
      */
     public function popScope(): bool
     {
-        return SentrySdk::popScope();
+        return SentrySdk::getCurrentHub()->popScope();
     }
 
     /**
@@ -81,7 +81,7 @@ final class HubAdapter implements HubInterface
      */
     public function withScope(callable $callback): void
     {
-        SentrySdk::withScope($callback);
+        SentrySdk::getCurrentHub()->withScope($callback);
     }
 
     /**
@@ -89,7 +89,7 @@ final class HubAdapter implements HubInterface
      */
     public function configureScope(callable $callback): void
     {
-        SentrySdk::configureScope($callback);
+        SentrySdk::getCurrentHub()->configureScope($callback);
     }
 
     /**
@@ -97,7 +97,7 @@ final class HubAdapter implements HubInterface
      */
     public function bindClient(ClientInterface $client): void
     {
-        SentrySdk::bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
     }
 
     /**
@@ -105,7 +105,7 @@ final class HubAdapter implements HubInterface
      */
     public function captureMessage(string $message, ?Severity $level = null): ?string
     {
-        return SentrySdk::captureMessage($message, $level);
+        return SentrySdk::getCurrentHub()->captureMessage($message, $level);
     }
 
     /**
@@ -113,7 +113,7 @@ final class HubAdapter implements HubInterface
      */
     public function captureException(\Throwable $exception): ?string
     {
-        return SentrySdk::captureException($exception);
+        return SentrySdk::getCurrentHub()->captureException($exception);
     }
 
     /**
@@ -121,7 +121,7 @@ final class HubAdapter implements HubInterface
      */
     public function captureEvent(array $payload): ?string
     {
-        return SentrySdk::captureEvent($payload);
+        return SentrySdk::getCurrentHub()->captureEvent($payload);
     }
 
     /**
@@ -129,7 +129,7 @@ final class HubAdapter implements HubInterface
      */
     public function captureLastError(): ?string
     {
-        return SentrySdk::captureLastError();
+        return SentrySdk::getCurrentHub()->captureLastError();
     }
 
     /**
@@ -137,7 +137,7 @@ final class HubAdapter implements HubInterface
      */
     public function addBreadcrumb(Breadcrumb $breadcrumb): bool
     {
-        return SentrySdk::addBreadcrumb($breadcrumb);
+        return SentrySdk::getCurrentHub()->addBreadcrumb($breadcrumb);
     }
 
     /**
@@ -145,9 +145,9 @@ final class HubAdapter implements HubInterface
      */
     public static function getCurrent(): HubInterface
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::getCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return SentrySdk::getCurrentHub(false);
+        return SentrySdk::getCurrentHub();
     }
 
     /**
@@ -155,9 +155,9 @@ final class HubAdapter implements HubInterface
      */
     public static function setCurrent(HubInterface $hub): HubInterface
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::getCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
 
-        return SentrySdk::setCurrentHub($hub, false);
+        return SentrySdk::setCurrentHub($hub);
     }
 
     /**
@@ -165,7 +165,7 @@ final class HubAdapter implements HubInterface
      */
     public function getIntegration(string $className): ?IntegrationInterface
     {
-        return SentrySdk::getIntegration($className);
+        return SentrySdk::getCurrentHub()->getIntegration($className);
     }
 
     /**

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\State;
+
+use Sentry\Breadcrumb;
+use Sentry\ClientInterface;
+use Sentry\Integration\IntegrationInterface;
+use Sentry\SentrySdk;
+use Sentry\Severity;
+
+/**
+ * An implementation of {@see HubInterface} which forwards any call to {@see SentrySdk}.
+ * This allows testing classes which otherwise would need to depend on it by
+ * having them depend on the interface instead, which can be mocked.
+ */
+final class HubAdapter implements HubInterface
+{
+    /**
+     * @var self The single instance which forwards all calls to {@see SentrySdk}
+     */
+    private static $instance;
+
+    /**
+     * Constructor.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Gets the instance of this class. This is a singleton, so once initialized
+     * you will always get the same instance.
+     *
+     * @return self
+     */
+    public static function getInstance(): self
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClient(): ?ClientInterface
+    {
+        return SentrySdk::getClient();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastEventId(): ?string
+    {
+        return SentrySdk::getLastEventId();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pushScope(): Scope
+    {
+        return SentrySdk::pushScope();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function popScope(): bool
+    {
+        return SentrySdk::popScope();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function withScope(callable $callback): void
+    {
+        SentrySdk::withScope($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureScope(callable $callback): void
+    {
+        SentrySdk::configureScope($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bindClient(ClientInterface $client): void
+    {
+        SentrySdk::bindClient($client);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function captureMessage(string $message, ?Severity $level = null): ?string
+    {
+        return SentrySdk::captureMessage($message, $level);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function captureException(\Throwable $exception): ?string
+    {
+        return SentrySdk::captureException($exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function captureEvent(array $payload): ?string
+    {
+        return SentrySdk::captureEvent($payload);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function captureLastError(): ?string
+    {
+        return SentrySdk::captureLastError();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addBreadcrumb(Breadcrumb $breadcrumb): bool
+    {
+        return SentrySdk::addBreadcrumb($breadcrumb);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getCurrent(): HubInterface
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0', __METHOD__), E_USER_DEPRECATED);
+
+        return SentrySdk::getCurrentHub(false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function setCurrent(HubInterface $hub): HubInterface
+    {
+        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0', __METHOD__), E_USER_DEPRECATED);
+
+        return SentrySdk::setCurrentHub($hub, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIntegration(string $className): ?IntegrationInterface
+    {
+        return SentrySdk::getIntegration($className);
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.cloning.php#object.clone
+     */
+    public function __clone()
+    {
+        throw new \BadMethodCallException('Cloning is forbidden.');
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.wakeup
+     */
+    public function __wakeup()
+    {
+        throw new \BadMethodCallException('Unserializing instances of this class is forbidden.');
+    }
+}

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -123,8 +123,10 @@ interface HubInterface
      * Returns the current global Hub.
      *
      * @return HubInterface
+     *
+     * @deprecated since version 2.2, to be removed in 3.0
      */
-    public static function getCurrent(): HubInterface;
+    public static function getCurrent(): self;
 
     /**
      * Sets the Hub as the current.
@@ -132,8 +134,10 @@ interface HubInterface
      * @param HubInterface $hub The Hub that will become the current one
      *
      * @return HubInterface
+     *
+     * @deprecated since version 2.2, to be removed in 3.0
      */
-    public static function setCurrent(HubInterface $hub): HubInterface;
+    public static function setCurrent(self $hub): self;
 
     /**
      * Gets the integration whose FQCN matches the given one if it's available on the current client.

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -7,6 +7,7 @@ namespace Sentry\State;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
+use Sentry\SentrySdk;
 use Sentry\Severity;
 
 /**
@@ -125,6 +126,7 @@ interface HubInterface
      * @return HubInterface
      *
      * @deprecated since version 2.2, to be removed in 3.0
+     * @see SentrySdk::getCurrentHub()
      */
     public static function getCurrent(): self;
 
@@ -136,6 +138,7 @@ interface HubInterface
      * @return HubInterface
      *
      * @deprecated since version 2.2, to be removed in 3.0
+     * @see SentrySdk::setCurrentHub()
      */
     public static function setCurrent(self $hub): self;
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -23,14 +23,10 @@ function init(array $options = []): void
  * @param Severity $level   The severity level of the message
  *
  * @return string|null
- *
- * @deprecated
  */
 function captureMessage(string $message, ?Severity $level = null): ?string
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureMessage method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    return SentrySdk::captureMessage($message, $level);
+    return SentrySdk::getCurrentHub()->captureMessage($message, $level);
 }
 
 /**
@@ -39,14 +35,10 @@ function captureMessage(string $message, ?Severity $level = null): ?string
  * @param \Throwable $exception The exception
  *
  * @return string|null
- *
- * @deprecated
  */
 function captureException(\Throwable $exception): ?string
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureException method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    return SentrySdk::captureException($exception);
+    return SentrySdk::getCurrentHub()->captureException($exception);
 }
 
 /**
@@ -55,28 +47,20 @@ function captureException(\Throwable $exception): ?string
  * @param array $payload The data of the event being captured
  *
  * @return string|null
- *
- * @deprecated
  */
 function captureEvent(array $payload): ?string
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureEvent method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    return SentrySdk::captureEvent($payload);
+    return SentrySdk::getCurrentHub()->captureEvent($payload);
 }
 
 /**
  * Logs the most recent error (obtained with {@link error_get_last}).
  *
  * @return string|null
- *
- * @deprecated
  */
 function captureLastError(): ?string
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureLastError method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    return SentrySdk::captureLastError();
+    return SentrySdk::getCurrentHub()->captureLastError();
 }
 
 /**
@@ -85,14 +69,10 @@ function captureLastError(): ?string
  * actions prior to an error or crash.
  *
  * @param Breadcrumb $breadcrumb The breadcrumb to record
- *
- * @deprecated
  */
 function addBreadcrumb(Breadcrumb $breadcrumb): void
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::addBreadcrumb method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    SentrySdk::addBreadcrumb($breadcrumb);
+    SentrySdk::getCurrentHub()->addBreadcrumb($breadcrumb);
 }
 
 /**
@@ -100,14 +80,10 @@ function addBreadcrumb(Breadcrumb $breadcrumb): void
  * operation can be run within its context.
  *
  * @param callable $callback The callback to be executed
- *
- * @deprecated
  */
 function configureScope(callable $callback): void
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::configureScope method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    SentrySdk::configureScope($callback);
+    SentrySdk::getCurrentHub()->configureScope($callback);
 }
 
 /**
@@ -115,12 +91,8 @@ function configureScope(callable $callback): void
  * is automatically removed once the operation finishes or throws.
  *
  * @param callable $callback The callback to be executed
- *
- * @deprecated
  */
 function withScope(callable $callback): void
 {
-    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::withScope method instead.', __FUNCTION__), E_USER_DEPRECATED);
-
-    SentrySdk::withScope($callback);
+    SentrySdk::getCurrentHub()->withScope($callback);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Sentry\State\Hub;
-
 /**
  * Creates a new Client and Hub which will be set as current.
  *
@@ -15,7 +13,7 @@ function init(array $options = []): void
 {
     $client = ClientBuilder::create($options)->getClient();
 
-    Hub::setCurrent(new Hub($client));
+    SentrySdk::init()->bindClient($client);
 }
 
 /**
@@ -25,10 +23,14 @@ function init(array $options = []): void
  * @param Severity $level   The severity level of the message
  *
  * @return string|null
+ *
+ * @deprecated
  */
 function captureMessage(string $message, ?Severity $level = null): ?string
 {
-    return Hub::getCurrent()->captureMessage($message, $level);
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureMessage method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    return SentrySdk::captureMessage($message, $level);
 }
 
 /**
@@ -37,10 +39,14 @@ function captureMessage(string $message, ?Severity $level = null): ?string
  * @param \Throwable $exception The exception
  *
  * @return string|null
+ *
+ * @deprecated
  */
 function captureException(\Throwable $exception): ?string
 {
-    return Hub::getCurrent()->captureException($exception);
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureException method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    return SentrySdk::captureException($exception);
 }
 
 /**
@@ -49,20 +55,28 @@ function captureException(\Throwable $exception): ?string
  * @param array $payload The data of the event being captured
  *
  * @return string|null
+ *
+ * @deprecated
  */
 function captureEvent(array $payload): ?string
 {
-    return Hub::getCurrent()->captureEvent($payload);
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureEvent method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    return SentrySdk::captureEvent($payload);
 }
 
 /**
  * Logs the most recent error (obtained with {@link error_get_last}).
  *
  * @return string|null
+ *
+ * @deprecated
  */
 function captureLastError(): ?string
 {
-    return Hub::getCurrent()->captureLastError();
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::captureLastError method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    return SentrySdk::captureLastError();
 }
 
 /**
@@ -71,10 +85,14 @@ function captureLastError(): ?string
  * actions prior to an error or crash.
  *
  * @param Breadcrumb $breadcrumb The breadcrumb to record
+ *
+ * @deprecated
  */
 function addBreadcrumb(Breadcrumb $breadcrumb): void
 {
-    Hub::getCurrent()->addBreadcrumb($breadcrumb);
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::addBreadcrumb method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    SentrySdk::addBreadcrumb($breadcrumb);
 }
 
 /**
@@ -82,10 +100,14 @@ function addBreadcrumb(Breadcrumb $breadcrumb): void
  * operation can be run within its context.
  *
  * @param callable $callback The callback to be executed
+ *
+ * @deprecated
  */
 function configureScope(callable $callback): void
 {
-    Hub::getCurrent()->configureScope($callback);
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::configureScope method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    SentrySdk::configureScope($callback);
 }
 
 /**
@@ -93,8 +115,12 @@ function configureScope(callable $callback): void
  * is automatically removed once the operation finishes or throws.
  *
  * @param callable $callback The callback to be executed
+ *
+ * @deprecated
  */
 function withScope(callable $callback): void
 {
-    Hub::getCurrent()->withScope($callback);
+    @trigger_error(sprintf('The function %s() is deprecated since version 2.2 and will be removed in 3.0. Use the SentrySdk::withScope method instead.', __FUNCTION__), E_USER_DEPRECATED);
+
+    SentrySdk::withScope($callback);
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -31,7 +31,7 @@ final class FunctionsTest extends TestCase
     {
         init(['default_integrations' => false]);
 
-        $this->assertNotNull(SentrySdk::getClient());
+        $this->assertNotNull(SentrySdk::getCurrentHub()->getClient());
     }
 
     public function testCaptureMessage(): void
@@ -43,7 +43,7 @@ final class FunctionsTest extends TestCase
             ->with('foo', Severity::debug())
             ->willReturn('92db40a886c0458288c7c83935a350ef');
 
-        SentrySdk::bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
 
         $this->assertEquals('92db40a886c0458288c7c83935a350ef', captureMessage('foo', Severity::debug()));
     }
@@ -59,7 +59,7 @@ final class FunctionsTest extends TestCase
             ->with($exception)
             ->willReturn('2b867534eead412cbdb882fd5d441690');
 
-        SentrySdk::bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
 
         $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureException($exception));
     }
@@ -73,7 +73,7 @@ final class FunctionsTest extends TestCase
             ->with(['message' => 'foo'])
             ->willReturn('2b867534eead412cbdb882fd5d441690');
 
-        SentrySdk::bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
 
         $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureEvent(['message' => 'foo']));
     }
@@ -85,7 +85,7 @@ final class FunctionsTest extends TestCase
         $client->expects($this->once())
             ->method('captureLastError');
 
-        SentrySdk::bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
 
         @trigger_error('foo', E_USER_NOTICE);
 
@@ -102,7 +102,7 @@ final class FunctionsTest extends TestCase
             ->method('getOptions')
             ->willReturn(new Options(['default_integrations' => false]));
 
-        SentrySdk::bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
 
         addBreadcrumb($breadcrumb);
         configureScope(function (Scope $scope) use ($breadcrumb): void {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -6,31 +6,32 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use function Sentry\addBreadcrumb;
 use Sentry\Breadcrumb;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\Options;
+use Sentry\SentrySdk;
+use Sentry\Severity;
+use Sentry\State\Scope;
+use function Sentry\addBreadcrumb;
 use function Sentry\captureEvent;
 use function Sentry\captureException;
 use function Sentry\captureLastError;
 use function Sentry\captureMessage;
-use Sentry\ClientInterface;
 use function Sentry\configureScope;
-use Sentry\Event;
 use function Sentry\init;
-use Sentry\Options;
-use Sentry\State\Hub;
-use Sentry\State\Scope;
 use function Sentry\withScope;
 
-class SdkTest extends TestCase
+/**
+ * @group legacy
+ */
+final class FunctionsTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        init();
-    }
-
     public function testInit(): void
     {
-        $this->assertNotNull(Hub::getCurrent()->getClient());
+        init(['default_integrations' => false]);
+
+        $this->assertNotNull(SentrySdk::getClient());
     }
 
     public function testCaptureMessage(): void
@@ -39,12 +40,12 @@ class SdkTest extends TestCase
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureMessage')
+            ->with('foo', Severity::debug())
             ->willReturn('92db40a886c0458288c7c83935a350ef');
 
-        Hub::getCurrent()->bindClient($client);
+        SentrySdk::bindClient($client);
 
-        $this->assertEquals($client, Hub::getCurrent()->getClient());
-        $this->assertEquals('92db40a886c0458288c7c83935a350ef', captureMessage('foo'));
+        $this->assertEquals('92db40a886c0458288c7c83935a350ef', captureMessage('foo', Severity::debug()));
     }
 
     public function testCaptureException(): void
@@ -58,7 +59,7 @@ class SdkTest extends TestCase
             ->with($exception)
             ->willReturn('2b867534eead412cbdb882fd5d441690');
 
-        Hub::getCurrent()->bindClient($client);
+        SentrySdk::bindClient($client);
 
         $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureException($exception));
     }
@@ -69,12 +70,12 @@ class SdkTest extends TestCase
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureEvent')
-            ->with(['message' => 'test'])
+            ->with(['message' => 'foo'])
             ->willReturn('2b867534eead412cbdb882fd5d441690');
 
-        Hub::getCurrent()->bindClient($client);
+        SentrySdk::bindClient($client);
 
-        $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureEvent(['message' => 'test']));
+        $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureEvent(['message' => 'foo']));
     }
 
     public function testCaptureLastError()
@@ -84,7 +85,7 @@ class SdkTest extends TestCase
         $client->expects($this->once())
             ->method('captureLastError');
 
-        Hub::getCurrent()->bindClient($client);
+        SentrySdk::bindClient($client);
 
         @trigger_error('foo', E_USER_NOTICE);
 
@@ -99,9 +100,9 @@ class SdkTest extends TestCase
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('getOptions')
-            ->willReturn(new Options());
+            ->willReturn(new Options(['default_integrations' => false]));
 
-        Hub::getCurrent()->bindClient($client);
+        SentrySdk::bindClient($client);
 
         addBreadcrumb($breadcrumb);
         configureScope(function (Scope $scope) use ($breadcrumb): void {
@@ -116,7 +117,7 @@ class SdkTest extends TestCase
     {
         $callbackInvoked = false;
 
-        withScope(function () use (&$callbackInvoked): void {
+        withScope(static function () use (&$callbackInvoked): void {
             $callbackInvoked = true;
         });
 
@@ -127,7 +128,7 @@ class SdkTest extends TestCase
     {
         $callbackInvoked = false;
 
-        configureScope(function () use (&$callbackInvoked): void {
+        configureScope(static function () use (&$callbackInvoked): void {
             $callbackInvoked = true;
         });
 

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Event;
 use Sentry\Integration\TransactionIntegration;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use function Sentry\withScope;
 
@@ -33,7 +33,7 @@ final class TransactionIntegrationTest extends TestCase
             ->method('getIntegration')
             ->willReturn($isIntegrationEnabled ? $integration : null);
 
-        Hub::getCurrent()->bindClient($client);
+        SentrySdk::getCurrentHub()->bindClient($client);
 
         withScope(function (Scope $scope) use ($event, $payload, $expectedTransaction): void {
             $event = $scope->applyToEvent($event, $payload);

--- a/tests/SentrySdkExtension.php
+++ b/tests/SentrySdkExtension.php
@@ -5,16 +5,14 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use PHPUnit\Runner\BeforeTestHook as BeforeTestHookInterface;
-use Sentry\State\Hub;
-use Sentry\State\Scope;
 use Sentry\SentrySdk;
+use Sentry\State\Scope;
 
 final class SentrySdkExtension implements BeforeTestHookInterface
 {
     public function executeBeforeTest(string $test): void
     {
         $reflectionProperty = new \ReflectionProperty(SentrySdk::class, 'currentHub');
-
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue(null, null);
         $reflectionProperty->setAccessible(false);

--- a/tests/SentrySdkExtension.php
+++ b/tests/SentrySdkExtension.php
@@ -7,12 +7,17 @@ namespace Sentry\Tests;
 use PHPUnit\Runner\BeforeTestHook as BeforeTestHookInterface;
 use Sentry\State\Hub;
 use Sentry\State\Scope;
+use Sentry\SentrySdk;
 
 final class SentrySdkExtension implements BeforeTestHookInterface
 {
     public function executeBeforeTest(string $test): void
     {
-        Hub::setCurrent(new Hub());
+        $reflectionProperty = new \ReflectionProperty(SentrySdk::class, 'currentHub');
+
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, null);
+        $reflectionProperty->setAccessible(false);
 
         $reflectionProperty = new \ReflectionProperty(Scope::class, 'globalEventProcessors');
         $reflectionProperty->setAccessible(true);

--- a/tests/SentrySdkTest.php
+++ b/tests/SentrySdkTest.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace Sentry\Tests;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sentry\Breadcrumb;
-use Sentry\ClientInterface;
-use Sentry\Integration\IntegrationInterface;
-use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
-use Sentry\State\Scope;
 
 final class SentrySdkTest extends TestCase
 {
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation The Sentry\SentrySdk::getCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
-     */
     public function testInit(): void
     {
         $hub1 = SentrySdk::init();
@@ -30,11 +19,6 @@ final class SentrySdkTest extends TestCase
         $this->assertNotSame(SentrySdk::init(), SentrySdk::init());
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation The Sentry\SentrySdk::getCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
-     */
     public function testGetCurrentHub(): void
     {
         SentrySdk::init();
@@ -45,220 +29,11 @@ final class SentrySdkTest extends TestCase
         $this->assertSame($hub2, $hub3);
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation The Sentry\SentrySdk::setCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
-     * @expectedDeprecation The Sentry\SentrySdk::getCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
-     */
     public function testSetCurrentHub(): void
     {
         $hub = new Hub();
 
         $this->assertSame($hub, SentrySdk::setCurrentHub($hub));
         $this->assertSame($hub, SentrySdk::getCurrentHub());
-    }
-
-    public function testGetLastEventId(): void
-    {
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureMessage')
-            ->willReturn('c3291ed00c34427bb987f1deabd956bd');
-
-        $this->assertNull(SentrySdk::getLastEventId());
-
-        SentrySdk::bindClient($client);
-        SentrySdk::captureMessage('foo bar');
-
-        $this->assertSame('c3291ed00c34427bb987f1deabd956bd', SentrySdk::getLastEventId());
-    }
-
-    public function testPushScope(): void
-    {
-        $scope = SentrySdk::pushScope();
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureEvent')
-            ->with([], $scope);
-
-        SentrySdk::bindClient($client);
-        SentrySdk::captureEvent([]);
-    }
-
-    public function testPopScope(): void
-    {
-        $this->assertFalse(SentrySdk::popScope());
-
-        $scope1 = SentrySdk::pushScope();
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureEvent')
-            ->with([], $scope1);
-
-        SentrySdk::bindClient($client);
-
-        $scope2 = SentrySdk::pushScope();
-
-        $this->assertNotSame($scope1, $scope2);
-        $this->assertTrue(SentrySdk::popScope());
-
-        SentrySdk::captureEvent([]);
-    }
-
-    public function testWithScope(): void
-    {
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-
-        SentrySdk::bindClient($client);
-        SentrySdk::withScope(function (Scope $scopeArg) use ($client): void {
-            $client->expects($this->once())
-                ->method('captureEvent')
-                ->with([], $scopeArg);
-
-            SentrySdk::captureEvent([]);
-        });
-    }
-
-    public function testConfigureScope(): void
-    {
-        $callbackCalled = false;
-        $scope = null;
-
-        SentrySdk::configureScope(static function (Scope $scopeArg) use (&$callbackCalled, &$scope): void {
-            $callbackCalled = true;
-            $scope = $scopeArg;
-        });
-
-        $this->assertTrue($callbackCalled);
-        $this->assertNotNull($scope);
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureEvent')
-            ->with([], $scope);
-
-        SentrySdk::bindClient($client);
-        SentrySdk::captureEvent([]);
-    }
-
-    public function testBindClient(): void
-    {
-        /** @var ClientInterface&MockObject $client1 */
-        $client1 = $this->createMock(ClientInterface::class);
-
-        $this->assertNull(SentrySdk::getClient());
-
-        SentrySdk::bindClient($client1);
-
-        $client2 = SentrySdk::getClient();
-
-        $this->assertSame($client1, $client2);
-    }
-
-    public function testCaptureMessage(): void
-    {
-        $this->assertNull(SentrySdk::captureMessage('foo bar'));
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureMessage')
-            ->with('foo bar')
-            ->willReturn('51884e708f85482d8c98b16dc6c3efcf');
-
-        SentrySdk::bindClient($client);
-
-        $this->assertSame('51884e708f85482d8c98b16dc6c3efcf', SentrySdk::captureMessage('foo bar'));
-    }
-
-    public function testCaptureException(): void
-    {
-        $exception = new \Exception();
-
-        $this->assertNull(SentrySdk::captureException($exception));
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureException')
-            ->with($exception)
-            ->willReturn('8f19c2ecf1d1429594c4b8b7b04d4be9');
-
-        SentrySdk::bindClient($client);
-
-        $this->assertSame('8f19c2ecf1d1429594c4b8b7b04d4be9', SentrySdk::captureException($exception));
-    }
-
-    public function testCaptureEvent(): void
-    {
-        $this->assertNull(SentrySdk::captureEvent([]));
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureEvent')
-            ->with(['foo' => 'bar'])
-            ->willReturn('57f29461c03640228bc996970dbef8f1');
-
-        SentrySdk::bindClient($client);
-
-        $this->assertSame('57f29461c03640228bc996970dbef8f1', SentrySdk::captureEvent(['foo' => 'bar']));
-    }
-
-    public function testCaptureLastError(): void
-    {
-        $this->assertNull(SentrySdk::captureLastError());
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('captureLastError')
-            ->willReturn('902d6cfece4c49c7992bf6bfba1e9d2d');
-
-        SentrySdk::bindClient($client);
-
-        $this->assertSame('902d6cfece4c49c7992bf6bfba1e9d2d', SentrySdk::captureLastError());
-    }
-
-    public function testAddBreadcrumb(): void
-    {
-        $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_DEBUG, Breadcrumb::TYPE_DEFAULT, 'user_error');
-
-        $this->assertFalse(SentrySdk::addBreadcrumb($breadcrumb));
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('getOptions')
-            ->willReturn(new Options());
-
-        SentrySdk::bindClient($client);
-
-        $this->assertTrue(SentrySdk::addBreadcrumb($breadcrumb));
-    }
-
-    public function testGetIntegration(): void
-    {
-        /** @var IntegrationInterface&MockObject $integration */
-        $integration = $this->createMock(IntegrationInterface::class);
-
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('getIntegration')
-            ->with('Foo\\Bar')
-            ->willReturn($integration);
-
-        SentrySdk::bindClient($client);
-
-        $this->assertSame($integration, SentrySdk::getIntegration('Foo\\Bar'));
     }
 }

--- a/tests/SentrySdkTest.php
+++ b/tests/SentrySdkTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\Breadcrumb;
+use Sentry\ClientInterface;
+use Sentry\Integration\IntegrationInterface;
+use Sentry\Options;
+use Sentry\SentrySdk;
+use Sentry\State\Hub;
+use Sentry\State\Scope;
+
+final class SentrySdkTest extends TestCase
+{
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The Sentry\SentrySdk::getCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
+     */
+    public function testInit(): void
+    {
+        $hub1 = SentrySdk::init();
+        $hub2 = SentrySdk::getCurrentHub();
+
+        $this->assertSame($hub1, $hub2);
+        $this->assertNotSame(SentrySdk::init(), SentrySdk::init());
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The Sentry\SentrySdk::getCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
+     */
+    public function testGetCurrentHub(): void
+    {
+        SentrySdk::init();
+
+        $hub2 = SentrySdk::getCurrentHub();
+        $hub3 = SentrySdk::getCurrentHub();
+
+        $this->assertSame($hub2, $hub3);
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation The Sentry\SentrySdk::setCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
+     * @expectedDeprecation The Sentry\SentrySdk::getCurrentHub() method is deprecated since version 2.2 and will be removed in 3.0.
+     */
+    public function testSetCurrentHub(): void
+    {
+        $hub = new Hub();
+
+        $this->assertSame($hub, SentrySdk::setCurrentHub($hub));
+        $this->assertSame($hub, SentrySdk::getCurrentHub());
+    }
+
+    public function testGetLastEventId(): void
+    {
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureMessage')
+            ->willReturn('c3291ed00c34427bb987f1deabd956bd');
+
+        $this->assertNull(SentrySdk::getLastEventId());
+
+        SentrySdk::bindClient($client);
+        SentrySdk::captureMessage('foo bar');
+
+        $this->assertSame('c3291ed00c34427bb987f1deabd956bd', SentrySdk::getLastEventId());
+    }
+
+    public function testPushScope(): void
+    {
+        $scope = SentrySdk::pushScope();
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with([], $scope);
+
+        SentrySdk::bindClient($client);
+        SentrySdk::captureEvent([]);
+    }
+
+    public function testPopScope(): void
+    {
+        $this->assertFalse(SentrySdk::popScope());
+
+        $scope1 = SentrySdk::pushScope();
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with([], $scope1);
+
+        SentrySdk::bindClient($client);
+
+        $scope2 = SentrySdk::pushScope();
+
+        $this->assertNotSame($scope1, $scope2);
+        $this->assertTrue(SentrySdk::popScope());
+
+        SentrySdk::captureEvent([]);
+    }
+
+    public function testWithScope(): void
+    {
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+
+        SentrySdk::bindClient($client);
+        SentrySdk::withScope(function (Scope $scopeArg) use ($client): void {
+            $client->expects($this->once())
+                ->method('captureEvent')
+                ->with([], $scopeArg);
+
+            SentrySdk::captureEvent([]);
+        });
+    }
+
+    public function testConfigureScope(): void
+    {
+        $callbackCalled = false;
+        $scope = null;
+
+        SentrySdk::configureScope(static function (Scope $scopeArg) use (&$callbackCalled, &$scope): void {
+            $callbackCalled = true;
+            $scope = $scopeArg;
+        });
+
+        $this->assertTrue($callbackCalled);
+        $this->assertNotNull($scope);
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with([], $scope);
+
+        SentrySdk::bindClient($client);
+        SentrySdk::captureEvent([]);
+    }
+
+    public function testBindClient(): void
+    {
+        /** @var ClientInterface&MockObject $client1 */
+        $client1 = $this->createMock(ClientInterface::class);
+
+        $this->assertNull(SentrySdk::getClient());
+
+        SentrySdk::bindClient($client1);
+
+        $client2 = SentrySdk::getClient();
+
+        $this->assertSame($client1, $client2);
+    }
+
+    public function testCaptureMessage(): void
+    {
+        $this->assertNull(SentrySdk::captureMessage('foo bar'));
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureMessage')
+            ->with('foo bar')
+            ->willReturn('51884e708f85482d8c98b16dc6c3efcf');
+
+        SentrySdk::bindClient($client);
+
+        $this->assertSame('51884e708f85482d8c98b16dc6c3efcf', SentrySdk::captureMessage('foo bar'));
+    }
+
+    public function testCaptureException(): void
+    {
+        $exception = new \Exception();
+
+        $this->assertNull(SentrySdk::captureException($exception));
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureException')
+            ->with($exception)
+            ->willReturn('8f19c2ecf1d1429594c4b8b7b04d4be9');
+
+        SentrySdk::bindClient($client);
+
+        $this->assertSame('8f19c2ecf1d1429594c4b8b7b04d4be9', SentrySdk::captureException($exception));
+    }
+
+    public function testCaptureEvent(): void
+    {
+        $this->assertNull(SentrySdk::captureEvent([]));
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with(['foo' => 'bar'])
+            ->willReturn('57f29461c03640228bc996970dbef8f1');
+
+        SentrySdk::bindClient($client);
+
+        $this->assertSame('57f29461c03640228bc996970dbef8f1', SentrySdk::captureEvent(['foo' => 'bar']));
+    }
+
+    public function testCaptureLastError(): void
+    {
+        $this->assertNull(SentrySdk::captureLastError());
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureLastError')
+            ->willReturn('902d6cfece4c49c7992bf6bfba1e9d2d');
+
+        SentrySdk::bindClient($client);
+
+        $this->assertSame('902d6cfece4c49c7992bf6bfba1e9d2d', SentrySdk::captureLastError());
+    }
+
+    public function testAddBreadcrumb(): void
+    {
+        $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_DEBUG, Breadcrumb::TYPE_DEFAULT, 'user_error');
+
+        $this->assertFalse(SentrySdk::addBreadcrumb($breadcrumb));
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getOptions')
+            ->willReturn(new Options());
+
+        SentrySdk::bindClient($client);
+
+        $this->assertTrue(SentrySdk::addBreadcrumb($breadcrumb));
+    }
+
+    public function testGetIntegration(): void
+    {
+        /** @var IntegrationInterface&MockObject $integration */
+        $integration = $this->createMock(IntegrationInterface::class);
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->with('Foo\\Bar')
+            ->willReturn($integration);
+
+        SentrySdk::bindClient($client);
+
+        $this->assertSame($integration, SentrySdk::getIntegration('Foo\\Bar'));
+    }
+}

--- a/tests/Spool/MemorySpoolTest.php
+++ b/tests/Spool/MemorySpoolTest.php
@@ -15,18 +15,11 @@ final class MemorySpoolTest extends TestCase
     /**
      * @var MemorySpool
      */
-    protected $spool;
+    private $spool;
 
     protected function setUp(): void
     {
         $this->spool = new MemorySpool();
-    }
-
-    public function testQueueEvent(): void
-    {
-        $this->assertAttributeEmpty('events', $this->spool);
-        $this->assertTrue($this->spool->queueEvent(new Event()));
-        $this->assertAttributeNotEmpty('events', $this->spool);
     }
 
     public function testFlushQueue(): void
@@ -38,23 +31,12 @@ final class MemorySpoolTest extends TestCase
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->exactly(2))
             ->method('send')
-            ->withConsecutive($event1, $event2);
+            ->withConsecutive([$event2], [$event1]);
 
         $this->spool->queueEvent($event1);
         $this->spool->queueEvent($event2);
 
         $this->spool->flushQueue($transport);
-
-        $this->assertAttributeEmpty('events', $this->spool);
-    }
-
-    public function testFlushQueueWithEmptyQueue(): void
-    {
-        /** @var TransportInterface|MockObject $transport */
-        $transport = $this->createMock(TransportInterface::class);
-        $transport->expects($this->never())
-            ->method('send');
-
         $this->spool->flushQueue($transport);
     }
 }

--- a/tests/phpt/error_handler_captures_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_fatal_error.phpt
@@ -34,7 +34,7 @@ $client = ClientBuilder::create([])
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
 $errorHandler = ErrorHandler::registerOnceErrorHandler();
 $errorHandler->addErrorHandlerListener(static function (): void {

--- a/tests/phpt/error_handler_captures_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_fatal_error.phpt
@@ -10,8 +10,8 @@ namespace Sentry\Tests;
 use Sentry\ClientBuilder;
 use Sentry\ErrorHandler;
 use Sentry\Event;
-use Sentry\State\Hub;
-use Sentry\Transport\TransportInterface;
+use Sentry\SentrySdk;
+use Sentry\Transport\TransportInterface;;
 
 $vendor = __DIR__;
 
@@ -34,7 +34,7 @@ $client = ClientBuilder::create([])
     ->setTransport($transport)
     ->getClient();
 
-Hub::getCurrent()->bindClient($client);
+SentrySdk::bindClient($client);
 
 $errorHandler = ErrorHandler::registerOnceErrorHandler();
 $errorHandler->addErrorHandlerListener(static function (): void {

--- a/tests/phpt/error_handler_captures_rethrown_exception_once.phpt
+++ b/tests/phpt/error_handler_captures_rethrown_exception_once.phpt
@@ -39,7 +39,7 @@ $client = ClientBuilder::create([])
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
 throw new \Exception('foo bar');
 ?>

--- a/tests/phpt/error_handler_captures_rethrown_exception_once.phpt
+++ b/tests/phpt/error_handler_captures_rethrown_exception_once.phpt
@@ -9,7 +9,7 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -39,7 +39,7 @@ $client = ClientBuilder::create([])
     ->setTransport($transport)
     ->getClient();
 
-Hub::getCurrent()->bindClient($client);
+SentrySdk::bindClient($client);
 
 throw new \Exception('foo bar');
 ?>

--- a/tests/phpt/error_handler_respects_error_reporting.phpt
+++ b/tests/phpt/error_handler_respects_error_reporting.phpt
@@ -33,7 +33,7 @@ $client = ClientBuilder::create(['capture_silenced_errors' => true])
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
 echo 'Triggering silenced error' . PHP_EOL;
 

--- a/tests/phpt/error_handler_respects_error_reporting.phpt
+++ b/tests/phpt/error_handler_respects_error_reporting.phpt
@@ -9,7 +9,7 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -33,7 +33,7 @@ $client = ClientBuilder::create(['capture_silenced_errors' => true])
     ->setTransport($transport)
     ->getClient();
 
-Hub::getCurrent()->bindClient($client);
+SentrySdk::bindClient($client);
 
 echo 'Triggering silenced error' . PHP_EOL;
 

--- a/tests/phpt/error_listener_integration_respects_error_types_option.phpt
+++ b/tests/phpt/error_listener_integration_respects_error_types_option.phpt
@@ -42,7 +42,7 @@ $client = (new ClientBuilder($options))
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
 trigger_error('Error thrown', E_USER_NOTICE);
 trigger_error('Error thrown', E_USER_WARNING);

--- a/tests/phpt/error_listener_integration_respects_error_types_option.phpt
+++ b/tests/phpt/error_listener_integration_respects_error_types_option.phpt
@@ -11,7 +11,7 @@ use Sentry\ClientBuilder;
 use Sentry\Event;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Options;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -42,7 +42,7 @@ $client = (new ClientBuilder($options))
     ->setTransport($transport)
     ->getClient();
 
-Hub::getCurrent()->bindClient($client);
+SentrySdk::bindClient($client);
 
 trigger_error('Error thrown', E_USER_NOTICE);
 trigger_error('Error thrown', E_USER_WARNING);

--- a/tests/phpt/error_listener_integration_skips_fatal_errors_if_configured.phpt
+++ b/tests/phpt/error_listener_integration_skips_fatal_errors_if_configured.phpt
@@ -11,7 +11,7 @@ use Sentry\ClientBuilder;
 use Sentry\Event;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Options;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -41,7 +41,7 @@ $client = (new ClientBuilder($options))
     ->setTransport($transport)
     ->getClient();
 
-Hub::getCurrent()->bindClient($client);
+SentrySdk::bindClient($client);
 
 class FooClass implements \Serializable
 {

--- a/tests/phpt/error_listener_integration_skips_fatal_errors_if_configured.phpt
+++ b/tests/phpt/error_listener_integration_skips_fatal_errors_if_configured.phpt
@@ -41,7 +41,7 @@ $client = (new ClientBuilder($options))
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
 class FooClass implements \Serializable
 {

--- a/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
+++ b/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
@@ -11,7 +11,7 @@ use Sentry\ClientBuilder;
 use Sentry\Event;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Options;
-use Sentry\State\Hub;
+use Sentry\SentrySdk;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -41,7 +41,7 @@ $client = (new ClientBuilder($options))
     ->setTransport($transport)
     ->getClient();
 
-Hub::getCurrent()->bindClient($client);
+SentrySdk::bindClient($client);
 
 class FooClass implements \Serializable
 {

--- a/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
+++ b/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
@@ -41,7 +41,7 @@ $client = (new ClientBuilder($options))
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
 class FooClass implements \Serializable
 {

--- a/tests/phpt/spool_drain.phpt
+++ b/tests/phpt/spool_drain.phpt
@@ -30,9 +30,9 @@ $client = ClientBuilder::create()
     ->setTransport($transport)
     ->getClient();
 
-SentrySdk::bindClient($client);
+SentrySdk::getCurrentHub()->bindClient($client);
 
-register_shutdown_function('register_shutdown_function', function () use ($spool, $nullTransport) {
+register_shutdown_function('register_shutdown_function', static function () use ($spool, $nullTransport): void {
     Assert::assertAttributeCount(1, 'events', $spool);
 
     $spool->flushQueue($nullTransport);

--- a/tests/phpt/spool_drain.phpt
+++ b/tests/phpt/spool_drain.phpt
@@ -8,11 +8,11 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use PHPUnit\Framework\Assert;
+use Sentry\SentrySdk;
 use Sentry\Spool\MemorySpool;
 use Sentry\Transport\SpoolTransport;
 use Sentry\Transport\NullTransport;
 use Sentry\ClientBuilder;
-use Sentry\State\Hub;
 
 $vendor = __DIR__;
 
@@ -26,9 +26,11 @@ $spool = new MemorySpool();
 $transport = new SpoolTransport($spool);
 $nullTransport = new NullTransport();
 
-$builder = ClientBuilder::create()->setTransport($transport);
+$client = ClientBuilder::create()
+    ->setTransport($transport)
+    ->getClient();
 
-Hub::getCurrent()->bindClient($builder->getClient());
+SentrySdk::bindClient($client);
 
 register_shutdown_function('register_shutdown_function', function () use ($spool, $nullTransport) {
     Assert::assertAttributeCount(1, 'events', $spool);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2 (develop)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

As discussed in #845, putting the `getCurrentHub` and `setCurrentHub` on the `HubInterface` was an error. ~Based on what has been done in other SDKs (I used Python and JS as reference) I decided to deprecate them and move the handling of the current hub in a `HubManager` class that can be used as a service in a proper DI-based environment or through the global functions for those that prefers to use them. PR is not ready yet, but I would like an opinion on a few implementation details. In particular, I'm undecided on how the global function `getHubManager` should be written. The main thing I would like to support is the retrieval of the instance from a service container, so I had to pass a callback around that will be used as a sort of factory method to instantiate the singleton variable the first time it's accessed. Another thing I had to solve is that since we (especially in an application based on a framework) cannot be sure that the function won't be accessed before the service container is built and initialized I needed a way to force replacing the instance even if it was already set. I don't really like this because of all the bad things that could occur when replacing an instance when you shouldn't, but I couldn't came up with a better solution.~ Any idea, comment or feedback is greatly appreciated.