### PR TITLE
Allow extras to be cleared

### DIFF
--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -274,6 +274,18 @@ final class Scope
     }
 
     /**
+     * Resets the extra data
+     *
+     * @return $this
+     */
+    public function clearExtra(): self
+    {
+        $this->extra->clear();
+
+        return $this;
+    }
+
+    /**
      * Applies the current context and fingerprint to the event. If the event has
      * already some breadcrumbs on it, the ones from this scope won't get merged.
      *


### PR DESCRIPTION
I am trying to send along data (extras) that is specific to a particular error. Currently when I set tags it attaches them to ALL errors that I send. After I send an error I want to be able to clear out that data so it doesn't pollute future calls. This is easier than trying to build up a full new scope each time