### PR TITLE
Add option to whitelist specific paths as 'in app'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `in_app_include` option to whitelist paths that should be marked as part of the app (#909)
 - Fix `Client::captureEvent` not considering the `attach_stacktrace` option (#940)
 - Replace `ramsey/uuid` dependency with `uuid_create` from the PECL [`uuid`](https://pecl.php.net/package/uuid) extension or [`symfony/polyfill-uuid`](https://github.com/symfony/polyfill-uuid) (#937)
 - Deprecate `Scope::setUser` behaviour of replacing user data. (#929)

--- a/src/Options.php
+++ b/src/Options.php
@@ -842,6 +842,8 @@ final class Options
                 return null;
             }
 
+            @trigger_error('The option "project_root" is deprecated. Please use the "in_app_include" option instead.', E_USER_DEPRECATED);
+
             return $this->normalizeAbsolutePath($value);
         });
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -301,6 +301,28 @@ final class Options
     }
 
     /**
+     * Gets the list of paths which has to be identified as in_app.
+     *
+     * @return string[]
+     */
+    public function getInAppIncludedPaths(): array
+    {
+        return $this->options['in_app_include'];
+    }
+
+    /**
+     * Set the list of paths to include in in_app detection.
+     *
+     * @param string[] $paths The list of paths
+     */
+    public function setInAppIncludedPaths(array $paths): void
+    {
+        $options = array_merge($this->options, ['in_app_include' => $paths]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Gets the project ID number to send to the Sentry server.
      */
     public function getProjectId(): ?string
@@ -769,6 +791,7 @@ final class Options
             },
             'excluded_exceptions' => [],
             'in_app_exclude' => [],
+            'in_app_include' => [],
             'send_default_pii' => false,
             'max_value_length' => 1024,
             'http_proxy' => null,
@@ -786,6 +809,7 @@ final class Options
         $resolver->setAllowedTypes('environment', ['null', 'string']);
         $resolver->setAllowedTypes('excluded_exceptions', 'array');
         $resolver->setAllowedTypes('in_app_exclude', 'array');
+        $resolver->setAllowedTypes('in_app_include', 'array');
         $resolver->setAllowedTypes('project_root', ['null', 'string']);
         $resolver->setAllowedTypes('logger', 'string');
         $resolver->setAllowedTypes('release', ['null', 'string']);
@@ -826,6 +850,10 @@ final class Options
         });
 
         $resolver->setNormalizer('in_app_exclude', function (SymfonyOptions $options, array $value) {
+            return array_map([$this, 'normalizeAbsolutePath'], $value);
+        });
+
+        $resolver->setNormalizer('in_app_include', function (SymfonyOptions $options, array $value) {
             return array_map([$this, 'normalizeAbsolutePath'], $value);
         });
     }

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -148,23 +148,25 @@ class Stacktrace implements \JsonSerializable
             $includedAppPaths = $this->options->getInAppIncludedPaths();
             $absoluteFilePath = @realpath($file) ?: $file;
             $isApplicationFile = 0 === strpos($absoluteFilePath, $this->options->getProjectRoot());
+            $isInApp = false;
 
