### PR TITLE
Make cleanupPendingRequests public

### DIFF
--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -102,7 +102,7 @@ final class HttpTransport implements TransportInterface
      * Cleanups the pending requests by forcing them to be sent. Any error that
      * occurs will be ignored.
      */
-    private function cleanupPendingRequests(): void
+    public function cleanupPendingRequests(): void
     {
         foreach ($this->pendingRequests as $pendingRequest) {
             try {


### PR DESCRIPTION
This allows for cleaning up pending requests in a long running process (queue consumer).

I want to create a [LongRunning Cleaner](https://github.com/LongRunning/LongRunning) that automatically calls this method when the cleaner is executed. For example after the execution of a RabbitMQ message in a consumer.