### PR TITLE
Allows merging user context on Scope::setUser()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Deprecate `Scope::setUser` behaviour of replacing user data. (#929)
-- Add the $merge parameter on `Scope::setUser` to allow merging user context. (#929)
+- Add the `$merge` parameter on `Scope::setUser` to allow merging user context. (#929)
 - Add the `Scope::clearUser` method to clear user context. (#929)
 
 ## 2.2.4 (2019-11-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Deprecate `Scope::setUser` behaviour of replacing user data. (#929)
+- Add the $merge parameter on `Scope::setUser` to allow merging user context. (#929)
+- Add the `Scope::clearUser` method to clear user context. (#929)
+
 ## 2.2.4 (2019-11-04)
 
 - Suggest installing Monolog to send log messages directly to Sentry (#908)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 - Deprecate `Scope::setUser` behaviour of replacing user data. (#929)
 - Add the `$merge` parameter on `Scope::setUser` to allow merging user context. (#929)
-- Add the `Scope::removeUser` method to remove specified data from user context. (#929)
 - Fix remaining PHP 7.4 deprecations (#930)
 - Make the `integrations` option accept a `callable` that will receive the list of default integrations and returns a customized list (#919)
 - Add the `IgnoreErrorsIntegration` integration to deprecate and replace the `exclude_exceptions` option (#928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Deprecate `Scope::setUser` behaviour of replacing user data. (#929)
 - Add the `$merge` parameter on `Scope::setUser` to allow merging user context. (#929)
-- Add the `Scope::clearUser` method to clear user context. (#929)
+- Add the `Scope::removeUser` method to remove specified data from user context. (#929)
 - Fix remaining PHP 7.4 deprecations (#930)
 - Make the `integrations` option accept a `callable` that will receive the list of default integrations and returns a customized list (#919)
 - Add the `IgnoreErrorsIntegration` integration to deprecate and replace the `exclude_exceptions` option (#928)

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -155,7 +155,7 @@ final class Scope
      *
      * @return $this
      */
-    public function clearUser(): self
+    public function removeUser(): self
     {
         $this->user->clear();
 

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -131,12 +131,34 @@ final class Scope
      * Sets the given data in the user context.
      *
      * @param array $data The data
+     * @param bool $merge If true, $data will be merged into user context instead of replaciong it
      *
      * @return $this
      */
-    public function setUser(array $data): self
+    public function setUser(array $data, bool $merge = false): self
     {
+        if ($merge) {
+            $this->user->merge($data);
+
+            return $this;
+        }
+
+        @trigger_error('Replacing user context on setUser is deprecated since sentry-php 2.3 and will be changed to a merge on 3.0. '
+             . 'For now you can use $merge = true to merge instead of replacing it.', E_USER_DEPRECATED);
+
         $this->user->replaceData($data);
+
+        return $this;
+    }
+
+    /**
+     * Clears all user context data.
+     *
+     * @return $this
+     */
+    public function clearUser(): self
+    {
+        $this->user->clear();
 
         return $this;
     }

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -131,7 +131,7 @@ final class Scope
      * Sets the given data in the user context.
      *
      * @param array $data The data
-     * @param bool $merge If true, $data will be merged into user context instead of replaciong it
+     * @param bool $merge If true, $data will be merged into user context instead of replacing it
      *
      * @return $this
      */

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -151,20 +151,6 @@ final class Scope
     }
 
     /**
-     * Removes specified data from user context.
-     *
-     * @param string $key The key of the information to remove
-     *
-     * @return $this
-     */
-    public function removeUser(string $key): self
-    {
-        $this->user->offsetUnset($key);
-
-        return $this;
-    }
-
-    /**
      * Sets the list of strings used to dictate the deduplication of this event.
      *
      * @param string[] $fingerprint The fingerprint values

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -143,8 +143,7 @@ final class Scope
             return $this;
         }
 
-        @trigger_error('Replacing user context on setUser is deprecated since sentry-php 2.3 and will be changed to a merge on 3.0. '
-             . 'For now you can use $merge = true to merge instead of replacing it.', E_USER_DEPRECATED);
+        @trigger_error('Replacing the data is deprecated since version 2.3 and will stop working from version 3.0. Set the second argument to `true` to merge the data instead.', E_USER_DEPRECATED);
 
         $this->user->replaceData($data);
 

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -151,13 +151,15 @@ final class Scope
     }
 
     /**
-     * Clears all user context data.
+     * Removes specified data from user context.
+     *
+     * @param string $key The key of the information to remove
      *
      * @return $this
      */
-    public function removeUser(): self
+    public function removeUser(string $key): self
     {
-        $this->user->clear();
+        $this->user->offsetUnset($key);
 
         return $this;
     }

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -130,8 +130,8 @@ final class Scope
     /**
      * Sets the given data in the user context.
      *
-     * @param array $data The data
-     * @param bool $merge If true, $data will be merged into user context instead of replacing it
+     * @param array $data  The data
+     * @param bool  $merge If true, $data will be merged into user context instead of replacing it
      *
      * @return $this
      */

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -91,11 +91,9 @@ final class EventTest extends TestCase
 
     public function testToArray(): void
     {
-        $event = new Event();
-
         $expected = [
             'event_id' => str_replace('-', '', static::GENERATED_UUID[0]),
-            'timestamp' => $event->getTimestamp(),
+            'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'level' => 'error',
             'platform' => 'php',
             'sdk' => [
@@ -115,6 +113,8 @@ final class EventTest extends TestCase
                 ],
             ],
         ];
+
+        $event = new Event();
 
         $this->assertEquals($expected, $event->toArray());
     }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -91,9 +91,11 @@ final class EventTest extends TestCase
 
     public function testToArray(): void
     {
+        $event = new Event();
+
         $expected = [
             'event_id' => str_replace('-', '', static::GENERATED_UUID[0]),
-            'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
+            'timestamp' => $event->getTimestamp(),
             'level' => 'error',
             'platform' => 'php',
             'sdk' => [
@@ -113,8 +115,6 @@ final class EventTest extends TestCase
                 ],
             ],
         ];
-
-        $event = new Event();
 
         $this->assertEquals($expected, $event->toArray());
     }

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -135,25 +135,6 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getUserContext()->toArray());
     }
 
-    public function testRemoveUser(): void
-    {
-        $scope = new Scope();
-
-        $scope->setUser(['foo' => 'bar', 'bar' => 'baz'], true);
-
-        $event = $scope->applyToEvent(new Event(), []);
-
-        $this->assertNotNull($event);
-        $this->assertNotEmpty($event->getUserContext()->toArray());
-
-        $scope->removeUser('foo');
-
-        $event = $scope->applyToEvent(new Event(), []);
-
-        $this->assertNotNull($event);
-        $this->assertSame(['bar' => 'baz'], $event->getUserContext()->toArray());
-    }
-
     public function testSetFingerprint(): void
     {
         $scope = new Scope();

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -87,7 +87,7 @@ final class ScopeTest extends TestCase
      *
      * @expectedDeprecation Replacing user context on setUser is deprecated since sentry-php 2.3 and will be changed to a merge on 3.0. For now you can use $merge = true to merge instead of replacing it.
      */
-    public function testDeprecatedSetUser(): void
+    public function testSetUserThrowsDeprecation(): void
     {
         $scope = new Scope();
 

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -29,6 +29,19 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
     }
 
+    public function testSetTags(): void
+    {
+        $scope = new Scope();
+        $scope->setTags(['foo' => 'bar']);
+        $event = $scope->applyToEvent(new Event(), []);
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar'], $event->getTagsContext()->toArray());
+        $scope->setTags(['bar' => 'baz']);
+        $event = $scope->applyToEvent(new Event(), []);
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
+    }
+
     public function testSetExtra(): void
     {
         $scope = new Scope();

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -64,6 +64,11 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtraContext()->toArray());
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Replacing user context on setUser is deprecated since sentry-php 2.3 and will be changed to a merge on 3.0. For now you can use $merge = true to merge instead of replacing it.
+     */
     public function testDeprecatedSetUser(): void
     {
         $scope = new Scope();

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -120,15 +120,14 @@ final class ScopeTest extends TestCase
         $this->assertNotNull($event);
         $this->assertSame([], $event->getUserContext()->toArray());
 
-        $merge = true;
-        $scope->setUser(['foo' => 'bar'], $merge);
+        $scope->setUser(['foo' => 'bar'], true);
 
         $event = $scope->applyToEvent(new Event(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar'], $event->getUserContext()->toArray());
 
-        $scope->setUser(['bar' => 'baz'], $merge);
+        $scope->setUser(['bar' => 'baz'], true);
 
         $event = $scope->applyToEvent(new Event(), []);
 
@@ -140,8 +139,7 @@ final class ScopeTest extends TestCase
     {
         $scope = new Scope();
 
-        $merge = true;
-        $scope->setUser(['foo' => 'bar'], $merge);
+        $scope->setUser(['foo' => 'bar'], true);
 
         $event = $scope->applyToEvent(new Event(), []);
 
@@ -287,8 +285,7 @@ final class ScopeTest extends TestCase
         $scope->setFingerprint(['foo']);
         $scope->setExtras(['foo' => 'bar']);
         $scope->setTags(['bar' => 'foo']);
-        $merge = true;
-        $scope->setUser(['foobar' => 'barfoo'], $merge);
+        $scope->setUser(['foobar' => 'barfoo'], true);
 
         $event = $scope->applyToEvent(new Event(), []);
 
@@ -324,8 +321,7 @@ final class ScopeTest extends TestCase
         $scope->addBreadcrumb($breadcrumb);
         $scope->setTag('foo', 'bar');
         $scope->setExtra('bar', 'foo');
-        $merge = true;
-        $scope->setUser(['foo' => 'baz'], $merge);
+        $scope->setUser(['foo' => 'baz'], true);
 
         $event = $scope->applyToEvent($event, []);
 
@@ -342,7 +338,7 @@ final class ScopeTest extends TestCase
         $scope->setLevel(Severity::fatal());
         $scope->setTag('bar', 'foo');
         $scope->setExtra('foo', 'bar');
-        $scope->setUser(['baz' => 'foo'], $merge);
+        $scope->setUser(['baz' => 'foo'], true);
 
         $event = $scope->applyToEvent($event, []);
 

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -143,7 +143,7 @@ final class ScopeTest extends TestCase
         $this->assertNotNull($event);
         $this->assertNotEmpty($event->getUserContext()->toArray());
 
-        $scope->clearUser();
+        $scope->removeUser();
 
         $event = $scope->applyToEvent(new Event(), []);
 

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -85,7 +85,7 @@ final class ScopeTest extends TestCase
     /**
      * @group legacy
      *
-     * @expectedDeprecation Replacing user context on setUser is deprecated since sentry-php 2.3 and will be changed to a merge on 3.0. For now you can use $merge = true to merge instead of replacing it.
+     * @expectedDeprecation Replacing the data is deprecated since version 2.3 and will stop working from version 3.0. Set the second argument to `true` to merge the data instead.
      */
     public function testSetUserThrowsDeprecation(): void
     {

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -29,24 +29,6 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
     }
 
-    public function setTags(): void
-    {
-        $scope = new Scope();
-        $scope->setTags(['foo' => 'bar']);
-
-        $event = $scope->applyToEvent(new Event(), []);
-
-        $this->assertNotNull($event);
-        $this->assertSame(['foo' => 'bar'], $event->getTagsContext()->toArray());
-
-        $scope->setTags(['bar' => 'baz']);
-
-        $event = $scope->applyToEvent(new Event(), []);
-
-        $this->assertNotNull($event);
-        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
-    }
-
     public function testSetExtra(): void
     {
         $scope = new Scope();
@@ -82,7 +64,7 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtraContext()->toArray());
     }
 
-    public function testSetUser(): void
+    public function testDeprecatedSetUser(): void
     {
         $scope = new Scope();
 
@@ -104,6 +86,51 @@ final class ScopeTest extends TestCase
 
         $this->assertNotNull($event);
         $this->assertSame(['bar' => 'baz'], $event->getUserContext()->toArray());
+    }
+
+    public function testSetUser(): void
+    {
+        $scope = new Scope();
+
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame([], $event->getUserContext()->toArray());
+
+        $merge = true;
+        $scope->setUser(['foo' => 'bar'], $merge);
+
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar'], $event->getUserContext()->toArray());
+
+        $scope->setUser(['bar' => 'baz'], $merge);
+
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getUserContext()->toArray());
+    }
+
+    public function testClearUser(): void
+    {
+        $scope = new Scope();
+
+        $merge = true;
+        $scope->setUser(['foo' => 'bar'], $merge);
+
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertNotEmpty($event->getUserContext()->toArray());
+
+        $scope->clearUser();
+
+        $event = $scope->applyToEvent(new Event(), []);
+
+        $this->assertNotNull($event);
+        $this->assertEmpty($event->getUserContext()->toArray());
     }
 
     public function testSetFingerprint(): void
@@ -237,7 +264,8 @@ final class ScopeTest extends TestCase
         $scope->setFingerprint(['foo']);
         $scope->setExtras(['foo' => 'bar']);
         $scope->setTags(['bar' => 'foo']);
-        $scope->setUser(['foobar' => 'barfoo']);
+        $merge = true;
+        $scope->setUser(['foobar' => 'barfoo'], $merge);
 
         $event = $scope->applyToEvent(new Event(), []);
 
@@ -273,7 +301,8 @@ final class ScopeTest extends TestCase
         $scope->addBreadcrumb($breadcrumb);
         $scope->setTag('foo', 'bar');
         $scope->setExtra('bar', 'foo');
-        $scope->setUser(['foo' => 'baz']);
+        $merge = true;
+        $scope->setUser(['foo' => 'baz'], $merge);
 
         $event = $scope->applyToEvent($event, []);
 
@@ -290,7 +319,7 @@ final class ScopeTest extends TestCase
         $scope->setLevel(Severity::fatal());
         $scope->setTag('bar', 'foo');
         $scope->setExtra('foo', 'bar');
-        $scope->setUser(['baz' => 'foo']);
+        $scope->setUser(['baz' => 'foo'], $merge);
 
         $event = $scope->applyToEvent($event, []);
 

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -135,23 +135,23 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getUserContext()->toArray());
     }
 
-    public function testClearUser(): void
+    public function testRemoveUser(): void
     {
         $scope = new Scope();
 
-        $scope->setUser(['foo' => 'bar'], true);
+        $scope->setUser(['foo' => 'bar', 'bar' => 'baz'], true);
 
         $event = $scope->applyToEvent(new Event(), []);
 
         $this->assertNotNull($event);
         $this->assertNotEmpty($event->getUserContext()->toArray());
 
-        $scope->removeUser();
+        $scope->removeUser('foo');
 
         $event = $scope->applyToEvent(new Event(), []);
 
         $this->assertNotNull($event);
-        $this->assertEmpty($event->getUserContext()->toArray());
+        $this->assertSame(['bar' => 'baz'], $event->getUserContext()->toArray());
     }
 
     public function testSetFingerprint(): void

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -33,11 +33,16 @@ final class ScopeTest extends TestCase
     {
         $scope = new Scope();
         $scope->setTags(['foo' => 'bar']);
+
         $event = $scope->applyToEvent(new Event(), []);
+
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar'], $event->getTagsContext()->toArray());
+
         $scope->setTags(['bar' => 'baz']);
+
         $event = $scope->applyToEvent(new Event(), []);
+
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTagsContext()->toArray());
     }


### PR DESCRIPTION
Closes #929

- Deprecate `Scope::setUser` behaviour of replacing user data. (#929)
- Add the $merge parameter on `Scope::setUser` to allow merging user context. (#929)
- Add the `Scope::clearUser` method to clear user context. (#929)