### PR TITLE
fix: Catch expections that are caused by transport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ cs-dry-run:
 	vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run
 
 cs-fix:
-	vendor/bin/php-cs-fixer fix --config=.php_cs
+	vendor/bin/php-cs-fixer fix --config=.php_cs.dist
 
 phpstan:
 	vendor/bin/phpstan analyse

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -110,7 +110,7 @@ final class HttpTransport implements TransportInterface
             } else {
                 $promise->wait(false);
             }
-            
+
             return $event->getId();
         } catch (ClientErrorException $e) {
             return null;


### PR DESCRIPTION
This fixes an issue if Sentry replies with `429` error code that we no longer throw an exception.

```
PHP Fatal error:  Uncaught Http\Client\Common\Exception\ClientErrorException: TOO MANY REQUESTS in /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/client-common/src/Plugin/ErrorPlugin.php:83
Stack trace:
#0 /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/client-common/src/Plugin/ErrorPlugin.php(65): Http\Client\Common\Plugin\ErrorPlugin->transformResponseToException(Object(GuzzleHttp\Psr7\Request), Object(Zend\Diactoros\Response))
#1 [internal function]: Http\Client\Common\Plugin\ErrorPlugin->Http\Client\Common\Plugin\{closure}(Object(Zend\Diactoros\Response))
#2 /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/curl-client/src/PromiseCore.php(215): call_user_func(Object(Closure), Object(Zend\Diactoros\Response))
#3 /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/curl-client/src/MultiRunner.php(99): Http\Client\Curl\PromiseCore->fulfill()
#4 /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/curl-client/src/CurlPromise.php(99): Http\Client\Curl\MultiRun in /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/client-common/src/Plugin/ErrorPlugin.php on line 83

Fatal error: Uncaught Http\Client\Common\Exception\ClientErrorException: TOO MANY REQUESTS in /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/client-common/src/Plugin/ErrorPlugin.php on line 83

Http\Client\Common\Exception\ClientErrorException: TOO MANY REQUESTS in /Users/haza/Projects/demo-projects/php/demo-php/vendor/php-http/client-common/src/Plugin/ErrorPlugin.php on line 83

Call Stack:
    0.9151    3181944   1. Sentry\ErrorHandler->handleException() /Users/haza/Projects/demo-projects/php/demo-php/vendor/sentry/sentry/src/ErrorHandler.php:0
```