### PR TITLE
Make the `integrations` option accept a callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Update PHPStan and introduce Psalm (#846)
 - Add an integration to set the transaction attribute of the event (#865)
 - Deprecate `Hub::getCurrent` and `Hub::setCurrent` methods to set the current hub instance (#847)
+- Make the `integrations` option accept a `callable` that will receive the list of default integrations and returns a customized list (#919)
 
 ## 2.1.3 (2019-09-06)
 

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -15,11 +15,6 @@ use Http\Message\UriFactory as UriFactoryInterface;
 use Jean85\PrettyVersions;
 use Sentry\HttpClient\HttpClientFactory;
 use Sentry\HttpClient\PluggableHttpClientFactory;
-use Sentry\Integration\ErrorListenerIntegration;
-use Sentry\Integration\ExceptionListenerIntegration;
-use Sentry\Integration\FatalErrorListenerIntegration;
-use Sentry\Integration\RequestIntegration;
-use Sentry\Integration\TransactionIntegration;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\RepresentationSerializerInterface;
 use Sentry\Serializer\Serializer;
@@ -104,16 +99,6 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $this->options = $options ?? new Options();
         $this->sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
-
-        if ($this->options->hasDefaultIntegrations()) {
-            $this->options->setIntegrations(array_merge([
-                new ExceptionListenerIntegration(),
-                new ErrorListenerIntegration(null, false),
-                new FatalErrorListenerIntegration(),
-                new RequestIntegration(),
-                new TransactionIntegration(),
-            ], $this->options->getIntegrations()));
-        }
     }
 
     /**

--- a/src/Integration/Handler.php
+++ b/src/Integration/Handler.php
@@ -16,9 +16,10 @@ final class Handler
     private static $integrations = [];
 
     /**
-     * Calls {@link IntegrationInterface::setupOnce} for all passed integrations if it hasn't been called yet.
+     * Calls {@link IntegrationInterface::setupOnce} for all passed integrations
+     * if it hasn't been called yet.
      *
-     * @param array $integrations The integrations
+     * @param IntegrationInterface[] $integrations The integrations
      *
      * @return array<string, IntegrationInterface>
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -56,7 +56,7 @@ final class Options
     private $resolver;
 
     /**
-     * @var IntegrationInterface[] The list of default integrations
+     * @var IntegrationInterface[]|null The list of default integrations
      */
     private $defaultIntegrations;
 
@@ -68,13 +68,6 @@ final class Options
     public function __construct(array $options = [])
     {
         $this->resolver = new OptionsResolver();
-        $this->defaultIntegrations = [
-            new ExceptionListenerIntegration(),
-            new ErrorListenerIntegration(null, false),
-            new FatalErrorListenerIntegration(),
-            new RequestIntegration(),
-            new TransactionIntegration(),
-        ];
 
         $this->configureOptions($this->resolver);
 
@@ -541,7 +534,7 @@ final class Options
      */
     public function getIntegrations(): array
     {
-        $defaultIntegrations = $this->options['default_integrations'] ? $this->defaultIntegrations : [];
+        $defaultIntegrations = $this->getDefaultIntegrations();
         $userIntegrations = $this->options['integrations'];
         $integrations = [];
 
@@ -995,5 +988,29 @@ final class Options
         }
 
         return true;
+    }
+
+    /**
+     * Gets the list of default integrations.
+     *
+     * @return IntegrationInterface[]
+     */
+    private function getDefaultIntegrations(): array
+    {
+        if (!$this->options['default_integrations']) {
+            return [];
+        }
+
+        if (null === $this->defaultIntegrations) {
+            $this->defaultIntegrations = [
+                new ExceptionListenerIntegration(),
+                new ErrorListenerIntegration(null, false),
+                new FatalErrorListenerIntegration(),
+                new RequestIntegration(),
+                new TransactionIntegration(),
+            ];
+        }
+
+        return $this->defaultIntegrations;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -549,30 +549,15 @@ final class Options
             return $userIntegrations($defaultIntegrations);
         }
 
-        $pickedIntegrationsClasses = [];
-        $userIntegrationsClasses = array_map('get_class', $userIntegrations);
-
         foreach ($defaultIntegrations as $defaultIntegration) {
-            $defaultIntegrationClass = \get_class($defaultIntegration);
-
-            if (!\in_array($defaultIntegrationClass, $userIntegrationsClasses, true)) {
-                $pickedIntegrationsClasses[$defaultIntegrationClass] = true;
-                $integrations[] = $defaultIntegration;
-            }
+            $integrations[\get_class($defaultIntegration)] = $defaultIntegration;
         }
 
         foreach ($userIntegrations as $userIntegration) {
-            $userIntegrationClass = \get_class($userIntegration);
-
-            if (isset($pickedIntegrationsClasses[$userIntegrationClass])) {
-                continue;
-            }
-
-            $pickedIntegrationsClasses[$userIntegrationClass] = true;
-            $integrations[] = $userIntegration;
+            $integrations[\get_class($userIntegration)] = $userIntegration;
         }
 
-        return $integrations;
+        return array_values($integrations);
     }
 
     /**

--- a/src/Options.php
+++ b/src/Options.php
@@ -58,7 +58,7 @@ final class Options
     /**
      * @var IntegrationInterface[] The list of default integrations
      */
-    private $defaultIntegrations = [];
+    private $defaultIntegrations;
 
     /**
      * Class constructor.
@@ -545,36 +545,34 @@ final class Options
         $userIntegrations = $this->options['integrations'];
         $integrations = [];
 
-        if (\is_array($userIntegrations)) {
-            $userIntegrationsClasses = array_map('get_class', $userIntegrations);
-
-            /** @var array<string, bool> $pickedIntegrationsClasses */
-            $pickedIntegrationsClasses = [];
-
-            foreach ($defaultIntegrations as $defaultIntegration) {
-                $defaultIntegrationClass = \get_class($defaultIntegration);
-
-                if (!\in_array($defaultIntegrationClass, $userIntegrationsClasses, true)) {
-                    $pickedIntegrationsClasses[$defaultIntegrationClass] = true;
-                    $integrations[] = $defaultIntegration;
-                }
-            }
-
-            foreach ($userIntegrations as $userIntegration) {
-                $userIntegrationClass = \get_class($userIntegration);
-
-                if (isset($pickedIntegrationsClasses[$userIntegrationClass])) {
-                    continue;
-                }
-
-                $pickedIntegrationsClasses[$userIntegrationClass] = true;
-                $integrations[] = $userIntegration;
-            }
-
-            return $integrations;
+        if (\is_callable($userIntegrations)) {
+            return $userIntegrations($defaultIntegrations);
         }
 
-        return $userIntegrations($defaultIntegrations);
+        $pickedIntegrationsClasses = [];
+        $userIntegrationsClasses = array_map('get_class', $userIntegrations);
+
+        foreach ($defaultIntegrations as $defaultIntegration) {
+            $defaultIntegrationClass = \get_class($defaultIntegration);
+
+            if (!\in_array($defaultIntegrationClass, $userIntegrationsClasses, true)) {
+                $pickedIntegrationsClasses[$defaultIntegrationClass] = true;
+                $integrations[] = $defaultIntegration;
+            }
+        }
+
+        foreach ($userIntegrations as $userIntegration) {
+            $userIntegrationClass = \get_class($userIntegration);
+
+            if (isset($pickedIntegrationsClasses[$userIntegrationClass])) {
+                continue;
+            }
+
+            $pickedIntegrationsClasses[$userIntegrationClass] = true;
+            $integrations[] = $userIntegration;
+        }
+
+        return $integrations;
     }
 
     /**

--- a/src/Transport/NullTransport.php
+++ b/src/Transport/NullTransport.php
@@ -10,6 +10,8 @@ use Sentry\Event;
  * This transport fakes the sending of events by just ignoring them.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
+ *
+ * @final since 2.3
  */
 class NullTransport implements TransportInterface
 {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -349,12 +349,12 @@ final class OptionsTest extends TestCase
                 new ExceptionListenerIntegration(),
             ],
             [
+                new ExceptionListenerIntegration(),
                 new ErrorListenerIntegration(null, false),
                 new FatalErrorListenerIntegration(),
                 new RequestIntegration(),
                 new TransactionIntegration(),
                 $integration,
-                new ExceptionListenerIntegration(),
             ],
         ];
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -336,16 +336,16 @@ final class OptionsTest extends TestCase
             [],
         ];
 
