### PR TITLE
Add support for Guzzle as default HTTP client

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,15 @@ parameters:
         -
             message: "/^Parameter #1 \\$function of function register_shutdown_function expects callable\\(\\): void, 'register_shutdown…' given\\.$/"
             path: src/Transport/HttpTransport.php
+        -
+            message: '/^Class Http\\Adapter\\Guzzle6\\Client not found\.$/'
+            path: src/ClientBuilder.php
+        -
+            message: '/^Call to static method createWithConfig\(\) on an unknown class Http\\Adapter\\Guzzle6\\Client\.$/'
+            path: src/ClientBuilder.php
+        -
+            message: '/^Access to constant PROXY on an unknown class GuzzleHttp\\RequestOptions\.$/'
+            path: src/ClientBuilder.php
     excludes_analyse:
         - tests/resources
         - tests/Fixtures

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -334,15 +334,15 @@ final class ClientBuilder implements ClientBuilderInterface
                 throw new \RuntimeException('The `http_proxy` option does not work together with a custom client.');
             }
 
-            if (ClassDiscovery::safeClassExists(CurlHttpClient::class)) {
-                /** @psalm-suppress InvalidPropertyAssignmentValue */
-                $this->httpClient = new CurlHttpClient(null, null, [
-                    CURLOPT_PROXY => $this->options->getHttpProxy(),
-                ]);
-            } elseif (ClassDiscovery::safeClassExists(GuzzleHttpClient::class)) {
+            if (ClassDiscovery::safeClassExists(GuzzleHttpClient::class)) {
                 /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $this->httpClient = GuzzleHttpClient::createWithConfig([
                     GuzzleHttpClientOptions::PROXY => $this->options->getHttpProxy(),
+                ]);
+            } elseif (ClassDiscovery::safeClassExists(CurlHttpClient::class)) {
+                /** @psalm-suppress InvalidPropertyAssignmentValue */
+                $this->httpClient = new CurlHttpClient(null, null, [
+                    CURLOPT_PROXY => $this->options->getHttpProxy(),
                 ]);
             }
 

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -17,7 +17,7 @@ use Sentry\Severity;
 final class HubAdapter implements HubInterface
 {
     /**
-     * @var self The single instance which forwards all calls to {@see SentrySdk}
+     * @var self|null The single instance which forwards all calls to {@see SentrySdk}
      */
     private static $instance;
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -32,13 +32,6 @@ use Sentry\Transport\TransportInterface;
 
 final class ClientBuilderTest extends TestCase
 {
-    public function testCreate(): void
-    {
-        $clientBuilder = ClientBuilder::create();
-
-        $this->assertInstanceOf(ClientBuilder::class, $clientBuilder);
-    }
-
     /**
      * @group legacy
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.3
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

With this PR I'm going to add the support out-of-the-box for Guzzle so that we can switch later the default HTTP client from Httplug Curl which is bugged and far less developed and maintained