### PR TITLE
Do not set the transaction attribute of the event when in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).
 - Fix sending of GZIP-compressed requests when the `enable_compression` option is `true` (#857)
+- Fix error thrown when trying to set the `transaction` attribute of the event in a CLI environment (#862)
 
 ## 2.1.1 (2019-06-13)
 

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -7,7 +7,6 @@ namespace Sentry;
 use Sentry\Exception\EventCreationException;
 use Sentry\Serializer\RepresentationSerializerInterface;
 use Sentry\Serializer\SerializerInterface;
-use Zend\Diactoros\ServerRequestFactory;
 
 /**
  * Factory for the {@see Event} class.
@@ -93,13 +92,8 @@ final class EventFactory implements EventFactoryInterface
 
         if (isset($payload['transaction'])) {
             $event->setTransaction($payload['transaction']);
-        } else {
-            $request = ServerRequestFactory::fromGlobals();
-            $serverParams = $request->getServerParams();
-
-            if (isset($serverParams['PATH_INFO'])) {
-                $event->setTransaction($serverParams['PATH_INFO']);
-            }
+        } elseif (isset($_SERVER['PATH_INFO'])) {
+            $event->setTransaction($_SERVER['PATH_INFO']);
         }
 
         if (isset($payload['logger'])) {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -21,6 +21,9 @@ use Sentry\Transport\TransportInterface;
 
 class ClientTest extends TestCase
 {
+    /**
+     * @backupGlobals
+     */
     public function testTransactionEventAttributeIsPopulated(): void
     {
         $_SERVER['PATH_INFO'] = '/foo';
@@ -39,9 +42,6 @@ class ClientTest extends TestCase
 
         $client = new Client(new Options(), $transport, $this->createEventFactory());
         $client->captureMessage('test');
-
-        unset($_SERVER['PATH_INFO']);
-        unset($_SERVER['REQUEST_METHOD']);
     }
 
     public function testTransactionEventAttributeIsNotPopulatedInCli(): void

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -16,6 +16,9 @@ use Sentry\Stacktrace;
 
 class EventFactoryTest extends TestCase
 {
+    /**
+     * @backupGlobals
+     */
     public function testCreateEventWithDefaultValues(): void
     {
         $options = new Options();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.1
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

This PR fixes #862 by skipping setting the `transaction` attribute of the event when the `$_SERVER['PATH_INFO']` value is not available (e.g. in CLI).