### PR TITLE
Add an integration to set the transaction attribute of the event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Silently cast numeric values to strings when trying to set the tags instead of throwing (#858)
 - Support force sending events on-demand and fix sending of events in long-running processes (#813)
 - Update PHPStan and introduce Psalm (#846)
+- Add an integration to set the transaction attribute of the event (#865)
 
 ## 2.1.2 (2019-08-22)
 
@@ -19,7 +20,7 @@
 ## 2.1.1 (2019-06-13)
 
 - Fix the behavior of the `excluded_exceptions` option: now it's used to skip capture of exceptions, not to purge the
-`exception` data of the event, which resulted in broken or empty chains of exceptions in reported events (#822)
+  `exception` data of the event, which resulted in broken or empty chains of exceptions in reported events (#822)
 - Fix handling of uploaded files in the `RequestIntegration`, to respect the PSR-7 spec fully (#827)
 - Fix use of `REMOTE_ADDR` server variable rather than HTTP header
 - Fix exception, open_basedir restriction in effect (#824)

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^7.5",
         "symfony/phpunit-bridge": "^4.3",
         "vimeo/psalm": "^3.4"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
         - '/Argument of an invalid type object supplied for foreach, only iterables are supported/'
         - '/Binary operation "\*" between array and 2 results in an error\./'
         - '/Http\\Client\\Curl\\Client/'
+        - '/^Parameter #1 \$object of method ReflectionProperty::setValue\(\) expects object, null given\.$/' # https://github.com/phpstan/phpstan/pull/2340
         -
             message: /^Cannot assign offset 'os' to array\|string\.$/
             path: src/Event.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,8 @@
     <listeners>
         <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>
+
+    <extensions>
+        <extension class="Sentry\Tests\SentrySdkExtension" />
+    </extensions>
 </phpunit>

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -27,6 +27,7 @@ use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Integration\RequestIntegration;
+use Sentry\Integration\TransactionIntegration;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\RepresentationSerializerInterface;
 use Sentry\Serializer\Serializer;
@@ -108,6 +109,7 @@ final class ClientBuilder implements ClientBuilderInterface
                 new ErrorListenerIntegration(null, false),
                 new FatalErrorListenerIntegration(),
                 new RequestIntegration(),
+                new TransactionIntegration(),
             ], $this->options->getIntegrations()));
         }
     }

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -90,12 +90,6 @@ final class EventFactory implements EventFactoryInterface
         $event->getTagsContext()->merge($this->options->getTags());
         $event->setEnvironment($this->options->getEnvironment());
 
-        if (isset($payload['transaction'])) {
-            $event->setTransaction($payload['transaction']);
-        } elseif (isset($_SERVER['PATH_INFO'])) {
-            $event->setTransaction($_SERVER['PATH_INFO']);
-        }
-
         if (isset($payload['logger'])) {
             $event->setLogger($payload['logger']);
         }

--- a/src/Integration/TransactionIntegration.php
+++ b/src/Integration/TransactionIntegration.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Integration;
+
+use Sentry\Event;
+use Sentry\State\Hub;
+use Sentry\State\Scope;
+
+/**
+ * This integration sets the `transaction` attribute of the event to the value
+ * found in the raw event payload or to the value of the `PATH_INFO` server var
+ * if present.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class TransactionIntegration implements IntegrationInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setupOnce(): void
+    {
+        Scope::addGlobalEventProcessor(static function (Event $event, array $payload): Event {
+            $currentHub = Hub::getCurrent();
+            $integration = $currentHub->getIntegration(self::class);
+
+            // The client bound to the current hub, if any, could not have this
+            // integration enabled. If this is the case, bail out
+            if (null === $integration) {
+                return $event;
+            }
+
+            if (null !== $event->getTransaction()) {
+                return $event;
+            }
+
+            if (isset($payload['transaction'])) {
+                $event->setTransaction($payload['transaction']);
+            } elseif (isset($_SERVER['PATH_INFO'])) {
+                $event->setTransaction($_SERVER['PATH_INFO']);
+            }
+
+            return $event;
+        });
+    }
+}

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -24,6 +24,7 @@ use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\RequestIntegration;
+use Sentry\Integration\TransactionIntegration;
 use Sentry\Options;
 use Sentry\Transport\HttpTransport;
 use Sentry\Transport\NullTransport;
@@ -219,6 +220,7 @@ final class ClientBuilderTest extends TestCase
                     FatalErrorListenerIntegration::class,
                     ExceptionListenerIntegration::class,
                     RequestIntegration::class,
+                    TransactionIntegration::class,
                 ],
             ],
             [
@@ -229,6 +231,7 @@ final class ClientBuilderTest extends TestCase
                     FatalErrorListenerIntegration::class,
                     ExceptionListenerIntegration::class,
                     RequestIntegration::class,
+                    TransactionIntegration::class,
                     StubIntegration::class,
                 ],
             ],

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -8,7 +8,6 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Http\Mock\Client as MockClient;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sentry\Client;
 use Sentry\ClientBuilder;
 use Sentry\Event;
 use Sentry\EventFactory;
@@ -23,46 +22,6 @@ use Sentry\Transport\TransportInterface;
 
 class ClientTest extends TestCase
 {
-    /**
-     * @backupGlobals
-     */
-    public function testTransactionEventAttributeIsPopulated(): void
-    {
-        $_SERVER['PATH_INFO'] = '/foo';
-        $_SERVER['REQUEST_METHOD'] = 'GET';
-
-        /** @var TransportInterface|MockObject $transport */
-        $transport = $this->createMock(TransportInterface::class);
-
-        $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $this->assertEquals('/foo', $event->getTransaction());
-
-                return true;
-            }));
-
-        $client = new Client(new Options(), $transport, $this->createEventFactory());
-        $client->captureMessage('test');
-    }
-
-    public function testTransactionEventAttributeIsNotPopulatedInCli(): void
-    {
-        /** @var TransportInterface|MockObject $transport */
-        $transport = $this->createMock(TransportInterface::class);
-
-        $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $this->assertNull($event->getTransaction());
-
-                return true;
-            }));
-
-        $client = new Client(new Options(), $transport, $this->createEventFactory());
-        $client->captureMessage('test');
-    }
-
     public function testCaptureMessage(): void
     {
         /** @var TransportInterface|MockObject $transport */

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -27,8 +27,6 @@ class EventFactoryTest extends TestCase
         $options->setTags(['test' => 'tag']);
         $options->setEnvironment('testEnvironment');
 
-        $_SERVER['PATH_INFO'] = 'testPathInfo';
-
         $eventFactory = new EventFactory(
             $this->createMock(SerializerInterface::class),
             $this->createMock(RepresentationSerializerInterface::class),
@@ -45,7 +43,6 @@ class EventFactoryTest extends TestCase
         $this->assertSame($options->getRelease(), $event->getRelease());
         $this->assertSame($options->getTags(), $event->getTagsContext()->toArray());
         $this->assertSame($options->getEnvironment(), $event->getEnvironment());
-        $this->assertSame('testPathInfo', $event->getTransaction());
         $this->assertNull($event->getStacktrace());
     }
 
@@ -70,10 +67,6 @@ class EventFactoryTest extends TestCase
     public function createWithPayloadDataProvider()
     {
         return [
-            [
-                ['transaction' => 'testTransaction'],
-                ['transaction' => 'testTransaction'],
-            ],
             [
                 ['logger' => 'testLogger'],
                 ['logger' => 'testLogger'],

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Integration;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\Integration\TransactionIntegration;
+use Sentry\State\Hub;
+use Sentry\State\Scope;
+use function Sentry\withScope;
+
+final class TransactionIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider setupOnceDataProvider
+     *
+     * @backupGlobals
+     */
+    public function testSetupOnce(Event $event, bool $isIntegrationEnabled, array $payload, array $serverGlobals, ?string $expectedTransaction): void
+    {
+        $_SERVER = array_merge($_SERVER, $serverGlobals);
+
+        $integration = new TransactionIntegration();
+        $integration->setupOnce();
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->willReturn($isIntegrationEnabled ? $integration : null);
+
+        Hub::getCurrent()->bindClient($client);
+
+        withScope(function (Scope $scope) use ($event, $payload, $expectedTransaction): void {
+            $event = $scope->applyToEvent($event, $payload);
+
+            $this->assertNotNull($event);
+            $this->assertSame($event->getTransaction(), $expectedTransaction);
+        });
+    }
+
+    public function setupOnceDataProvider(): \Generator
+    {
+        yield [
+            new Event(),
+            true,
+            [],
+            [],
+            null,
+        ];
+
+        yield [
+            new Event(),
+            true,
+            ['transaction' => '/foo/bar'],
+            [],
+            '/foo/bar',
+        ];
+
+        yield [
+            new Event(),
+            true,
+            [],
+            ['PATH_INFO' => '/foo/bar'],
+            '/foo/bar',
+        ];
+
+        $event = new Event();
+        $event->setTransaction('/foo/bar');
+
+        yield [
+            $event,
+            true,
+            [],
+            [],
+            '/foo/bar',
+        ];
+
+        $event = new Event();
+        $event->setTransaction('/foo/bar');
+
+        yield [
+            $event,
+            true,
+            ['/foo/bar/baz'],
+            [],
+            '/foo/bar',
+        ];
+
+        yield [
+            new Event(),
+            false,
+            ['transaction' => '/foo/bar'],
+            [],
+            null,
+        ];
+    }
+}

--- a/tests/SentrySdkExtension.php
+++ b/tests/SentrySdkExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Runner\BeforeTestHook as BeforeTestHookInterface;
+use Sentry\State\Hub;
+use Sentry\State\Scope;
+
+final class SentrySdkExtension implements BeforeTestHookInterface
+{
+    public function executeBeforeTest(string $test): void
+    {
+        Hub::setCurrent(new Hub());
+
+        $reflectionProperty = new \ReflectionProperty(Scope::class, 'globalEventProcessors');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, []);
+        $reflectionProperty->setAccessible(false);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Stemming from #864, this PR adds a new integration similar to the one present in the JS SDK for NodeJS that sets the `transaction` attribute of the event. This is a much more cleaner approach than setting it into the event factory as it can be configured from the user so that if he doesn't want to report such information he won't.