-            if (!$isApplicationFile) {
+            foreach ($includedAppPaths as $includedPath) {
+                if (0 === mb_strpos($absoluteFilePath, $includedPath)) {
+                    $isInApp = true;
+                    break;
+                }
+            }
+
+            if (!$isApplicationFile && !$isInApp) {
                 $frame->setIsInApp(false);
             } elseif (!empty($excludedAppPaths)) {
                 foreach ($excludedAppPaths as $excludedPath) {
                     if (0 === mb_strpos($absoluteFilePath, $excludedPath)) {
-                        foreach ($includedAppPaths as $includedPath) {
-                            if (false === mb_strpos($absoluteFilePath, $includedPath)) {
-                                $frame->setIsInApp(false);
-                            } elseif (0 === mb_strpos($absoluteFilePath, $includedPath)) {
-                                $frame->setIsInApp(true);
-                                break;
-                            }
-                        }
-
-                        if (empty($includedAppPaths)) {
+                        if ($isInApp) {
+                            $frame->setIsInApp(true);
+                        } elseif (!$isInApp) {
                             $frame->setIsInApp(false);
+                            break;
                         }
 
                         break;

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -145,15 +145,27 @@ class Stacktrace implements \JsonSerializable
 
         if (null !== $this->options->getProjectRoot()) {
             $excludedAppPaths = $this->options->getInAppExcludedPaths();
+            $includedAppPaths = $this->options->getInAppIncludedPaths();
             $absoluteFilePath = @realpath($file) ?: $file;
             $isApplicationFile = 0 === strpos($absoluteFilePath, $this->options->getProjectRoot());
 
             if (!$isApplicationFile) {
                 $frame->setIsInApp(false);
             } elseif (!empty($excludedAppPaths)) {
-                foreach ($excludedAppPaths as $path) {
-                    if (0 === mb_strpos($absoluteFilePath, $path)) {
-                        $frame->setIsInApp(false);
+                foreach ($excludedAppPaths as $excludedPath) {
+                    if (0 === mb_strpos($absoluteFilePath, $excludedPath)) {
+                        foreach ($includedAppPaths as $includedPath) {
+                            if (false === mb_strpos($absoluteFilePath, $includedPath)) {
+                                $frame->setIsInApp(false);
+                            } elseif (0 === mb_strpos($absoluteFilePath, $includedPath)) {
+                                $frame->setIsInApp(true);
+                                break;
+                            }
+                        }
+
+                        if (empty($includedAppPaths)) {
+                            $frame->setIsInApp(false);
+                        }
 
                         break;
                     }

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -11,9 +11,13 @@ use Sentry\Serializer\SerializerInterface;
  * This class contains all the information about an error stacktrace.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
+ *
+ * @final since version 2.3
  */
 class Stacktrace implements \JsonSerializable
 {
+    private const INTERNAL_FRAME_FILENAME = '[internal]';
+
     /**
      * @var Options The client options
      */
@@ -77,7 +81,7 @@ class Stacktrace implements \JsonSerializable
         foreach ($backtrace as $frame) {
             $stacktrace->addFrame($file, $line, $frame);
 
-            $file = $frame['file'] ?? '[internal]';
+            $file = $frame['file'] ?? self::INTERNAL_FRAME_FILENAME;
             $line = $frame['line'] ?? 0;
         }
 
@@ -95,6 +99,15 @@ class Stacktrace implements \JsonSerializable
     public function getFrames(): array
     {
         return $this->frames;
+    }
+
+    public function getFrame(int $index): Frame
+    {
+        if ($index < 0 || $index >= \count($this->frames)) {
+            throw new \OutOfBoundsException();
+        }
+
+        return $this->frames[$index];
     }
 
     /**
@@ -138,42 +151,7 @@ class Stacktrace implements \JsonSerializable
             $frame->setPostContext($sourceCodeExcerpt['post_context']);
         }
 
-        // In case it's an Sentry internal frame, we mark it as in_app false
-        if (null !== $functionName && 0 === strpos($functionName, 'Sentry\\')) {
-            $frame->setIsInApp(false);
-        }
-
-        if (null !== $this->options->getProjectRoot()) {
-            $excludedAppPaths = $this->options->getInAppExcludedPaths();
-            $includedAppPaths = $this->options->getInAppIncludedPaths();
-            $absoluteFilePath = @realpath($file) ?: $file;
-            $isApplicationFile = 0 === strpos($absoluteFilePath, $this->options->getProjectRoot());
-            $isInApp = false;
-
-            foreach ($includedAppPaths as $includedPath) {
-                if (0 === mb_strpos($absoluteFilePath, $includedPath)) {
-                    $isInApp = true;
-                    break;
-                }
-            }
-
-            if (!$isApplicationFile && !$isInApp) {
-                $frame->setIsInApp(false);
-            } elseif (!empty($excludedAppPaths)) {
-                foreach ($excludedAppPaths as $excludedPath) {
-                    if (0 === mb_strpos($absoluteFilePath, $excludedPath)) {
-                        if ($isInApp) {
-                            $frame->setIsInApp(true);
-                        } elseif (!$isInApp) {
-                            $frame->setIsInApp(false);
-                            break;
-                        }
-
-                        break;
-                    }
-                }
-            }
-        }
+        $frame->setIsInApp($this->isFrameInApp($file, $functionName));
 
         $frameArguments = $this->getFrameArguments($backtraceFrame);
 
@@ -431,5 +409,50 @@ class Stacktrace implements \JsonSerializable
         } else {
             return $arg;
         }
+    }
+
+    /**
+     * Checks whether a certain frame should be marked as "in app" or not.
+     *
+     * @param string      $file         The file to check
+     * @param string|null $functionName The name of the function
+     */
+    private function isFrameInApp(string $file, ?string $functionName): bool
+    {
+        if (self::INTERNAL_FRAME_FILENAME === $file) {
+            return false;
+        }
+
+        if (null !== $functionName && 0 === strpos($functionName, 'Sentry\\')) {
+            return false;
+        }
+
+        $projectRoot = $this->options->getProjectRoot();
+        $excludedAppPaths = $this->options->getInAppExcludedPaths();
+        $includedAppPaths = $this->options->getInAppIncludedPaths();
+        $absoluteFilePath = @realpath($file) ?: $file;
+        $isInApp = false;
+
+        if (null !== $projectRoot) {
+            $isInApp = 0 === mb_strpos($absoluteFilePath, $projectRoot);
+        }
+
+        foreach ($excludedAppPaths as $excludedAppPath) {
+            if (0 === mb_strpos($absoluteFilePath, $excludedAppPath)) {
+                $isInApp = false;
+
+                break;
+            }
+        }
+
+        foreach ($includedAppPaths as $includedAppPath) {
+            if (0 === mb_strpos($absoluteFilePath, $includedAppPath)) {
+                $isInApp = true;
+
+                break;
+            }
+        }
+
+        return $isInApp;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -217,6 +217,8 @@ class ClientTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @requires OSFAMILY Linux
      */
     public function testAppPathLinux(): void
@@ -230,6 +232,9 @@ class ClientTest extends TestCase
         $this->assertEquals('/foo/baz/', $client->getOptions()->getProjectRoot());
     }
 
+    /**
+     * @group legacy
+     */
     public function testAppPathWindows(): void
     {
         $client = ClientBuilder::create(['project_root' => 'C:\\foo\\bar\\'])->getClient();
@@ -412,7 +417,9 @@ class ClientTest extends TestCase
         $transport->expects($this->once())
             ->method('send')
             ->with($this->callback(function (Event $event): bool {
-                return null !== $event->getStacktrace();
+                $result = $event->getStacktrace();
+
+                return null !== $result;
             }));
 
         $client = ClientBuilder::create(['attach_stacktrace' => true])

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -56,6 +56,7 @@ final class OptionsTest extends TestCase
             ['environment', 'foo', 'getEnvironment', 'setEnvironment'],
             ['excluded_exceptions', ['foo', 'bar', 'baz'], 'getExcludedExceptions', 'setExcludedExceptions'],
             ['in_app_exclude', ['foo', 'bar'], 'getInAppExcludedPaths', 'setInAppExcludedPaths'],
+            ['in_app_include', ['foo', 'bar'], 'getInAppIncludedPaths', 'setInAppIncludedPaths'],
             ['project_root', 'baz', 'getProjectRoot', 'setProjectRoot'],
             ['logger', 'foo', 'getLogger', 'setLogger'],
             ['release', 'dev', 'getRelease', 'setRelease'],
@@ -248,6 +249,26 @@ final class OptionsTest extends TestCase
     }
 
     public function excludedPathProviders()
+    {
+        return [
+            ['some/path', 'some/path'],
+            ['some/specific/file.php', 'some/specific/file.php'],
+            [__DIR__, __DIR__],
+            [__FILE__, __FILE__],
+        ];
+    }
+
+    /**
+     * @dataProvider includedPathProviders
+     */
+    public function testIncludedAppPathsOverrideExcludedAppPaths(string $value, string $expected)
+    {
+        $configuration = new Options(['in_app_include' => [$value]]);
+
+        $this->assertSame([$expected], $configuration->getInAppIncludedPaths());
+    }
+
+    public function includedPathProviders(): array
     {
         return [
             ['some/path', 'some/path'],

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -155,18 +155,21 @@ final class StacktraceTest extends TestCase
                 'path/to/recursive/excluded/path',
         ]);
         $this->options->setInAppIncludedPaths([
+                'path/elsewhere',
                 'path/to/excluded/path',
                 'path/to/recursive/', //recursive
         ]);
 
         $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
 
+        $stacktrace->addFrame('path/elsewhere', 12, ['function' => 'test_function']);
         $stacktrace->addFrame('path/to/excluded/path/file.php', 12, ['function' => 'test_function']);
         $stacktrace->addFrame('path/to/recursive/file.php', 12, ['function' => 'test_function']);
         $stacktrace->addFrame('path/to/recursive/excluded/path/file.php', 12, ['function' => 'test_function']);
         $stacktrace->addFrame('path/to/excluded/folder/file.php', 12, ['function' => 'test_function']);
 
         $frames = $stacktrace->getFrames();
+        $this->assertTrue($frames[4]->isInApp());
         $this->assertTrue($frames[3]->isInApp());
         $this->assertTrue($frames[2]->isInApp());
         $this->assertTrue($frames[1]->isInApp());

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -145,6 +145,34 @@ final class StacktraceTest extends TestCase
         $this->assertTrue($frames[2]->isInApp());
     }
 
+    public function testAddFrameMarksAsInAppOverrideExcludedPaths(): void
+    {
+        $this->options->setProjectRoot('path/to');
+
+        $this->options->setInAppExcludedPaths([
+                'path/to/excluded/folder',
+                'path/to/excluded/path',
+                'path/to/recursive/excluded/path',
+        ]);
+        $this->options->setInAppIncludedPaths([
+                'path/to/excluded/path',
+                'path/to/recursive/', //recursive
+        ]);
+
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+
+        $stacktrace->addFrame('path/to/excluded/path/file.php', 12, ['function' => 'test_function']);
+        $stacktrace->addFrame('path/to/recursive/file.php', 12, ['function' => 'test_function']);
+        $stacktrace->addFrame('path/to/recursive/excluded/path/file.php', 12, ['function' => 'test_function']);
+        $stacktrace->addFrame('path/to/excluded/folder/file.php', 12, ['function' => 'test_function']);
+
+        $frames = $stacktrace->getFrames();
+        $this->assertTrue($frames[3]->isInApp());
+        $this->assertTrue($frames[2]->isInApp());
+        $this->assertTrue($frames[1]->isInApp());
+        $this->assertFalse($frames[0]->isInApp());
+    }
+
     /**
      * @dataProvider addFrameRespectsContextLinesOptionDataProvider
      */

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -127,53 +127,161 @@ final class StacktraceTest extends TestCase
         $this->assertFrameEquals($frames[3], 'test_function_parent_parent_parent', 'app/file', 12);
     }
 
-    public function testAddFrameMarksAsInApp(): void
+    /**
+     * @group legacy
+     *
+     * @dataProvider addFrameSetsInAppFlagCorrectlyDataProvider
+     */
+    public function testAddFrameSetsInAppFlagCorrectly(array $options, string $file, string $functionName, bool $expectedResult): void
     {
-        $this->options->setProjectRoot('path/to');
-        $this->options->setInAppExcludedPaths(['path/to/excluded/path']);
+        $options = new Options($options);
+        $stacktrace = new Stacktrace(
+            $options,
+            new Serializer($options),
+            new RepresentationSerializer($options)
+        );
 
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace->addFrame($file, 0, ['function' => $functionName]);
 
-        $stacktrace->addFrame('path/to/file', 12, ['function' => 'test_function']);
-        $stacktrace->addFrame('path/to/excluded/path/to/file', 12, ['function' => 'test_function']);
-        $stacktrace->addFrame('path/elsewhere', 12, ['function' => 'test_function']);
-
-        $frames = $stacktrace->getFrames();
-
-        $this->assertFalse($frames[0]->isInApp());
-        $this->assertFalse($frames[1]->isInApp());
-        $this->assertTrue($frames[2]->isInApp());
+        $this->assertSame($expectedResult, $stacktrace->getFrame(0)->isInApp());
     }
 
-    public function testAddFrameMarksAsInAppOverrideExcludedPaths(): void
+    public function addFrameSetsInAppFlagCorrectlyDataProvider(): \Generator
     {
-        $this->options->setProjectRoot('path/to');
+        yield 'No config specified' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [],
+                'in_app_include' => [],
+            ],
+            '[internal]',
+            'test_function',
+            false,
+        ];
 
-        $this->options->setInAppExcludedPaths([
-                'path/to/excluded/folder',
-                'path/to/excluded/path',
-                'path/to/recursive/excluded/path',
-        ]);
-        $this->options->setInAppIncludedPaths([
-                'path/elsewhere',
-                'path/to/excluded/path',
-                'path/to/recursive/', //recursive
-        ]);
+        yield 'project_root specified && file path matching project_root' => [
+            [
+                'project_root' => 'path/to',
+                'in_app_exclude' => [],
+                'in_app_include' => [],
+            ],
+            'path/to/file',
+            'test_function',
+            true,
+        ];
 
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        yield 'project_root specified && file path matching project_root && file path matching in_app_exclude' => [
+            [
+                'project_root' => 'path/to/file',
+                'in_app_exclude' => [
+                    'path/to',
+                ],
+                'in_app_include' => [],
+            ],
+            'path/to/file',
+            'test_function',
+            false,
+        ];
 
-        $stacktrace->addFrame('path/elsewhere', 12, ['function' => 'test_function']);
-        $stacktrace->addFrame('path/to/excluded/path/file.php', 12, ['function' => 'test_function']);
-        $stacktrace->addFrame('path/to/recursive/file.php', 12, ['function' => 'test_function']);
-        $stacktrace->addFrame('path/to/recursive/excluded/path/file.php', 12, ['function' => 'test_function']);
-        $stacktrace->addFrame('path/to/excluded/folder/file.php', 12, ['function' => 'test_function']);
+        yield 'project_root specified && file path not maching project_root && file path matching in_app_include' => [
+            [
+                'project_root' => 'nested/path/to',
+                'in_app_exclude' => [],
+                'in_app_include' => [
+                    'path/to',
+                ],
+            ],
+            'path/to/file',
+            'test_function',
+            true,
+        ];
 
-        $frames = $stacktrace->getFrames();
-        $this->assertTrue($frames[4]->isInApp());
-        $this->assertTrue($frames[3]->isInApp());
-        $this->assertTrue($frames[2]->isInApp());
-        $this->assertTrue($frames[1]->isInApp());
-        $this->assertFalse($frames[0]->isInApp());
+        yield 'in_app_include specified && file path not matching' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [],
+                'in_app_include' => [
+                    'path/to/nested/file',
+                ],
+            ],
+            'path/to/file',
+            'test_function',
+            false,
+        ];
+
+        yield 'in_app_include specified && file path matching' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [],
+                'in_app_include' => [
+                    'path/to/nested/file',
+                    'path/to/file',
+                ],
+            ],
+            'path/to/file',
+            'test_function',
+            true,
+        ];
+
+        yield 'in_app_include specified && in_app_exclude specified && file path matching in_app_include' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [
+                    'path/to/nested/file',
+                ],
+                'in_app_include' => [
+                    'path/to/file',
+                ],
+            ],
+            'path/to/file',
+            'test_function',
+            true,
+        ];
+
+        yield 'in_app_include specified && in_app_exclude specified && file path matching in_app_exclude' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [
+                    'path/to/nested/file',
+                ],
+                'in_app_include' => [
+                    'path/to/file',
+                ],
+            ],
+            'path/to/nested/file',
+            'test_function',
+            false,
+        ];
+
+        yield 'in_app_include specified && in_app_exclude specified && file path matching in_app_include && in_app_include prioritized over in_app_exclude' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [
+                    'path/to/file',
+                ],
+                'in_app_include' => [
+                    'path/to/file/nested',
+                ],
+            ],
+            'path/to/file/nested',
+            'test_function',
+            true,
+        ];
+
+        yield 'in_app_include specified && in_app_exclude specified && file path matching in_app_exclude && in_app_exclude prioritized over in_app_include' => [
+            [
+                'project_root' => null,
+                'in_app_exclude' => [
+                    'path/to/file',
+                ],
+                'in_app_include' => [
+                    'path/to/file/nested',
+                ],
+            ],
+            'path/to/file',
+            'test_function',
+            false,
+        ];
     }
 
     /**
@@ -276,24 +384,6 @@ final class StacktraceTest extends TestCase
         $this->assertFrameEquals($frames[0], null, 'path/to/file', 7);
         $this->assertFrameEquals($frames[1], 'call_user_func', '[internal]', 0);
         $this->assertFrameEquals($frames[2], 'TestClass::triggerError', 'path/to/file', 12);
-    }
-
-    public function testInAppWithEmptyFrame(): void
-    {
-        $stack = [
-            [
-                'function' => '{closure}',
-            ],
-            null,
-        ];
-
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
-        $stacktrace->addFrame('/some/file', 123, $stack);
-        $frames = $stacktrace->getFrames();
-
-        $this->assertCount(1, $frames);
-        $this->assertContainsOnlyInstancesOf(Frame::class, $frames);
-        $this->assertTrue($frames[0]->isInApp());
     }
 
     public function testGetFrameArgumentsDoesNotModifyCapturedArgs(): void


### PR DESCRIPTION
To bypass the default value for _in_app_exclude_ from getsentry/sentry-laravel, I added the _in_app_whitelist_ option.

The problem is that our own _vendor/packages_ do not appear in the 'in app' stackstrace.

With this option it is possible to whitelist subfolders if you don't want to exclude all folders individually. 

To use this option just add _in_app_whitelist_ to your sentry configuration and define some relative paths as an array.

Resolves #595