### PR TITLE
Revert extracting the transaction name from structured log data in Monolog handler

### DIFF
--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -54,10 +54,6 @@ final class Handler extends AbstractProcessingHandler
             $payload['exception'] = $record['context']['exception'];
         }
 
-        if (isset($record['extra']['transaction'])) {
-            $payload['transaction'] = $record['extra']['transaction'];
-        }
-
         $this->hub->withScope(function (Scope $scope) use ($record, $payload): void {
             $scope->setExtra('monolog.channel', $record['channel']);
             $scope->setExtra('monolog.level', $record['level_name']);

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -310,29 +310,5 @@ final class HandlerTest extends TestCase
             ],
             [],
         ];
-
-        yield [
-            [
-                'message' => 'foo bar',
-                'level' => Logger::DEBUG,
-                'level_name' => Logger::getLevelName(Logger::DEBUG),
-                'channel' => 'channel.foo',
-                'context' => [],
-                'extra' => [
-                    'transaction' => 'Foo transaction',
-                ],
-            ],
-            [
-                'level' => Severity::debug(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-                'transaction' => 'Foo transaction',
-            ],
-            [
-                'monolog.channel' => 'channel.foo',
-                'monolog.level' => Logger::getLevelName(Logger::DEBUG),
-            ],
-            [],
-        ];
     }
 }


### PR DESCRIPTION
This PR reverts #843 after the decision of not wanting to support extracting information from structured log data due to the following reasons:

- some key names (e.g. `transaction`) are too generic and may not represent the same concept intended by Sentry
- blindly setting anything from the structured log data into the event payload is not a good move as the data could be really big or it may contain unwanted things

/cc @JanMikes