### PR TITLE
Allow numeric value in tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
 - Changed type hint for both parameter and return value of `HubInterface::getCurrentHub` and `HubInterface::setCurrentHub()` methods (#849)
 - Add the `setTags`, `setExtras` and `clearBreadcrumbs` methods to the `Scope` class (#852)
+- Silently cast numeric values to strings when trying to set the tags instead of throwing (#858)
 
 ## 2.1.1 (2019-06-13)
 

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -65,9 +65,10 @@ class Context implements \ArrayAccess, \JsonSerializable, \IteratorAggregate
     }
 
     /**
-     * Sets the given data into this object.
+     * Sets each element of the array to the value of the corresponding key in
+     * the given input data.
      *
-     * @param array $data
+     * @param array $data The data to set
      */
     public function setData(array $data): void
     {

--- a/src/Context/TagsContext.php
+++ b/src/Context/TagsContext.php
@@ -21,13 +21,7 @@ class TagsContext extends Context
             throw new \InvalidArgumentException('The tags context does not allow recursive merging of its data.');
         }
 
-        foreach ($data as $value) {
-            if (!\is_string($value)) {
-                throw new \InvalidArgumentException('The $data argument must contains a simple array of string values.');
-            }
-        }
-
-        parent::merge($data);
+        parent::merge(self::sanitizeData($data));
     }
 
     /**
@@ -35,13 +29,7 @@ class TagsContext extends Context
      */
     public function setData(array $data): void
     {
-        foreach ($data as $value) {
-            if (!\is_string($value)) {
-                throw new \InvalidArgumentException('The $data argument must contains a simple array of string values.');
-            }
-        }
-
-        parent::setData($data);
+        parent::setData(self::sanitizeData($data));
     }
 
     /**
@@ -49,13 +37,7 @@ class TagsContext extends Context
      */
     public function replaceData(array $data): void
     {
-        foreach ($data as $value) {
-            if (!\is_string($value)) {
-                throw new \InvalidArgumentException('The $data argument must contains a simple array of string values.');
-            }
-        }
-
-        parent::replaceData($data);
+        parent::replaceData(self::sanitizeData($data));
     }
 
     /**
@@ -63,10 +45,38 @@ class TagsContext extends Context
      */
     public function offsetSet($offset, $value): void
     {
+        if (is_numeric($value)) {
+            $value = (string) $value;
+        }
+
         if (!\is_string($value)) {
             throw new \InvalidArgumentException('The $value argument must be a string.');
         }
 
         parent::offsetSet($offset, $value);
+    }
+
+    /**
+     * Convert numeric values to string, throw exception if item in $data array is not string or number.
+     *
+     * @param array $data
+     *
+     * @return array
+     *
+     * @throws \InvalidArgumentException
+     */
+    private static function sanitizeData(array $data): array
+    {
+        foreach ($data as &$value) {
+            if (is_numeric($value)) {
+                $value = (string) $value;
+            }
+
+            if (!\is_string($value)) {
+                throw new \InvalidArgumentException('The $data argument must contains a simple array of string values.');
+            }
+        }
+
+        return $data;
     }
 }

--- a/src/Context/TagsContext.php
+++ b/src/Context/TagsContext.php
@@ -57,13 +57,14 @@ class TagsContext extends Context
     }
 
     /**
-     * Convert numeric values to string, throw exception if item in $data array is not string or number.
+     * Sanitizes the given data by converting numeric values to strings.
      *
-     * @param array $data
+     * @param array $data The data to sanitize
      *
      * @return array
      *
-     * @throws \InvalidArgumentException
+     * @throws \InvalidArgumentException If any of the values of the input data
+     *                                   is not a number or a string
      */
     private static function sanitizeData(array $data): array
     {

--- a/tests/Context/TagsContextTest.php
+++ b/tests/Context/TagsContextTest.php
@@ -29,9 +29,9 @@ class TagsContextTest extends TestCase
     {
         return [
             [
-                ['foo' => 'baz', 'baz' => 'foo'],
+                ['foo' => 'baz', 'baz' => 'foo', 'int' => 1, 'float' => 1.1],
                 false,
-                ['foo' => 'baz', 'bar' => 'foo', 'baz' => 'foo'],
+                ['foo' => 'baz', 'bar' => 'foo', 'baz' => 'foo', 'int' => '1', 'float' => '1.1'],
                 null,
             ],
             [


### PR DESCRIPTION
It's a very common scene that we use a numeric value as a tag, e.g. user id. 

Developers are not always aware that should pass a real string value to Sentry's TagsContext, and  InvalidArgumentException thrown in Sentry may not be caught by framework's exception handler because Sentry is called in the exception handler in most cases, thus no error logs in framework nor reports in Sentry, which makes it hard to track error.