### PR TITLE
Use PECL uuid function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix `Client::captureEvent` not considering the `attach_stacktrace` option (#940)
+- Replace `ramsey/uuid` dependency with `uuid_create` from the PECL [`uuid`](https://pecl.php.net/package/uuid) extension or [`symfony/polyfill-uuid`](https://github.com/symfony/polyfill-uuid) (#937)
 - Deprecate `Scope::setUser` behaviour of replacing user data. (#929)
 - Add the `$merge` parameter on `Scope::setUser` to allow merging user context. (#929)
 - Make the `integrations` option accept a `callable` that will receive the list of default integrations and returns a customized list (#919)

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,8 @@
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-message-implementation": "^1.0",
-        "ramsey/uuid": "^3.3",
         "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/polyfill-uuid": "^1.13",
         "zendframework/zend-diactoros": "^1.7.1|^2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php-http/message": "^1.5",
         "psr/http-message-implementation": "^1.0",
         "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.0",
-        "symfony/polyfill-uuid": "^1.13",
+        "symfony/polyfill-uuid": "^1.13.1",
         "zendframework/zend-diactoros": "^1.7.1|^2.0"
     },
     "require-dev": {

--- a/src/Event.php
+++ b/src/Event.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace Sentry;
 
 use Jean85\PrettyVersions;
-use Ramsey\Uuid\Exception\UnsatisfiedDependencyException;
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
 use Sentry\Context\Context;
 use Sentry\Context\RuntimeContext;
 use Sentry\Context\ServerOsContext;
@@ -22,7 +19,7 @@ use Sentry\Context\UserContext;
 final class Event implements \JsonSerializable
 {
     /**
-     * @var UuidInterface The UUID
+     * @var string The UUID
      */
     private $id;
 
@@ -156,7 +153,7 @@ final class Event implements \JsonSerializable
      */
     public function __construct()
     {
-        $this->id = Uuid::uuid4();
+        $this->id = str_replace('-', '', uuid_create(UUID_TYPE_RANDOM));
         $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $this->level = Severity::error();
         $this->serverOsContext = new ServerOsContext();
@@ -172,7 +169,7 @@ final class Event implements \JsonSerializable
      */
     public function getId(): string
     {
-        return str_replace('-', '', $this->id->toString());
+        return $this->id;
     }
 
     /**
@@ -584,7 +581,7 @@ final class Event implements \JsonSerializable
     public function toArray(): array
     {
         $data = [
-            'event_id' => str_replace('-', '', $this->id->toString()),
+            'event_id' => $this->id,
             'timestamp' => $this->timestamp,
             'level' => (string) $this->level,
             'platform' => 'php',

--- a/src/Event.php
+++ b/src/Event.php
@@ -147,7 +147,6 @@ final class Event implements \JsonSerializable
     /**
      * Event constructor.
      *
-     * @throws UnsatisfiedDependencyException if `Moontoast\Math\BigNumber` is not present
      * @throws \InvalidArgumentException
      * @throws \Exception
      */

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -8,14 +8,11 @@ use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\Client;
-use Sentry\ClientBuilder;
-use Sentry\ClientInterface;
 use Sentry\Context\Context;
 use Sentry\Context\RuntimeContext;
 use Sentry\Context\ServerOsContext;
 use Sentry\Context\TagsContext;
 use Sentry\Event;
-use Sentry\Options;
 use Sentry\Severity;
 use Sentry\Util\PHPVersion;
 
@@ -24,22 +21,6 @@ use Sentry\Util\PHPVersion;
  */
 final class EventTest extends TestCase
 {
-    /**
-     * @var Options
-     */
-    protected $options;
-
-    /**
-     * @var ClientInterface
-     */
-    protected $client;
-
-    protected function setUp(): void
-    {
-        $this->client = ClientBuilder::create()->getClient();
-        $this->options = $this->client->getOptions();
-    }
-
     public function testEventIsGeneratedWithUniqueIdentifier(): void
     {
         $event1 = new Event();


### PR DESCRIPTION
This PR replaces the RamserUUID object `uuid_create`.

Calls to the PECL library are faster and avoid storing complexe object for nothing.