### PR TITLE
#901: Replace critical with fatal status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix deprecation raised when serializing callable in certain circumstances (#821)
+- Replace `critical` (deprecated) with `fatal` breadcrumb status (#901)
 
 ## 2.2.2 (2019-10-10)
 

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -60,8 +60,15 @@ final class Breadcrumb implements \JsonSerializable
 
     /**
      * This constant defines the critical level for a breadcrumb.
+     *
+     * @deprecated 2.2.2 Use fatal instead. Will be removed in a later version.
      */
     public const LEVEL_CRITICAL = 'critical';
+
+    /**
+     * This constant defines the fatal level for a breadcrumb.
+     */
+    public const LEVEL_FATAL = 'fatal';
 
     /**
      * This constant defines the list of values allowed to be set as severity
@@ -73,6 +80,7 @@ final class Breadcrumb implements \JsonSerializable
         self::LEVEL_WARNING,
         self::LEVEL_ERROR,
         self::LEVEL_CRITICAL,
+        self::LEVEL_FATAL,
     ];
 
     /**
@@ -151,7 +159,7 @@ final class Breadcrumb implements \JsonSerializable
             case E_CORE_WARNING:
             case E_COMPILE_ERROR:
             case E_COMPILE_WARNING:
-                return self::LEVEL_CRITICAL;
+                return self::LEVEL_FATAL;
             case E_USER_ERROR:
                 return self::LEVEL_ERROR;
             case E_NOTICE:

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -61,7 +61,7 @@ final class Breadcrumb implements \JsonSerializable
     /**
      * This constant defines the critical level for a breadcrumb.
      *
-     * @deprecated 2.2.2 Use fatal instead. Will be removed in a later version.
+     * @deprecated since version 2.2.2, to be removed in 3.0; use fatal instead.
      */
     public const LEVEL_CRITICAL = 'critical';
 

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -286,7 +286,7 @@ final class ScopeTest extends TestCase
         $this->assertEquals(['foo' => 'baz'], $event->getUserContext()->toArray());
 
         $scope->setFingerprint(['foo', 'bar']);
-        $scope->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_CRITICAL, Breadcrumb::TYPE_ERROR, 'error_reporting'));
+        $scope->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_FATAL, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $scope->setLevel(Severity::fatal());
         $scope->setTag('bar', 'foo');
         $scope->setExtra('foo', 'bar');


### PR DESCRIPTION
Critical breadcrumb status is not supported. Replaced it with fatal.

Fixes #901 