### PR TITLE
Add functions to clear breadcrumbs and bulk set tags and extras in the scope

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,6 +13,7 @@ return PhpCsFixer\Config::create()
         'psr4' => true,
         'random_api_migration' => true,
         'yoda_style' => true,
+        'self_accessor' => false,
         'phpdoc_no_useless_inheritdoc' => false,
         'phpdoc_align' => [
             'tags' => ['param', 'return', 'throws', 'type', 'var'],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
 - Changed type hint for both parameter and return value of `HubInterface::getCurrentHub` and `HubInterface::setCurrentHub()` methods (#849)
+- Add the `setTags`, `setExtras` and `clearBreadcrumbs` methods to the `Scope` class (#852)
 
 ## 2.1.1 (2019-06-13)
 
@@ -26,6 +27,7 @@
 - Add a Monolog handler (#808)
 - Allow capturing the body of an HTTP request (#807)
 - Capture exceptions during serialization, to avoid hard failures (#818)
+- Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (786)
 
 ## 2.0.1 (2019-03-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 - Add a Monolog handler (#808)
 - Allow capturing the body of an HTTP request (#807)
 - Capture exceptions during serialization, to avoid hard failures (#818)
-- Mark Sentry internal frames when using `attach_stacktrace` as `in_app` `false` (786)
 
 ## 2.0.1 (2019-03-01)
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -227,6 +227,7 @@ final class Hub implements HubInterface
     public function getIntegration(string $className): ?IntegrationInterface
     {
         $client = $this->getClient();
+
         if (null !== $client) {
             return $client->getIntegration($className);
         }

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -99,18 +99,6 @@ final class Scope
     }
 
     /**
-     * Gets the tags contained in the tags context.
-     *
-     * @return array<string, string>
-     *
-     * @internal
-     */
-    public function getTags(): array
-    {
-        return $this->tags->toArray();
-    }
-
-    /**
      * Sets a new information in the extra context.
      *
      * @param string $key   The key that uniquely identifies the information
@@ -140,18 +128,6 @@ final class Scope
     }
 
     /**
-     * Gets the information contained in the extra context.
-     *
-     * @return array<string, mixed>
-     *
-     * @internal
-     */
-    public function getExtra(): array
-    {
-        return $this->extra->toArray();
-    }
-
-    /**
      * Sets the given data in the user context.
      *
      * @param array $data The data
@@ -163,18 +139,6 @@ final class Scope
         $this->user->replaceData($data);
 
         return $this;
-    }
-
-    /**
-     * Gets the information contained in the user context.
-     *
-     * @return array<string, mixed>
-     *
-     * @internal
-     */
-    public function getUser(): array
-    {
-        return $this->user->toArray();
     }
 
     /**
@@ -192,18 +156,6 @@ final class Scope
     }
 
     /**
-     * Gets the list of strings used to dictate the deduplication of this event.
-     *
-     * @return string[]
-     *
-     * @internal
-     */
-    public function getFingerprint(): array
-    {
-        return $this->fingerprint;
-    }
-
-    /**
      * Sets the severity to apply to all events captured in this scope.
      *
      * @param Severity|null $level The severity
@@ -215,18 +167,6 @@ final class Scope
         $this->level = $level;
 
         return $this;
-    }
-
-    /**
-     * Gets the severity to apply to all events captured in this scope.
-     *
-     * @return Severity|null
-     *
-     * @internal
-     */
-    public function getLevel(): ?Severity
-    {
-        return $this->level;
     }
 
     /**
@@ -243,18 +183,6 @@ final class Scope
         $this->breadcrumbs = \array_slice($this->breadcrumbs, -$maxBreadcrumbs);
 
         return $this;
-    }
-
-    /**
-     * Gets the breadcrumbs.
-     *
-     * @return Breadcrumb[]
-     *
-     * @internal
-     */
-    public function getBreadcrumbs(): array
-    {
-        return $this->breadcrumbs;
     }
 
     /**

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -85,6 +85,20 @@ final class Scope
     }
 
     /**
+     * Merges the given tags into the current tags context.
+     *
+     * @param array<string, string> $tags The tags to merge into the current context
+     *
+     * @return $this
+     */
+    public function setTags(array $tags): self
+    {
+        $this->tags->merge($tags);
+
+        return $this;
+    }
+
+    /**
      * Gets the tags contained in the tags context.
      *
      * @return array<string, string>
@@ -107,6 +121,20 @@ final class Scope
     public function setExtra(string $key, $value): self
     {
         $this->extra[$key] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Merges the given data into the current extras context.
+     *
+     * @param array<string, mixed> $extras Data to merge into the current context
+     *
+     * @return $this
+     */
+    public function setExtras(array $extras): self
+    {
+        $this->extra->merge($extras);
 
         return $this;
     }
@@ -227,6 +255,18 @@ final class Scope
     public function getBreadcrumbs(): array
     {
         return $this->breadcrumbs;
+    }
+
+    /**
+     * Clears all the breadcrumbs.
+     *
+     * @return $this
+     */
+    public function clearBreadcrumbs(): self
+    {
+        $this->breadcrumbs = [];
+
+        return $this;
     }
 
     /**

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -8,6 +8,7 @@ use Monolog\Logger;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
+use Sentry\Event;
 use Sentry\Monolog\Handler;
 use Sentry\Severity;
 use Sentry\State\Hub;
@@ -16,35 +17,27 @@ use Sentry\State\Scope;
 final class HandlerTest extends TestCase
 {
     /**
-     * @var MockObject|ClientInterface
-     */
-    private $client;
-
-    protected function setUp(): void
-    {
-        $this->client = $this->createMock(ClientInterface::class);
-    }
-
-    /**
      * @dataProvider handleDataProvider
      */
     public function testHandle(array $record, array $expectedPayload, array $expectedExtra, array $expectedTags): void
     {
-        $this->client->expects($this->once())
-            ->method('captureEvent')
-            ->with($expectedPayload, $this->callback(static function (Scope $scope) use ($expectedExtra, $expectedTags): bool {
-                if ($expectedExtra !== $scope->getExtra()) {
-                    return false;
-                }
+        $scope = new Scope();
 
-                if ($expectedTags !== $scope->getTags()) {
-                    return false;
-                }
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with($expectedPayload, $this->callback(function (Scope $scopeArg) use ($expectedExtra, $expectedTags): bool {
+                $event = $scopeArg->applyToEvent(new Event(), []);
+
+                $this->assertNotNull($event);
+                $this->assertSame($expectedExtra, $event->getExtraContext()->toArray());
+                $this->assertSame($expectedTags, $event->getTagsContext()->toArray());
 
                 return true;
             }));
 
-        $handler = new Handler(new Hub($this->client));
+        $handler = new Handler(new Hub($client, $scope));
         $handler->handle($record);
     }
 
@@ -313,7 +306,7 @@ final class HandlerTest extends TestCase
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::INFO),
-                '1' => 'numeric key',
+                '0' => 'numeric key',
             ],
             [],
         ];
@@ -332,6 +325,7 @@ final class HandlerTest extends TestCase
             [
                 'level' => Severity::debug(),
                 'message' => 'foo bar',
+                'logger' => 'monolog.channel.foo',
                 'transaction' => 'Foo transaction',
             ],
             [

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -15,88 +15,127 @@ final class ScopeTest extends TestCase
     public function testSetTag(): void
     {
         $scope = new Scope();
+        $event = $scope->applyToEvent(new Event(), []);
 
-        $this->assertEquals([], $scope->getTags());
+        $this->assertNotNull($event);
+        $this->assertTrue($event->getTagsContext()->isEmpty());
 
         $scope->setTag('foo', 'bar');
         $scope->setTag('bar', 'baz');
 
-        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $scope->getTags());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
     }
 
     public function setTags(): void
     {
         $scope = new Scope();
-
         $scope->setTags(['foo' => 'bar']);
 
-        $this->assertEquals(['foo' => 'bar'], $scope->getTags());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar'], $event->getTagsContext()->toArray());
 
         $scope->setTags(['bar' => 'baz']);
 
-        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $scope->getTags());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
     }
 
     public function testSetExtra(): void
     {
         $scope = new Scope();
+        $event = $scope->applyToEvent(new Event(), []);
 
-        $this->assertEquals([], $scope->getExtra());
+        $this->assertNotNull($event);
+        $this->assertTrue($event->getExtraContext()->isEmpty());
 
         $scope->setExtra('foo', 'bar');
         $scope->setExtra('bar', 'baz');
 
-        $this->assertEquals(['foo' => 'bar', 'bar' => 'baz'], $scope->getExtra());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtraContext()->toArray());
     }
 
     public function setExtras(): void
     {
         $scope = new Scope();
-
         $scope->setExtras(['foo' => 'bar']);
 
-        $this->assertEquals(['foo' => 'bar'], $scope->getExtra());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar'], $event->getExtraContext()->toArray());
 
         $scope->setExtras(['bar' => 'baz']);
 
-        $this->assertEquals(['bar' => 'baz'], $scope->getExtra());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtraContext()->toArray());
     }
 
     public function testSetUser(): void
     {
         $scope = new Scope();
 
-        $this->assertEquals([], $scope->getUser());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame([], $event->getUserContext()->toArray());
 
         $scope->setUser(['foo' => 'bar']);
 
-        $this->assertEquals(['foo' => 'bar'], $scope->getUser());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar'], $event->getUserContext()->toArray());
 
         $scope->setUser(['bar' => 'baz']);
 
-        $this->assertEquals(['bar' => 'baz'], $scope->getUser());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['bar' => 'baz'], $event->getUserContext()->toArray());
     }
 
     public function testSetFingerprint(): void
     {
         $scope = new Scope();
+        $event = $scope->applyToEvent(new Event(), []);
 
-        $this->assertEmpty($scope->getFingerprint());
+        $this->assertNotNull($event);
+        $this->assertEmpty($event->getFingerprint());
 
         $scope->setFingerprint(['foo', 'bar']);
 
-        $this->assertEquals(['foo', 'bar'], $scope->getFingerprint());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo', 'bar'], $event->getFingerprint());
     }
 
     public function testSetLevel(): void
     {
         $scope = new Scope();
+        $event = $scope->applyToEvent(new Event(), []);
 
-        $this->assertNull($scope->getLevel());
+        $this->assertNotNull($event);
+        $this->assertEquals(Severity::error(), $event->getLevel());
 
         $scope->setLevel(Severity::debug());
 
-        $this->assertEquals(Breadcrumb::LEVEL_DEBUG, $scope->getLevel());
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertEquals(Severity::debug(), $event->getLevel());
     }
 
     public function testAddBreadcrumb(): void

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -64,7 +64,7 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtraContext()->toArray());
     }
 
-    public function setExtras(): void
+    public function testSetExtras(): void
     {
         $scope = new Scope();
         $scope->setExtras(['foo' => 'bar']);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2 (develop)
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This closes #797 by implementing the `setTags`, `setExtras` and `clearBreadcrumbs` methods on the `Scope` class. I also refactored the tests to stop relying on reflection to access the active scope of an hub. I wonder if it makes sense to deprecate all the getters on the scope as the other SDKs do not implement them