### PR TITLE
Fix sending of GZIP-compressed requests when the enable_compression option is on

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,7 +32,6 @@ cache:
 
 init:
     - SET PATH=c:\php\%PHP_VERSION%;%PATH%
-    - SET SYMFONY_DEPRECATIONS_HELPER=strict
     - SET ANSICON=121x90 (121x90)
     - SET INSTALL_PHP=1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
+- Fix sending of GZIP-compressed requests when the `enable_compression` option is `true` (#857)
 
 ## 2.1.1 (2019-06-13)
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "phpstan/phpstan-phpunit": "^0.10",
         "phpstan/phpstan": "^0.10.3",
         "phpunit/phpunit": "^7.0",
-        "symfony/phpunit-bridge": "^4.1.6"
+        "symfony/phpunit-bridge": "^4.3"
     },
     "conflict": {
         "php-http/client-common": "1.8.0",

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -22,6 +22,7 @@ use Http\Message\MessageFactory;
 use Http\Message\UriFactory;
 use Jean85\PrettyVersions;
 use Sentry\HttpClient\Authentication\SentryAuthentication;
+use Sentry\HttpClient\Plugin\GzipEncoderPlugin;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
@@ -291,12 +292,14 @@ final class ClientBuilder implements ClientBuilderInterface
 
         $this->addHttpClientPlugin(new HeaderSetPlugin(['User-Agent' => $this->sdkIdentifier . '/' . $this->getSdkVersion()]));
         $this->addHttpClientPlugin(new AuthenticationPlugin(new SentryAuthentication($this->options, $this->sdkIdentifier, $this->getSdkVersion())));
-        $this->addHttpClientPlugin(new RetryPlugin(['retries' => $this->options->getSendAttempts()]));
-        $this->addHttpClientPlugin(new ErrorPlugin());
 
         if ($this->options->isCompressionEnabled()) {
+            $this->addHttpClientPlugin(new GzipEncoderPlugin());
             $this->addHttpClientPlugin(new DecoderPlugin());
         }
+
+        $this->addHttpClientPlugin(new RetryPlugin(['retries' => $this->options->getSendAttempts()]));
+        $this->addHttpClientPlugin(new ErrorPlugin());
 
         return new PluginClient($this->httpClient, $this->httpClientPlugins);
     }

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\HttpClient\Plugin;
+
+use Http\Client\Common\Plugin as PluginInterface;
+use Http\Message\Encoding\GzipEncodeStream;
+use Http\Promise\Promise as PromiseInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * This plugin encodes the request body by compressing it with Gzip.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class GzipEncoderPlugin implements PluginInterface
+{
+    /**
+     * Constructor.
+     *
+     * @throws \RuntimeException If the zlib extension is not enabled
+     */
+    public function __construct()
+    {
+        if (!\extension_loaded('zlib')) {
+            throw new \RuntimeException('The "zlib" extension must be enabled to use this plugin.');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first): PromiseInterface
+    {
+        $requestBody = $request->getBody();
+
+        if ($requestBody->isSeekable()) {
+            $requestBody->rewind();
+        }
+
+        $request = $request->withHeader('Content-Encoding', 'gzip');
+        $request = $request->withBody(new GzipEncodeStream($requestBody));
+
+        return $next($request);
+    }
+}

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\HttpClient\Plugin;
+
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Promise\Promise as PromiseInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Sentry\HttpClient\Plugin\GzipEncoderPlugin;
+
+final class GzipEncoderPluginTest extends TestCase
+{
+    /**
+     * @requires extension zlib
+     */
+    public function testHandleRequest(): void
+    {
+        $plugin = new GzipEncoderPlugin();
+        $nextCallableCalled = false;
+        $expectedPromise = $this->createMock(PromiseInterface::class);
+        $request = MessageFactoryDiscovery::find()->createRequest(
+            'POST',
+            'http://www.local.host',
+            [],
+            'foo'
+        );
+
+        $this->assertSame('foo', (string) $request->getBody());
+        $this->assertSame(
+            $expectedPromise,
+            $plugin->handleRequest(
+                $request,
+                function (RequestInterface $requestArg) use (&$nextCallableCalled, $expectedPromise): PromiseInterface {
+                    $nextCallableCalled = true;
+
+                    $this->assertSame('gzip', $requestArg->getHeaderLine('Content-Encoding'));
+                    $this->assertSame(gzcompress('foo', -1, ZLIB_ENCODING_GZIP), (string) $requestArg->getBody());
+
+                    return $expectedPromise;
+                },
+                static function () {}
+            )
+        );
+
+        $this->assertTrue($nextCallableCalled);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

When the `enable_compression` option was enabled it was affecting only the responses received by the server while first of all the requests should be compressed with GZIP. This PR fixes the problem. Note that if Sentry is running in uWSGI mode and behind a NGINX server as described in the [documentation](https://docs.sentry.io/server/performance/#performance-web-server) and the client sends a chunked request (as in our case) then a bug in the latter makes the proxied request have both the `Transfer-Encoding` and `Content-Length` headers set, which per HTTP/1.1 specs is not valid. For this reason Sentry will be unable to read the request content and will silently discard the event logging an error. The solution is to unset the `Transfer-Encoding` header in the NGINX config.

```nginx
server {
  ...

  location / {
    include uwsgi_params;
    
    uwsgi_param HTTP_TRANSFER_ENCODING "";

    ...
  }
}
```

ping @HazAT can you please update the docs with the note about NGINX + uWSGI?