-        $integration1 = new class() implements IntegrationInterface {
+        $integration = new class() implements IntegrationInterface {
             public function setupOnce(): void
             {
             }
         };
 
-        yield 'User integration added + && default integration appearing only once' => [
+        yield 'User integration added && default integration appearing only once' => [
             true,
             [
-                $integration1,
+                $integration,
                 new ExceptionListenerIntegration(),
             ],
             [
@@ -353,12 +353,12 @@ final class OptionsTest extends TestCase
                 new FatalErrorListenerIntegration(),
                 new RequestIntegration(),
                 new TransactionIntegration(),
-                $integration1,
+                $integration,
                 new ExceptionListenerIntegration(),
             ],
         ];
 
-        $integration1 = new class() implements IntegrationInterface {
+        $integration = new class() implements IntegrationInterface {
             public function setupOnce(): void
             {
             }
@@ -367,23 +367,23 @@ final class OptionsTest extends TestCase
         yield 'User integration added twice' => [
             false,
             [
-                $integration1,
-                $integration1,
+                $integration,
+                $integration,
             ],
             [
-                $integration1,
+                $integration,
             ],
         ];
 
         yield 'User integrations as callable returning empty list' => [
             true,
-            static function (array $defaultIntegrations): array {
+            static function (): array {
                 return [];
             },
             [],
         ];
 
-        $integration1 = new class() implements IntegrationInterface {
+        $integration = new class() implements IntegrationInterface {
             public function setupOnce(): void
             {
             }
@@ -391,15 +391,15 @@ final class OptionsTest extends TestCase
 
         yield 'User integrations as callable returning custom list' => [
             true,
-            static function (array $defaultIntegrations) use ($integration1): array {
-                return [$integration1];
+            static function () use ($integration): array {
+                return [$integration];
             },
-            [$integration1],
+            [$integration],
         ];
 
         yield 'User integrations as callable returning $defaultIntegrations argument' => [
             true,
-            static function (array $defaultIntegrations) use ($integration1): array {
+            static function (array $defaultIntegrations): array {
                 return $defaultIntegrations;
             },
             [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.3
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

This PR aligns the SDK behavior of the `integrations` option with the one present in the JS SDK. Basically, instead of accepting only a list of integrations, a `callable` can now be set that will receive the list of default integrations and will return a (customized) list of integrations. This allows users to pick only certain default integrations without having to maintain in their own project the list of default integrations that must be kept in sync with the one of our library