### PR TITLE
Don't autoload functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,9 +43,6 @@
         "raven/raven": "*"
     },
     "autoload": {
-        "files": [
-            "src/functions.php"
-        ],
         "psr-4" : {
             "Sentry\\" : "src/"
         }


### PR DESCRIPTION
To me, this is a real bad pattern. It scatters the global context with functions. Why not let people opt-in if they want this?

