### PR TITLE
Fix PHP 7.4 deprecations

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,10 +3,12 @@ build: false
 clone_depth: 2
 clone_folder: c:\projects\sentry-php
 skip_branch_with_pr: true
+image: Visual Studio 2019
 branches:
     only:
         - master
         - develop
+        - /^release\/.+$/
 
 environment:
     matrix:
@@ -21,6 +23,10 @@ environment:
         - PHP_VERSION: 7.3-Win32-VC15
           DEPENDENCIES: lowest
         - PHP_VERSION: 7.3-Win32-VC15
+          DEPENDENCIES: highest
+        - PHP_VERSION: 7.4-Win32-VC15
+          DEPENDENCIES: lowest
+        - PHP_VERSION: 7.4-Win32-VC15
           DEPENDENCIES: highest
 
 matrix:
@@ -49,7 +55,7 @@ install:
     - IF %INSTALL_PHP%==1 echo extension=php_mbstring.dll >> php.ini
     - IF %INSTALL_PHP%==1 echo extension=php_openssl.dll >> php.ini
     - cd c:\projects\sentry-php
-    - IF NOT EXIST composer.phar appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.8.3/composer.phar
+    - IF NOT EXIST composer.phar appveyor-retry appveyor DownloadFile https://github.com/composer/composer/releases/download/1.9.1/composer.phar
     - php composer.phar self-update
     - IF %DEPENDENCIES%==lowest php composer.phar update --no-progress --no-interaction --no-suggest --ansi --prefer-lowest --prefer-dist
     - IF %DEPENDENCIES%==highest php composer.phar update --no-progress --no-interaction --no-suggest --ansi --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ php:
     - 7.1
     - 7.2
     - 7.3
-    - 7.4snapshot
+    - 7.4
 
 env:
     - dependencies=highest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix remaining PHP 7.4 deprecations (#930)
+
 ## 2.2.5 (2019-11-27)
 
 - Add compatibility with Symfony 5 (#925)

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.11",
         "phpstan/phpstan-phpunit": "^0.11",
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^7.5.18",
         "symfony/phpunit-bridge": "^4.3|^5.0",
         "vimeo/psalm": "^3.4"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,6 @@ parameters:
         - tests
     ignoreErrors:
         - '/Argument of an invalid type object supplied for foreach, only iterables are supported/'
-        - '/Binary operation "\*" between array and 2 results in an error\./'
         - '/Http\\Client\\Curl\\Client/'
         - '/^Parameter #1 \$object of method ReflectionProperty::setValue\(\) expects object, null given\.$/' # https://github.com/phpstan/phpstan/pull/2340
         -

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,10 @@
          colors="true"
          bootstrap="tests/bootstrap.php"
 >
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+    </php>
+
     <testsuites>
         <testsuite name="Sentry for PHP">
             <directory>tests</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,10 +6,6 @@
          colors="true"
          bootstrap="tests/bootstrap.php"
 >
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
-    </php>
-
     <testsuites>
         <testsuite name="Sentry for PHP">
             <directory>tests</directory>

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -301,8 +301,8 @@ abstract class AbstractSerializer
         $callableType = $reflection->isClosure() ? 'Lambda ' : 'Callable ';
         $callableReturnType = $reflection->getReturnType();
 
-        if (null !== $callableReturnType) {
-            $callableType .= $callableReturnType . ' ';
+        if ($callableReturnType instanceof \ReflectionNamedType) {
+            $callableType .= $callableReturnType->getName() . ' ';
         }
 
         if ($class) {
@@ -316,7 +316,12 @@ abstract class AbstractSerializer
     {
         $params = [];
         foreach ($reflection->getParameters() as &$param) {
-            $paramType = $param->getType() ?? 'mixed';
+            $reflectionType = $param->getType();
+            if ($reflectionType instanceof \ReflectionNamedType) {
+                $paramType = $reflectionType->getName();
+            } else {
+                $paramType = 'mixed';
+            }
 
             if ($param->allowsNull()) {
                 $paramType .= '|null';

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -361,7 +361,7 @@ abstract class AbstractSerializerTest extends TestCase
         return [
             [
                 'callable' => function (array $param1) {
-                    return $param1 * 2;
+                    throw new \Exception('Don\'t even think about invoke me');
                 },
                 'expected' => 'Lambda ' . __NAMESPACE__ . '\\{closure} [array param1]',
             ],


### PR DESCRIPTION
We had the deprecation handler on a too-low setting, so we missed deprecations under PHP 7.4: https://travis-ci.org/getsentry/sentry-php/jobs/622409178#L330-L345

This fixes them.