### PR TITLE
Add the IgnoreErrorsIntegration integration and deprecate the excluded_exceptions option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix remaining PHP 7.4 deprecations (#930)
 - Make the `integrations` option accept a `callable` that will receive the list of default integrations and returns a customized list (#919)
-- Add the `InboundFiltersIntegration` integration to deprecate and replace the `exclude_exceptions` option (#928)
+- Add the `IgnoreErrorsIntegration` integration to deprecate and replace the `exclude_exceptions` option (#928)
 
 ## 2.2.5 (2019-11-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix remaining PHP 7.4 deprecations (#930)
 - Make the `integrations` option accept a `callable` that will receive the list of default integrations and returns a customized list (#919)
+- Add the `InboundFiltersIntegration` integration to deprecate and replace the `exclude_exceptions` option (#928)
 
 ## 2.2.5 (2019-11-27)
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 # Sentry for PHP
 
-[![Build Status](https://secure.travis-ci.org/getsentry/sentry-php.png?branch=develop)](http://travis-ci.org/getsentry/sentry-php)
-[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/getsentry/sentry-php?branch=master&svg=true)](https://ci.appveyor.com/project/sentry/sentry-php)
+[![Build Status](https://img.shields.io/travis/getsentry/sentry-php/develop?logo=travis)](http://travis-ci.org/getsentry/sentry-php)
+[![AppVeyor Build Status](https://img.shields.io/appveyor/ci/sentry/sentry-php/develop?logo=appveyor)](https://ci.appveyor.com/project/sentry/sentry-php)
 [![Total Downloads](https://poser.pugx.org/sentry/sentry/downloads)](https://packagist.org/packages/sentry/sentry)
 [![Monthly Downloads](https://poser.pugx.org/sentry/sentry/d/monthly)](https://packagist.org/packages/sentry/sentry)
 [![Latest Stable Version](https://poser.pugx.org/sentry/sentry/v/stable)](https://packagist.org/packages/sentry/sentry)
@@ -24,8 +24,8 @@ information needed to prioritize, identify, reproduce and fix each issue.
 To install the SDK you will need to be using [Composer]([https://getcomposer.org/)
 in your project. To install it please see the [docs](https://getcomposer.org/download/).
 
-This is our "core" SDK, meaning that all the important code regarding error handling lives here. 
-If you are happy with using the HTTP client we recommend install the SDK like: [`sentry/sdk`](https://github.com/getsentry/sentry-php-sdk) 
+This is our "core" SDK, meaning that all the important code regarding error handling lives here.
+If you are happy with using the HTTP client we recommend install the SDK like: [`sentry/sdk`](https://github.com/getsentry/sentry-php-sdk)
 
 ```bash
 php composer.phar require sentry/sdk

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,6 +31,12 @@ parameters:
         -
             message: '/^Property Sentry\\HttpClient\\HttpClientFactory::\$httpClient \(Http\\Client\\HttpAsyncClient\|null\) does not accept Http\\Client\\Curl\\Client.$/'
             path: src/HttpClient/HttpClientFactory.php
+        -
+            message: '/^Access to an undefined property Sentry\\Integration\\IntegrationInterface::\$options\.$/'
+            path: src/Integration/InboundFiltersIntegration.php
+        -
+            message: '/^Call to an undefined method Sentry\\Integration\\IntegrationInterface::shouldDropEvent\(\)\.$/'
+            path: src/Integration/InboundFiltersIntegration.php
     excludes_analyse:
         - tests/resources
         - tests/Fixtures

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,10 +33,10 @@ parameters:
             path: src/HttpClient/HttpClientFactory.php
         -
             message: '/^Access to an undefined property Sentry\\Integration\\IntegrationInterface::\$options\.$/'
-            path: src/Integration/InboundFiltersIntegration.php
+            path: src/Integration/IgnoreErrorsIntegration.php
         -
             message: '/^Call to an undefined method Sentry\\Integration\\IntegrationInterface::shouldDropEvent\(\)\.$/'
-            path: src/Integration/InboundFiltersIntegration.php
+            path: src/Integration/IgnoreErrorsIntegration.php
     excludes_analyse:
         - tests/resources
         - tests/Fixtures

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,7 @@ namespace Sentry;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Sentry\Integration\Handler;
-use Sentry\Integration\InboundFiltersIntegration;
+use Sentry\Integration\IgnoreErrorsIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\State\Scope;
 use Sentry\Transport\ClosableTransportInterface;
@@ -99,7 +99,7 @@ final class Client implements FlushableClientInterface
      */
     public function captureException(\Throwable $exception, ?Scope $scope = null): ?string
     {
-        if (!isset($this->integrations[InboundFiltersIntegration::class]) && $this->options->isExcludedException($exception, false)) {
+        if (!isset($this->integrations[IgnoreErrorsIntegration::class]) && $this->options->isExcludedException($exception, false)) {
             return null;
         }
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -52,9 +52,15 @@ interface ClientInterface
     public function captureEvent(array $payload, ?Scope $scope = null): ?string;
 
     /**
-     * Returns the integration instance if it is installed on the Client.
+     * Returns the integration instance if it is installed on the client.
      *
      * @param string $className the classname of the integration
+     *
+     * @psalm-template T of IntegrationInterface
+     *
+     * @psalm-param class-string<T> $className
+     *
+     * @psalm-return T|null
      */
     public function getIntegration(string $className): ?IntegrationInterface;
 }

--- a/src/Integration/Handler.php
+++ b/src/Integration/Handler.php
@@ -22,6 +22,8 @@ final class Handler
      * @param IntegrationInterface[] $integrations The integrations
      *
      * @return array<string, IntegrationInterface>
+     *
+     * @psalm-return array<class-string<IntegrationInterface>, IntegrationInterface>
      */
     public static function setupIntegrations(array $integrations): array
     {

--- a/src/Integration/IgnoreErrorsIntegration.php
+++ b/src/Integration/IgnoreErrorsIntegration.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class InboundFiltersIntegration implements IntegrationInterface
+final class IgnoreErrorsIntegration implements IntegrationInterface
 {
     /**
      * @var array<string, mixed> The options

--- a/src/Integration/InboundFiltersIntegration.php
+++ b/src/Integration/InboundFiltersIntegration.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Integration;
+
+use Sentry\Event;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * This integration decides whether an event should not be captured according
+ * to a series of options that must match with its data.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class InboundFiltersIntegration implements IntegrationInterface
+{
+    /**
+     * @var array<string, mixed> The options
+     */
+    private $options;
+
+    /**
+     * Creates a new instance of this integration and configures it with the
+     * given options.
+     *
+     * @param array<string, mixed> $options The options
+     *
+     * @psalm-param array{
+     *     ignore_exceptions?: bool
+     * } $options
+     */
+    public function __construct(array $options = [])
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'ignore_exceptions' => [],
+        ]);
+
+        $resolver->setAllowedTypes('ignore_exceptions', ['array']);
+
+        $this->options = $resolver->resolve($options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setupOnce(): void
+    {
+        Scope::addGlobalEventProcessor(function (Event $event): ?Event {
+            $currentHub = SentrySdk::getCurrentHub();
+            $integration = $currentHub->getIntegration(self::class);
+
+            if (null !== $integration && $integration->shouldDropEvent($event, $integration->options)) {
+                return null;
+            }
+
+            return $event;
+        });
+    }
+
+    /**
+     * Checks whether the given event should be dropped according to the options
+     * that configures the current instance of this integration.
+     *
+     * @param Event                $event   The event to check
+     * @param array<string, mixed> $options The options of the integration
+     */
+    private function shouldDropEvent(Event $event, array $options): bool
+    {
+        if ($this->isIgnoredException($event, $options)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether the given event should be dropped or not according to the
+     * criteria defined in the integration's options.
+     *
+     * @param Event                $event   The event instance
+     * @param array<string, mixed> $options The options of the integration
+     */
+    private function isIgnoredException(Event $event, array $options): bool
+    {
+        $exceptions = $event->getExceptions();
+
+        if (empty($exceptions) || !isset($exceptions[0]['type'])) {
+            return false;
+        }
+
+        foreach ($options['ignore_exceptions'] as $ignoredException) {
+            if (is_a($exceptions[0]['type'], $ignoredException, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Options.php
+++ b/src/Options.php
@@ -230,7 +230,7 @@ final class Options
      */
     public function getExcludedExceptions(): array
     {
-        @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "InboundFiltersIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "IgnoreErrorsIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
 
         return $this->options['excluded_exceptions'];
     }
@@ -245,7 +245,7 @@ final class Options
      */
     public function setExcludedExceptions(array $exceptions): void
     {
-        @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "InboundFiltersIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "IgnoreErrorsIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
 
         $options = array_merge($this->options, ['excluded_exceptions' => $exceptions]);
 
@@ -266,7 +266,7 @@ final class Options
     public function isExcludedException(\Throwable $exception, bool $throwDeprecation = true): bool
     {
         if ($throwDeprecation) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "InboundFiltersIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "IgnoreErrorsIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
         }
 
         foreach ($this->options['excluded_exceptions'] as $exceptionClass) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -225,9 +225,13 @@ final class Options
      * events to Sentry.
      *
      * @return string[]
+     *
+     * @deprecated since version 2.3, to be removed in 3.0
      */
     public function getExcludedExceptions(): array
     {
+        @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "InboundFiltersIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
+
         return $this->options['excluded_exceptions'];
     }
 
@@ -236,9 +240,13 @@ final class Options
      * events to Sentry.
      *
      * @param string[] $exceptions The list of exception classes
+     *
+     * @deprecated since version 2.3, to be removed in 3.0
      */
     public function setExcludedExceptions(array $exceptions): void
     {
+        @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "InboundFiltersIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
+
         $options = array_merge($this->options, ['excluded_exceptions' => $exceptions]);
 
         $this->options = $this->resolver->resolve($options);
@@ -248,10 +256,19 @@ final class Options
      * Checks whether the given exception should be ignored when sending events
      * to Sentry.
      *
-     * @param \Throwable $exception The exception
+     * @param \Throwable $exception        The exception
+     * @param bool       $throwDeprecation Flag indicating whether to throw a
+     *                                     deprecation for the usage of this
+     *                                     method
+     *
+     * @deprecated since version 2.3, to be removed in 3.0
      */
-    public function isExcludedException(\Throwable $exception): bool
+    public function isExcludedException(\Throwable $exception, bool $throwDeprecation = true): bool
     {
+        if ($throwDeprecation) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 2.3 and will be removed in 3.0. Use the "InboundFiltersIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         foreach ($this->options['excluded_exceptions'] as $exceptionClass) {
             if ($exception instanceof $exceptionClass) {
                 return true;

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -7,7 +7,6 @@ namespace Sentry\State;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
-use Sentry\SentrySdk;
 use Sentry\Severity;
 
 /**
@@ -110,7 +109,6 @@ interface HubInterface
      * @return HubInterface
      *
      * @deprecated since version 2.2, to be removed in 3.0
-     * @see SentrySdk::getCurrentHub()
      */
     public static function getCurrent(): self;
 
@@ -122,7 +120,6 @@ interface HubInterface
      * @return HubInterface
      *
      * @deprecated since version 2.2, to be removed in 3.0
-     * @see SentrySdk::setCurrentHub()
      */
     public static function setCurrent(self $hub): self;
 
@@ -130,6 +127,12 @@ interface HubInterface
      * Gets the integration whose FQCN matches the given one if it's available on the current client.
      *
      * @param string $className The FQCN of the integration
+     *
+     * @psalm-template T of IntegrationInterface
+     *
+     * @psalm-param class-string<T> $className
+     *
+     * @psalm-return T|null
      */
     public function getIntegration(string $className): ?IntegrationInterface;
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\ClientBuilder;
 use Sentry\Event;
 use Sentry\Options;
+use Sentry\SentrySdk;
 use Sentry\Serializer\Serializer;
 use Sentry\Severity;
 use Sentry\Stacktrace;
@@ -71,6 +72,7 @@ class ClientTest extends TestCase
      */
     public function testCaptureExceptionDoesNothingIfExcludedExceptionsOptionMatches(bool $shouldCapture, string $excluded, \Throwable $thrown): void
     {
+        /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transportFactory = $this->createTransportFactory($transport);
 
@@ -86,7 +88,8 @@ class ClientTest extends TestCase
             ->setTransportFactory($transportFactory)
             ->getClient();
 
-        $client->captureException($thrown);
+        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::getCurrentHub()->captureException($thrown);
     }
 
     public function captureExceptionDoesNothingIfExcludedExceptionsOptionMatchesDataProvider(): array

--- a/tests/Integration/IgnoreErrorsIntegrationTest.php
+++ b/tests/Integration/IgnoreErrorsIntegrationTest.php
@@ -8,19 +8,19 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Event;
-use Sentry\Integration\InboundFiltersIntegration;
+use Sentry\Integration\IgnoreErrorsIntegration;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use function Sentry\withScope;
 
-final class InboundFiltersIntegrationTest extends TestCase
+final class IgnoreErrorsIntegrationTest extends TestCase
 {
     /**
      * @dataProvider invokeDataProvider
      */
     public function testInvoke(Event $event, bool $isIntegrationEnabled, array $integrationOptions, bool $expectedEventToBeDropped): void
     {
-        $integration = new InboundFiltersIntegration($integrationOptions);
+        $integration = new IgnoreErrorsIntegration($integrationOptions);
         $integration->setupOnce();
 
         /** @var ClientInterface&MockObject $client */

--- a/tests/Integration/InboundFiltersIntegrationTest.php
+++ b/tests/Integration/InboundFiltersIntegrationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Integration;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\Integration\InboundFiltersIntegration;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+use function Sentry\withScope;
+
+final class InboundFiltersIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider invokeDataProvider
+     */
+    public function testInvoke(Event $event, bool $isIntegrationEnabled, array $integrationOptions, bool $expectedEventToBeDropped): void
+    {
+        $integration = new InboundFiltersIntegration($integrationOptions);
+        $integration->setupOnce();
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->willReturn($isIntegrationEnabled ? $integration : null);
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        withScope(function (Scope $scope) use ($event, $expectedEventToBeDropped): void {
+            $event = $scope->applyToEvent($event, []);
+
+            if ($expectedEventToBeDropped) {
+                $this->assertNull($event);
+            } else {
+                $this->assertNotNull($event);
+            }
+        });
+    }
+
+    public function invokeDataProvider(): \Generator
+    {
+        $event = new Event();
+        $event->setExceptions([
+            ['type' => \RuntimeException::class],
+        ]);
+
+        yield 'Integration disabled' => [
+            new Event(),
+            false,
+            [
+                'ignore_exceptions' => [],
+            ],
+            false,
+        ];
+
+        $event = new Event();
+        $event->setExceptions([
+            ['type' => \RuntimeException::class],
+        ]);
+
+        yield 'No exceptions to check' => [
+            new Event(),
+            true,
+            [
+                'ignore_exceptions' => [],
+            ],
+            false,
+        ];
+
+        $event = new Event();
+        $event->setExceptions([
+            ['type' => \RuntimeException::class],
+        ]);
+
+        yield 'The exception is matching exactly the "ignore_exceptions" option' => [
+            $event,
+            true,
+            [
+                'ignore_exceptions' => [
+                    \RuntimeException::class,
+                ],
+            ],
+            true,
+        ];
+
+        $event = new Event();
+        $event->setExceptions([
+            ['type' => \RuntimeException::class],
+        ]);
+
+        yield 'The exception is matching the "ignore_exceptions" option' => [
+            $event,
+            true,
+            [
+                'ignore_exceptions' => [
+                    \Exception::class,
+                ],
+            ],
+            true,
+        ];
+    }
+}

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 final class OptionsTest extends TestCase
 {
     /**
+     * @group legacy
+     *
      * @dataProvider optionsDataProvider
      */
     public function testConstructor($option, $value, $getterMethod): void
@@ -27,6 +29,8 @@ final class OptionsTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider optionsDataProvider
      */
     public function testGettersAndSetters(string $option, $value, string $getterMethod, ?string $setterMethod = null): void
@@ -206,7 +210,7 @@ final class OptionsTest extends TestCase
     {
         $configuration = new Options(['excluded_exceptions' => $excludedExceptions]);
 
-        $this->assertSame($result, $configuration->isExcludedException($exception));
+        $this->assertSame($result, $configuration->isExcludedException($exception, false));
     }
 
     public function excludedExceptionsDataProvider()

--- a/tests/SentrySdkExtension.php
+++ b/tests/SentrySdkExtension.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use PHPUnit\Runner\BeforeTestHook as BeforeTestHookInterface;
+use Sentry\Integration\Handler;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
 
@@ -18,6 +19,11 @@ final class SentrySdkExtension implements BeforeTestHookInterface
         $reflectionProperty->setAccessible(false);
 
         $reflectionProperty = new \ReflectionProperty(Scope::class, 'globalEventProcessors');
+        $reflectionProperty->setAccessible(true);
+        $reflectionProperty->setValue(null, []);
+        $reflectionProperty->setAccessible(false);
+
+        $reflectionProperty = new \ReflectionProperty(Handler::class, 'integrations');
         $reflectionProperty->setAccessible(true);
         $reflectionProperty->setValue(null, []);
         $reflectionProperty->setAccessible(false);

--- a/tests/phpt/error_handler_captures_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_fatal_error.phpt
@@ -10,8 +10,10 @@ namespace Sentry\Tests;
 use Sentry\ClientBuilder;
 use Sentry\ErrorHandler;
 use Sentry\Event;
+use Sentry\Options;
 use Sentry\SentrySdk;
-use Sentry\Transport\TransportInterface;;
+use Sentry\Transport\TransportFactoryInterface;
+use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
 
@@ -21,17 +23,22 @@ while (!file_exists($vendor . '/vendor')) {
 
 require $vendor . '/vendor/autoload.php';
 
-$transport = new class implements TransportInterface {
-    public function send(Event $event): ?string
+$transportFactory = new class implements TransportFactoryInterface {
+    public function create(Options $options): TransportInterface
     {
-        echo 'Transport called' . PHP_EOL;
+        return new class implements TransportInterface {
+            public function send(Event $event): ?string
+            {
+                echo 'Transport called' . PHP_EOL;
 
-        return null;
+                return null;
+            }
+        };
     }
 };
 
 $client = ClientBuilder::create([])
-    ->setTransport($transport)
+    ->setTransportFactory($transportFactory)
     ->getClient();
 
 SentrySdk::getCurrentHub()->bindClient($client);

--- a/tests/phpt/error_handler_captures_rethrown_exception_once.phpt
+++ b/tests/phpt/error_handler_captures_rethrown_exception_once.phpt
@@ -9,7 +9,9 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\Options;
 use Sentry\SentrySdk;
+use Sentry\Transport\TransportFactoryInterface;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -26,17 +28,22 @@ set_exception_handler(static function (\Exception $exception): void {
     throw $exception;
 });
 
-$transport = new class implements TransportInterface {
-    public function send(Event $event): ?string
+$transportFactory = new class implements TransportFactoryInterface {
+    public function create(Options $options): TransportInterface
     {
-        echo 'Transport called' . PHP_EOL;
+        return new class implements TransportInterface {
+            public function send(Event $event): ?string
+            {
+                echo 'Transport called' . PHP_EOL;
 
-        return null;
+                return null;
+            }
+        };
     }
 };
 
 $client = ClientBuilder::create([])
-    ->setTransport($transport)
+    ->setTransportFactory($transportFactory)
     ->getClient();
 
 SentrySdk::getCurrentHub()->bindClient($client);

--- a/tests/phpt/error_handler_respects_error_reporting.phpt
+++ b/tests/phpt/error_handler_respects_error_reporting.phpt
@@ -9,7 +9,9 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\Options;
 use Sentry\SentrySdk;
+use Sentry\Transport\TransportFactoryInterface;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -20,17 +22,22 @@ while (!file_exists($vendor . '/vendor')) {
 
 require $vendor . '/vendor/autoload.php';
 
-$transport = new class implements TransportInterface {
-    public function send(Event $event): ?string
+$transportFactory = new class implements TransportFactoryInterface {
+    public function create(Options $options): TransportInterface
     {
-        echo 'Transport called' . PHP_EOL;
+        return new class implements TransportInterface {
+            public function send(Event $event): ?string
+            {
+                echo 'Transport called' . PHP_EOL;
 
-        return null;
+                return null;
+            }
+        };
     }
 };
 
 $client = ClientBuilder::create(['capture_silenced_errors' => true])
-    ->setTransport($transport)
+    ->setTransportFactory($transportFactory)
     ->getClient();
 
 SentrySdk::getCurrentHub()->bindClient($client);

--- a/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
+++ b/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
@@ -12,6 +12,7 @@ use Sentry\Event;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Options;
 use Sentry\SentrySdk;
+use Sentry\Transport\TransportFactoryInterface;
 use Sentry\Transport\TransportInterface;
 
 $vendor = __DIR__;
@@ -22,23 +23,29 @@ while (!file_exists($vendor . '/vendor')) {
 
 require $vendor . '/vendor/autoload.php';
 
-$transport = new class implements TransportInterface {
-    public function send(Event $event): ?string
+$transportFactory = new class implements TransportFactoryInterface {
+    public function create(Options $options): TransportInterface
     {
-        echo 'Transport called' . PHP_EOL;
+        return new class implements TransportInterface {
+            public function send(Event $event): ?string
+            {
+                echo 'Transport called' . PHP_EOL;
 
-        return null;
+                return null;
+            }
+        };
     }
 };
 
-$options = new Options();
-$options->setDefaultIntegrations(false);
-$options->setIntegrations([
-    new FatalErrorListenerIntegration($options),
+$options = new Options([
+    'default_integrations' => false,
+    'integrations' => [
+        new FatalErrorListenerIntegration(),
+    ],
 ]);
 
 $client = (new ClientBuilder($options))
-    ->setTransport($transport)
+    ->setTransportFactory($transportFactory)
     ->getClient();
 
 SentrySdk::getCurrentHub()->bindClient($client);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.3
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

Closes #924. I decided that I didn't want to use the `$payload` argument of the `capture*` methods as an hacky way to pass options that configured the behavior of the method. Instead, like in the [JS SDK](https://github.com/getsentry/sentry-javascript/blob/c565329fac4876856da106e36790b0d975029a68/packages/core/src/integrations/inboundfilters.ts) I added a new integration that can be further expanded in the future and that will centralize all the logic to decide whether an event should be captured or not according to a set of criteria that must match with the event data. Being an integration means that the configuration now applies to all those methods and not only to the `captureException` one, so we cannot enable it by default until `3.0`