### PR TITLE
add option to disable `ssl_verify_peer` in curl client

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -322,17 +322,18 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->messageFactory = $this->messageFactory ?? MessageFactoryDiscovery::find();
         $this->uriFactory = $this->uriFactory ?? UriFactoryDiscovery::find();
 
-        if (null !== $this->options->getHttpProxy()) {
+        if (null !== $this->options->getHttpProxy() || true !== $this->options->getSSLVerifyPeer()) {
             if (null !== $this->httpClient) {
-                throw new \RuntimeException('The `http_proxy` option does not work together with a custom client.');
+                throw new \RuntimeException('The options `http_proxy` and `ssl_verify_peer` do not work together with a custom client.');
             }
 
             if (!ClassDiscovery::safeClassExists(HttpCurlClient::class)) {
-                throw new \RuntimeException('The `http_proxy` option requires the `php-http/curl-client` package to be installed.');
+                throw new \RuntimeException('The options `http_proxy` and `ssl_verify_peer` require the `php-http/curl-client` package to be installed.');
             }
 
             $this->httpClient = new HttpCurlClient(null, null, [
                 CURLOPT_PROXY => $this->options->getHttpProxy(),
+                CURLOPT_SSL_VERIFYPEER => $this->options->getSSLVerifyPeer(),
             ]);
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -642,6 +642,28 @@ final class Options
     }
 
     /**
+     * Gets the ssl verify peer setting.
+     *
+     * @return bool
+     */
+    public function getSSLVerifyPeer(): bool
+    {
+        return $this->options['ssl_verify_peer'];
+    }
+
+    /**
+     * Sets the ssl verify peer option. Be aware this option only works when curl client is used.
+     *
+     * @param bool $sslVerifyPeer The http proxy
+     */
+    public function setSSLVerifyPeer(bool $sslVerifyPeer): void
+    {
+        $options = array_merge($this->options, ['ssl_verify_peer' => $sslVerifyPeer]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Gets whether the silenced errors should be captured or not.
      *
      * @return bool If true, errors silenced through the @ operator will be reported,
@@ -765,6 +787,7 @@ final class Options
             'send_default_pii' => false,
             'max_value_length' => 1024,
             'http_proxy' => null,
+            'ssl_verify_peer' => true,
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
@@ -794,6 +817,7 @@ final class Options
         $resolver->setAllowedTypes('default_integrations', 'bool');
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
+        $resolver->setAllowedTypes('ssl_verify_peer', 'bool');
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -313,7 +313,23 @@ final class ClientBuilderTest extends TestCase
         $clientBuilder->setHttpClient($this->createMock(HttpAsyncClient::class));
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The `http_proxy` option does not work together with a custom client.');
+        $this->expectExceptionMessage('The options `http_proxy` and `ssl_verify_peer` do not work together with a custom client.');
+
+        $clientBuilder->getClient();
+    }
+
+    public function testCreateWithSSLVerifyPeerAndCustomTransportThrowsException(): void
+    {
+        $options = new Options([
+            'dsn' => 'http://public:secret@example.com/sentry/1',
+            'ssl_verify_peer' => false,
+        ]);
+
+        $clientBuilder = new ClientBuilder($options);
+        $clientBuilder->setHttpClient($this->createMock(HttpAsyncClient::class));
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The options `http_proxy` and `ssl_verify_peer` do not work together with a custom client.');
 
         $clientBuilder->getClient();
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -59,6 +59,7 @@ final class OptionsTest extends TestCase
             ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
             ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
             ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
+            ['ssl_verify_peer', false, 'getSSLVerifyPeer', 'setSSLVerifyPeer'],
             ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
             ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
         ];


### PR DESCRIPTION
This pull request will allow php sentry client to work with self-signed certificates or behind a company proxy, that breaks ssl connections.