### PR TITLE
Fix failing build on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ env:
 
 matrix:
     fast_finish: true
-    allow_failures:
-        - php: 7.4snapshot
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "psr/http-message-implementation": "^1.0",
         "ramsey/uuid": "^3.3",
         "symfony/options-resolver": "^2.7|^3.0|^4.0",
-        "zendframework/zend-diactoros": "^1.4|^2.0"
+        "zendframework/zend-diactoros": "^1.7.1|^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",

--- a/tests/phpt/error_handler_respects_error_reporting.phpt
+++ b/tests/phpt/error_handler_respects_error_reporting.phpt
@@ -37,13 +37,13 @@ SentrySdk::getCurrentHub()->bindClient($client);
 
 echo 'Triggering silenced error' . PHP_EOL;
 
-@$a['missing'];
+@$a++;
 
 $client->getOptions()->setCaptureSilencedErrors(false);
 
 echo 'Triggering silenced error' . PHP_EOL;
 
-@$a['missing'];
+@$b++;
 ?>
 --EXPECT--
 Triggering silenced error


### PR DESCRIPTION
With this we will be sure of being compatible with PHP 7.4. The build was failing just because a PHPT test was triggering a new notice present under 7.4.