### PR TITLE
Skip integrations not bound to the current client and fetch their options from it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
 - Fix sending of GZIP-compressed requests when the `enable_compression` option is `true` (#857)
 - Fix error thrown when trying to set the `transaction` attribute of the event in a CLI environment (#862)
+- Fix integrations that were not skipped if the client binded to the current hub was not using them (#861)
 
 ## 2.1.1 (2019-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
 - Fix sending of GZIP-compressed requests when the `enable_compression` option is `true` (#857)
 - Fix error thrown when trying to set the `transaction` attribute of the event in a CLI environment (#862)
-- Fix integrations that were not skipped if the client binded to the current hub was not using them (#861)
+- Fix integrations that were not skipped if the client bound to the current hub was not using them (#861)
 
 ## 2.1.1 (2019-06-13)
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -104,9 +104,9 @@ final class ClientBuilder implements ClientBuilderInterface
         if ($this->options->hasDefaultIntegrations()) {
             $this->options->setIntegrations(array_merge([
                 new ExceptionListenerIntegration(),
-                new ErrorListenerIntegration($this->options, false),
-                new FatalErrorListenerIntegration($this->options),
-                new RequestIntegration($this->options),
+                new ErrorListenerIntegration(null, false),
+                new FatalErrorListenerIntegration(),
+                new RequestIntegration(),
             ], $this->options->getIntegrations()));
         }
     }

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -61,7 +61,7 @@ final class ErrorListenerIntegration implements IntegrationInterface
             $integration = $currentHub->getIntegration(self::class);
             $client = $currentHub->getClient();
 
-            // The client binded to the current hub, if any, could not have this
+            // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
             if (null === $integration || null === $client) {
                 return;

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -58,19 +58,12 @@ final class ErrorListenerIntegration implements IntegrationInterface
             }
 
             $currentHub = Hub::getCurrent();
+            $integration = $currentHub->getIntegration(self::class);
             $client = $currentHub->getClient();
 
-            // The client could have been detached from the hub. If this is the
-            // case this integration should not run
-            if (null === $client) {
-                return;
-            }
-
-            $integration = $client->getIntegration(self::class);
-
-            // The integration could be binded to a client that is not the one
-            // attached to the current hub. If this is the case, bail out
-            if (null === $integration) {
+            // The client binded to the current hub, if any, could not have this
+            // integration enabled. If this is the case, bail out
+            if (null === $integration || null === $client) {
                 return;
             }
 

--- a/src/Integration/ExceptionListenerIntegration.php
+++ b/src/Integration/ExceptionListenerIntegration.php
@@ -23,7 +23,7 @@ final class ExceptionListenerIntegration implements IntegrationInterface
             $currentHub = Hub::getCurrent();
             $integration = $currentHub->getIntegration(self::class);
 
-            // The client binded to the current hub, if any, could not have this
+            // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
             if (null === $integration) {
                 return;

--- a/src/Integration/ExceptionListenerIntegration.php
+++ b/src/Integration/ExceptionListenerIntegration.php
@@ -23,8 +23,8 @@ final class ExceptionListenerIntegration implements IntegrationInterface
             $currentHub = Hub::getCurrent();
             $integration = $currentHub->getIntegration(self::class);
 
-            // The integration could be binded to a client that is not the one
-            // attached to the current hub. If this is the case, bail out
+            // The client binded to the current hub, if any, could not have this
+            // integration enabled. If this is the case, bail out
             if (null === $integration) {
                 return;
             }

--- a/src/Integration/ExceptionListenerIntegration.php
+++ b/src/Integration/ExceptionListenerIntegration.php
@@ -20,7 +20,16 @@ final class ExceptionListenerIntegration implements IntegrationInterface
     {
         $errorHandler = ErrorHandler::registerOnce(ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE, false);
         $errorHandler->addExceptionHandlerListener(static function (\Throwable $exception): void {
-            Hub::getCurrent()->captureException($exception);
+            $currentHub = Hub::getCurrent();
+            $integration = $currentHub->getIntegration(self::class);
+
+            // The integration could be binded to a client that is not the one
+            // attached to the current hub. If this is the case, bail out
+            if (null === $integration) {
+                return;
+            }
+
+            $currentHub->captureException($exception);
         });
     }
 }

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -43,19 +43,12 @@ final class FatalErrorListenerIntegration implements IntegrationInterface
         $errorHandler = ErrorHandler::registerOnceFatalErrorHandler();
         $errorHandler->addFatalErrorHandlerListener(function (FatalErrorException $exception): void {
             $currentHub = Hub::getCurrent();
+            $integration = $currentHub->getIntegration(self::class);
             $client = $currentHub->getClient();
 
-            // The client could have been detached from the hub. If this is the
-            // case this integration should not run
-            if (null === $client) {
-                return;
-            }
-
-            $integration = $client->getIntegration(self::class);
-
-            // The integration could be binded to a client that is not the one
-            // attached to the current hub. If this is the case, bail out
-            if (null === $integration) {
+            // The client binded to the current hub, if any, could not have this
+            // integration enabled. If this is the case, bail out
+            if (null === $integration || null === $client) {
                 return;
             }
 

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -46,7 +46,7 @@ final class FatalErrorListenerIntegration implements IntegrationInterface
             $integration = $currentHub->getIntegration(self::class);
             $client = $currentHub->getClient();
 
-            // The client binded to the current hub, if any, could not have this
+            // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
             if (null === $integration || null === $client) {
                 return;

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -29,7 +29,7 @@ final class ModulesIntegration implements IntegrationInterface
         Scope::addGlobalEventProcessor(function (Event $event) {
             $integration = Hub::getCurrent()->getIntegration(self::class);
 
-            // The integration could be binded to a client that is not the one
+            // The integration could be bound to a client that is not the one
             // attached to the current hub. If this is the case, bail out
             if ($integration instanceof self) {
                 self::applyToEvent($integration, $event);

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -27,10 +27,12 @@ final class ModulesIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event) {
-            $self = Hub::getCurrent()->getIntegration(self::class);
+            $integration = Hub::getCurrent()->getIntegration(self::class);
 
-            if ($self instanceof self) {
-                self::applyToEvent($self, $event);
+            // The integration could be binded to a client that is not the one
+            // attached to the current hub. If this is the case, bail out
+            if ($integration instanceof self) {
+                self::applyToEvent($integration, $event);
             }
 
             return $event;

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -61,19 +61,13 @@ final class RequestIntegration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event): Event {
-            $client = Hub::getCurrent()->getClient();
+            $currentHub = Hub::getCurrent();
+            $integration = $currentHub->getIntegration(self::class);
+            $client = $currentHub->getClient();
 
-            // The client could have been detached from the hub. If this is the
-            // case this integration should not run
-            if (null === $client) {
-                return $event;
-            }
-
-            $integration = $client->getIntegration(self::class);
-
-            // The integration could be binded to a client that is not the one
-            // attached to the current hub. If this is the case, bail out
-            if (!$integration instanceof self) {
+            // The client binded to the current hub, if any, could not have this
+            // integration enabled. If this is the case, bail out
+            if (null === $integration || null === $client) {
                 return $event;
             }
 
@@ -92,9 +86,7 @@ final class RequestIntegration implements IntegrationInterface
      */
     public static function applyToEvent(self $self, Event $event, ?ServerRequestInterface $request = null): void
     {
-        if (null !== $request) {
-            @trigger_error(sprintf('The "%s" method is deprecated since version 2.1 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
-        }
+        @trigger_error(sprintf('The "%s" method is deprecated since version 2.1 and will be removed in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
         if (null === $self->options) {
             throw new \BadMethodCallException('The options of the integration must be set.');

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -65,7 +65,7 @@ final class RequestIntegration implements IntegrationInterface
             $integration = $currentHub->getIntegration(self::class);
             $client = $currentHub->getClient();
 
-            // The client binded to the current hub, if any, could not have this
+            // The client bound to the current hub, if any, could not have this
             // integration enabled. If this is the case, bail out
             if (null === $integration || null === $client) {
                 return $event;

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -227,6 +227,7 @@ final class Hub implements HubInterface
     public function getIntegration(string $className): ?IntegrationInterface
     {
         $client = $this->getClient();
+
         if (null !== $client) {
             return $client->getIntegration($className);
         }

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -18,7 +18,21 @@ use Zend\Diactoros\Uri;
 final class RequestIntegrationTest extends TestCase
 {
     /**
+     * @group legacy
+     *
+     * @expectedDeprecation Passing the options as argument of the constructor of the "Sentry\Integration\RequestIntegration" class is deprecated since version 2.1 and will not work in 3.0.
+     */
+    public function testConstructorThrowsDeprecationIfPassingOptions(): void
+    {
+        new RequestIntegration(new Options([]));
+    }
+
+    /**
+     * @group legacy
+     *
      * @dataProvider applyToEventWithRequestHavingIpAddressDataProvider
+     *
+     * @expectedDeprecation The "Sentry\Integration\RequestIntegration::applyToEvent" method is deprecated since version 2.1 and will be removed in 3.0.
      */
     public function testInvokeWithRequestHavingIpAddress(bool $shouldSendPii, array $expectedValue): void
     {
@@ -26,9 +40,6 @@ final class RequestIntegrationTest extends TestCase
         $event->getUserContext()->setData(['foo' => 'bar']);
 
         $request = new ServerRequest(['REMOTE_ADDR' => '127.0.0.1']);
-
-        $this->assertInstanceOf(ServerRequestInterface::class, $request);
-
         $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
 
         RequestIntegration::applyToEvent($integration, $event, $request);
@@ -41,7 +52,10 @@ final class RequestIntegrationTest extends TestCase
         return [
             [
                 true,
-                ['ip_address' => '127.0.0.1', 'foo' => 'bar'],
+                [
+                    'ip_address' => '127.0.0.1',
+                    'foo' => 'bar',
+                ],
             ],
             [
                 false,
@@ -51,7 +65,11 @@ final class RequestIntegrationTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider applyToEventDataProvider
+     *
+     * @expectedDeprecation The "Sentry\Integration\RequestIntegration::applyToEvent" method is deprecated since version 2.1 and will be removed in 3.0.
      */
     public function testApplyToEvent(array $options, ServerRequestInterface $request, array $expectedResult): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

As noticed by @HazAT in #847, some integrations were executed even though the client binded to the current hub was not using them. I also changed how we pass the options to the integrations by stopping to use the constructor and fetching them from the client binded to the current hub so that we can avoid having a circular reference between the two