### PR TITLE
Remote static integrations

### DIFF
--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -7,7 +7,6 @@ namespace Sentry\Integration;
 use Jean85\PrettyVersions;
 use PackageVersions\Versions;
 use Sentry\Event;
-use Sentry\State\Hub;
 use Sentry\State\Scope;
 
 /**
@@ -26,12 +25,8 @@ final class ModulesIntegration implements IntegrationInterface
      */
     public function setupOnce(): void
     {
-        Scope::addGlobalEventProcessor(function (Event $event) {
-            $self = Hub::getCurrent()->getIntegration(self::class);
-
-            if ($self instanceof self) {
-                self::applyToEvent($self, $event);
-            }
+        Scope::addGlobalEventProcessor(static function (Event $event) {
+            static::applyToEvent($event);
 
             return $event;
         });
@@ -40,10 +35,9 @@ final class ModulesIntegration implements IntegrationInterface
     /**
      * Applies the information gathered by this integration to the event.
      *
-     * @param self  $self  The instance of this integration
      * @param Event $event The event that will be enriched with the modules
      */
-    public static function applyToEvent(self $self, Event $event): void
+    public static function applyToEvent(Event $event): void
     {
         if (empty(self::$loadedModules)) {
             foreach (Versions::VERSIONS as $package => $rawVersion) {

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -71,11 +71,11 @@ final class RequestIntegration implements IntegrationInterface
     public function applyToEvent(Event $event, ?ServerRequestInterface $request = null): void
     {
         if (null === $request) {
-            $request = isset($_SERVER['REQUEST_METHOD']) && \PHP_SAPI !== 'cli' ? ServerRequestFactory::fromGlobals() : null;
-        }
+            if (!isset($_SERVER['REQUEST_METHOD']) || \PHP_SAPI === 'cli') {
+                return;
+            }
 
-        if (null === $request) {
-            return;
+            $request = ServerRequestFactory::fromGlobals();
         }
 
         $requestData = [

--- a/tests/Integration/ModulesIntegrationTest.php
+++ b/tests/Integration/ModulesIntegrationTest.php
@@ -16,7 +16,7 @@ final class ModulesIntegrationTest extends TestCase
         $event = new Event();
         $integration = new ModulesIntegration();
 
-        ModulesIntegration::applyToEvent($integration, $event);
+        ModulesIntegration::applyToEvent($event);
 
         $modules = $event->getModules();
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -30,8 +30,7 @@ final class RequestIntegrationTest extends TestCase
         $this->assertInstanceOf(ServerRequestInterface::class, $request);
 
         $integration = new RequestIntegration(new Options(['send_default_pii' => $shouldSendPii]));
-
-        RequestIntegration::applyToEvent($integration, $event, $request);
+        $integration->applyToEvent($event, $request);
 
         $this->assertEquals($expectedValue, $event->getUserContext()->toArray());
     }
@@ -57,8 +56,7 @@ final class RequestIntegrationTest extends TestCase
     {
         $event = new Event();
         $integration = new RequestIntegration(new Options($options));
-
-        RequestIntegration::applyToEvent($integration, $event, $request);
+        $integration->applyToEvent($event, $request);
 
         $this->assertEquals($expectedResult, $event->getRequest());
     }


### PR DESCRIPTION
As the classes are final, these are not bc breaks ; instead of using a "a la python" mecanism to apply to events on the request integration (getting the instance of the hub), we should use the current one and be done with it.

this allows us to make the request integration independent from the Hub, making it way easier to integrate it from 3rd party (such as Monolog).