### PR TITLE
Make the $errcontext argument of the ErrorHandler::handleError() method nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Suggest installing Monolog to send log messages directly to Sentry (#908)
+- Make the `$errcontext` argument of the `ErrorHandler::handleError()` method `nullable` (#917)
 
 ## 2.2.3 (2019-10-31)
 

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -357,19 +357,19 @@ final class ErrorHandler
      * Handles errors by capturing them through the Raven client according to
      * the configured bit field.
      *
-     * @param int    $level      The level of the error raised, represented by
-     *                           one of the E_* constants
-     * @param string $message    The error message
-     * @param string $file       The filename the error was raised in
-     * @param int    $line       The line number the error was raised at
-     * @param array  $errcontext The error context (deprecated since PHP 7.2)
+     * @param int        $level      The level of the error raised, represented by
+     *                               one of the E_* constants
+     * @param string     $message    The error message
+     * @param string     $file       The filename the error was raised in
+     * @param int        $line       The line number the error was raised at
+     * @param array|null $errcontext The error context (deprecated since PHP 7.2)
      *
      * @return bool If the function returns `false` then the PHP native error
      *              handler will be called
      *
      * @throws \Throwable
      */
-    private function handleError(int $level, string $message, string $file, int $line, array $errcontext = []): bool
+    private function handleError(int $level, string $message, string $file, int $line, ?array $errcontext = []): bool
     {
         if (0 === error_reporting()) {
             $errorAsException = new SilencedErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This closes #912 by making the `$errcontext` argument of the `ErrorHandler::handleError()` `nullable`. Even though the [PHP documentation](https://www.php.net/manual/en/function.set-error-handler.php#refsect1-function.set-error-handler-parameters) don't mention this, actually looking at the PHP source code up to `8.0` the argument can receive a `null` value