### PR TITLE
Fix error thrown when serializing an event containing invalid UTF-8 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix remaining PHP 7.4 deprecations (#930)
+- Fix error thrown during JSON encoding if a string contains invalid UTF-8 characters (#934)
 
 ## 2.2.5 (2019-11-27)
 

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
             "vendor/bin/phpstan analyse"
         ],
         "psalm": [
-            "vendor/bin/psalm --config=psalm.xml.dist"
+            "vendor/bin/psalm"
         ]
     },
     "config": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -14,6 +14,12 @@ parameters:
         -
             message: "/^Parameter #1 \\$function of function register_shutdown_function expects callable\\(\\): void, 'register_shutdown…' given\\.$/"
             path: src/Transport/HttpTransport.php
+        -
+            message: '/^Argument of an invalid type array\|object supplied for foreach, only iterables are supported\.$/'
+            path: src/Util/JSON.php
+        -
+            message: '/^Constant JSON_INVALID_UTF8_SUBSTITUTE not found\.$/'
+            path: src/Util/JSON.php
     excludes_analyse:
         - tests/resources
         - tests/Fixtures

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -64,5 +64,11 @@
                 <referencedClass name="Http\Client\Curl\Client" />
             </errorLevel>
         </UndefinedClass>
+
+        <UndefinedConstant errorLevel="error">
+            <errorLevel type="suppress">
+                <file name="src/Util/JSON.php" />
+            </errorLevel>
+        </UndefinedConstant>
     </issueHandlers>
 </psalm>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -64,11 +64,5 @@
                 <referencedClass name="Http\Client\Curl\Client" />
             </errorLevel>
         </UndefinedClass>
-
-        <UndefinedConstant errorLevel="error">
-            <errorLevel type="suppress">
-                <file name="src/Util/JSON.php" />
-            </errorLevel>
-        </UndefinedConstant>
     </issueHandlers>
 </psalm>

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -109,7 +109,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
             'POST',
             sprintf('/api/%d/store/', $projectId),
             ['Content-Type' => 'application/json'],
-            JSON::encode($event)
+            JSON::encode($event->toArray())
         );
 
         $promise = $this->httpClient->sendAsyncRequest($request);

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -27,6 +27,7 @@ final class JSON
         $options = JSON_UNESCAPED_UNICODE;
 
         if (\PHP_VERSION_ID >= 70200) {
+            /** @psalm-suppress UndefinedConstant */
             $options |= JSON_INVALID_UTF8_SUBSTITUTE;
         }
 

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -37,7 +37,7 @@ final class JSON
         // try to sanitize the data ourselves before retrying encoding. If it
         // fails again we throw an exception as usual.
         if (JSON_ERROR_UTF8 === json_last_error()) {
-            $encodedData = json_encode(self::sanitizeData($data, 256), $options);
+            $encodedData = json_encode(self::sanitizeData($data, 512), $options);
         }
 
         if (JSON_ERROR_NONE !== json_last_error()) {
@@ -74,13 +74,11 @@ final class JSON
      * @param int   $maxDepth The maximum depth to walk through `$data`
      *
      * @return mixed
-     *
-     * @throws JsonException
      */
     private static function sanitizeData($data, int $maxDepth)
     {
         if ($maxDepth < 0) {
-            throw new JsonException('Max depth limit of data to be sanitized reached.');
+            return $data;
         }
 
         if (\is_string($data)) {
@@ -130,11 +128,7 @@ final class JSON
 
         mb_substitute_character(0xfffd);
 
-        if (false === $encoding) {
-            $value = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
-        } else {
-            $value = mb_convert_encoding($value, 'UTF-8', $encoding);
-        }
+        $value = mb_convert_encoding($value, 'UTF-8', $encoding ?: 'UTF-8');
 
         mb_substitute_character($previousSubstituteCharacter);
 

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -154,6 +154,22 @@ final class JSONTest extends TestCase
         JSON::encode($resource);
     }
 
+    public function testEncodeRespectsOptionsArgument(): void
+    {
+        $this->assertSame('{}', JSON::encode([], JSON_FORCE_OBJECT));
+    }
+
+    /**
+     * @requires PHP < 7.2
+     *
+     * @expectedException \Sentry\Exception\JsonException
+     * @expectedExceptionMessage Reached the maximum depth limit while sanitizing the data.
+     */
+    public function testEncodeThrowsOnPhp71OrLowerWhenSanitizationReachesMaxDepthLimit(): void
+    {
+        JSON::encode([[["\x61\xb0\x62"]]], 0, 2);
+    }
+
     /**
      * @dataProvider decodeDataProvider
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Fixes #828. Originally I wanted to continue on @Jean85's PR but since he closed it and I force pushed to start over the work I could not, so here we go with a brand new. I abandoned the idea of using the serializer and instead hard-coded the sanitization of strings into the `JSON` util class. For PHP 7.2 or greater I don't expect to have to run the custom code because of the `JSON_INVALID_UTF8_SUBSTITUTE` option, so what I did is trying to serialize the data one first time and if it fails because of invalid UTF-8 characters I loop over the data where possible and try to convert all strings to UTF-8 before trying once more the encoding to JSON. If it fails again I throw the exception as it was done before. Due to this double serialization happening in case of PHP < 7.2 and an invalid UTF-8 string, there is a small performance penalty but I suppose it's acceptable