### PR TITLE
GZIP-encode the request in memory instead of streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix GZIP-compressed requests failing when `exit($code)` was used to terminate the application (#877)
+
 ## 2.1.2 (2019-08-22)
 
 - Fix `TypeError` in `Sentry\Monolog\Handler` when the extra data array has numeric keys (#833).

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -20,7 +20,7 @@ use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\StreamFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use Http\Message\MessageFactory;
-use Http\Message\StreamFactory;
+use Http\Message\StreamFactory as StreamFactoryInterface;
 use Http\Message\UriFactory;
 use Jean85\PrettyVersions;
 use Sentry\HttpClient\Authentication\SentryAuthentication;
@@ -55,7 +55,7 @@ final class ClientBuilder implements ClientBuilderInterface
     private $uriFactory;
 
     /**
-     * @var StreamFactory|null The PSR-17 stream factory
+     * @var StreamFactoryInterface|null The PSR-17 stream factory
      */
     private $streamFactory;
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -17,8 +17,10 @@ use Http\Client\HttpAsyncClient;
 use Http\Discovery\ClassDiscovery;
 use Http\Discovery\HttpAsyncClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\StreamFactoryDiscovery;
 use Http\Discovery\UriFactoryDiscovery;
 use Http\Message\MessageFactory;
+use Http\Message\StreamFactory;
 use Http\Message\UriFactory;
 use Jean85\PrettyVersions;
 use Sentry\HttpClient\Authentication\SentryAuthentication;
@@ -51,6 +53,11 @@ final class ClientBuilder implements ClientBuilderInterface
      * @var UriFactory|null The PSR-7 URI factory
      */
     private $uriFactory;
+
+    /**
+     * @var StreamFactory|null The PSR-17 stream factory
+     */
+    private $streamFactory;
 
     /**
      * @var MessageFactory|null The PSR-7 message factory
@@ -282,6 +289,10 @@ final class ClientBuilder implements ClientBuilderInterface
             throw new \RuntimeException('The PSR-7 URI factory must be set.');
         }
 
+        if (null === $this->streamFactory) {
+            throw new \RuntimeException('The PSR-17 stream factory must be set.');
+        }
+
         if (null === $this->httpClient) {
             throw new \RuntimeException('The PSR-18 HTTP client must be set.');
         }
@@ -294,7 +305,7 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->addHttpClientPlugin(new AuthenticationPlugin(new SentryAuthentication($this->options, $this->sdkIdentifier, $this->getSdkVersion())));
 
         if ($this->options->isCompressionEnabled()) {
-            $this->addHttpClientPlugin(new GzipEncoderPlugin());
+            $this->addHttpClientPlugin(new GzipEncoderPlugin($this->streamFactory));
             $this->addHttpClientPlugin(new DecoderPlugin());
         }
 
@@ -320,6 +331,7 @@ final class ClientBuilder implements ClientBuilderInterface
         }
 
         $this->messageFactory = $this->messageFactory ?? MessageFactoryDiscovery::find();
+        $this->streamFactory = $this->streamFactory ?? StreamFactoryDiscovery::find();
         $this->uriFactory = $this->uriFactory ?? UriFactoryDiscovery::find();
 
         if (null !== $this->options->getHttpProxy()) {

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -41,7 +41,7 @@ final class GzipEncoderPlugin implements PluginInterface
 
         $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
 
-        if ($encodedBody === false) {
+        if (false === $encodedBody) {
             throw new \RuntimeException('Failed to GZIP-encode the request body.');
         }
 

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Sentry\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin as PluginInterface;
-use Http\Message\StreamFactory;
+use Http\Message\StreamFactory as StreamFactoryInterface;
 use Http\Promise\Promise as PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -17,18 +17,18 @@ use Psr\Http\Message\RequestInterface;
 final class GzipEncoderPlugin implements PluginInterface
 {
     /**
-     * @var StreamFactory The PSR-17 stream factory
+     * @var StreamFactoryInterface The PSR-17 stream factory
      */
     private $streamFactory;
 
     /**
      * Constructor.
      *
-     * @param \Http\Message\StreamFactory $streamFactory
+     * @param StreamFactoryInterface $streamFactory The stream factory
      *
      * @throws \RuntimeException If the zlib extension is not enabled
      */
-    public function __construct(StreamFactory $streamFactory)
+    public function __construct(StreamFactoryInterface $streamFactory)
     {
         if (!\extension_loaded('zlib')) {
             throw new \RuntimeException('The "zlib" extension must be enabled to use this plugin.');

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Sentry\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin as PluginInterface;
-use Http\Message\Encoding\GzipEncodeStream;
 use Http\Promise\Promise as PromiseInterface;
 use Psr\Http\Message\RequestInterface;
+use Zend\Diactoros\StreamFactory;
 
 /**
  * This plugin encodes the request body by compressing it with Gzip.
@@ -39,8 +39,12 @@ final class GzipEncoderPlugin implements PluginInterface
             $requestBody->rewind();
         }
 
+        $encodedBody = (new StreamFactory())->createStream(
+            gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP)
+        );
+
         $request = $request->withHeader('Content-Encoding', 'gzip');
-        $request = $request->withBody(new GzipEncodeStream($requestBody));
+        $request = $request->withBody($encodedBody);
 
         return $next($request);
     }

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin as PluginInterface;
+use Http\Discovery\StreamFactoryDiscovery;
 use Http\Message\StreamFactory as StreamFactoryInterface;
 use Http\Promise\Promise as PromiseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -24,17 +25,21 @@ final class GzipEncoderPlugin implements PluginInterface
     /**
      * Constructor.
      *
-     * @param StreamFactoryInterface $streamFactory The stream factory
+     * @param StreamFactoryInterface|null $streamFactory The stream factory
      *
      * @throws \RuntimeException If the zlib extension is not enabled
      */
-    public function __construct(StreamFactoryInterface $streamFactory)
+    public function __construct(?StreamFactoryInterface $streamFactory = null)
     {
         if (!\extension_loaded('zlib')) {
             throw new \RuntimeException('The "zlib" extension must be enabled to use this plugin.');
         }
 
-        $this->streamFactory = $streamFactory;
+        if (null === $streamFactory) {
+            @trigger_error(sprintf('A PSR-17 stream factory is needed as argument of the constructor of the "%s" class since version 2.1.3 and will be required in 3.0.', self::class), E_USER_DEPRECATED);
+        }
+
+        $this->streamFactory = $streamFactory ?? StreamFactoryDiscovery::find();
     }
 
     /**

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -39,12 +39,15 @@ final class GzipEncoderPlugin implements PluginInterface
             $requestBody->rewind();
         }
 
-        $encodedBody = (new StreamFactory())->createStream(
-            gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP)
-        );
+        $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
+
+        // If an error occurred during the compression the request is sent uncompressed
+        if ($encodedBody === false) {
+            return $next($request);
+        }
 
         $request = $request->withHeader('Content-Encoding', 'gzip');
-        $request = $request->withBody($encodedBody);
+        $request = $request->withBody((new StreamFactory())->createStream($encodedBody));
 
         return $next($request);
     }

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -41,9 +41,8 @@ final class GzipEncoderPlugin implements PluginInterface
 
         $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
 
-        // If an error occurred during the compression the request is sent uncompressed
         if ($encodedBody === false) {
-            return $next($request);
+            throw new \RuntimeException('Failed to GZIP-encode the request body.');
         }
 
         $request = $request->withHeader('Content-Encoding', 'gzip');

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Tests\HttpClient\Plugin;
 
 use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\StreamFactoryDiscovery;
 use Http\Promise\Promise as PromiseInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -17,7 +18,7 @@ final class GzipEncoderPluginTest extends TestCase
      */
     public function testHandleRequest(): void
     {
-        $plugin = new GzipEncoderPlugin();
+        $plugin = new GzipEncoderPlugin(StreamFactoryDiscovery::find());
         $nextCallableCalled = false;
         $expectedPromise = $this->createMock(PromiseInterface::class);
         $request = MessageFactoryDiscovery::find()->createRequest(


### PR DESCRIPTION
This is a fix for a PHP bug that was discovered causing the `GzipEncodeStream` to output an empty string when `exit($code)` is used instead of the expected encoded string which causes requests to Sentry to fail because the event data was never sent.

/fixes #871
/closes getsentry/sentry-laravel#271