### PR TITLE
Disable the deprecation about delaying sending of events until shutdown

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -345,7 +345,12 @@ final class ClientBuilder implements ClientBuilderInterface
         /** @psalm-suppress PossiblyInvalidPropertyAssignmentValue */
         $this->httpClient = $this->httpClient ?? HttpAsyncClientDiscovery::find();
 
-        return new HttpTransport($this->options, $this->createHttpClientInstance(), $this->messageFactory);
+        return new HttpTransport(
+            $this->options,
+            $this->createHttpClientInstance(),
+            $this->messageFactory,
+            false
+        );
     }
 
     /**


### PR DESCRIPTION
This PR fixes #884 by disabling the deprecation when the transport is initialized by Sentry itself (out-of-the-box setup)