### PR TITLE
Add PSR-3 error logger to ClientBuilder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,14 @@
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-message-implementation": "^1.0",
+        "psr/log": "^1.1",
         "ramsey/uuid": "^3.3",
         "symfony/options-resolver": "^2.7|^3.0|^4.0",
         "zendframework/zend-diactoros": "^1.4|^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13",
+        "jangregor/phpstan-prophecy": "^0.4.2",
         "monolog/monolog": "^1.3|^2.0",
         "php-http/mock-client": "^1.0",
         "phpstan/extension-installer": "^1.0",

--- a/src/Log/OptionalLoggerAwareTrait.php
+++ b/src/Log/OptionalLoggerAwareTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Log;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Trait to implement Psr\Log\LoggerAwareInterface similar to Psr\Log\LoggerAwareTrait
+ * but with a protected getter for the logger that falls back
+ * to NullLogger in case no logger has been set for the object.
+ */
+trait OptionalLoggerAwareTrait
+{
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return LoggerInterface
+     */
+    protected function getLogger(): LoggerInterface
+    {
+        return $this->logger ?? new NullLogger();
+    }
+}

--- a/src/Transport/PendingRequest.php
+++ b/src/Transport/PendingRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Transport;
+
+use Http\Promise\Promise as HttpPromiseInterface;
+use Sentry\Event;
+
+/**
+ * Represents a pending request with associated event.
+ */
+class PendingRequest
+{
+    /**
+     * @var HttpPromiseInterface
+     */
+    private $promise;
+
+    /**
+     * @var Event
+     */
+    private $event;
+
+    public function __construct(HttpPromiseInterface $promise, Event $event)
+    {
+        $this->promise = $promise;
+        $this->event = $event;
+    }
+
+    public function getPromise(): HttpPromiseInterface
+    {
+        return $this->promise;
+    }
+
+    public function getEvent(): Event
+    {
+        return $this->event;
+    }
+}


### PR DESCRIPTION
Q | A
-- | --
Branch? | 2.3
Bug fix? | no
New feature? | yes
BC breaks? | no
Deprecations? | no
License | MIT


To be able to log Sentry PHP framework incidents,
a logger is added to the option, which be default logs nothing.

Integrations can set any PSR-3 logger by setting
an instance to the "error_logger" option.

The logger is currently only used to log failures when sending
an event.
