### PR TITLE
Fix Client::captureEvent not considering the attach_stacktrace option

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,8 +35,6 @@ matrix:
 cache:
     - composer.phar
     - '%LOCALAPPDATA%\Composer\files'
-    - '%PROGRAMDATA%\chocolatey\bin -> .appveyor.yml'
-    - '%PROGRAMDATA%\chocolatey\lib -> .appveyor.yml'
     - C:\php -> .appveyor.yml
 
 init:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `Client::captureEvent` not considering the `attach_stacktrace` option (#940)
+
 ## 2.2.6 (2019-12-18)
 
 - Fix remaining PHP 7.4 deprecations (#930)

--- a/src/Client.php
+++ b/src/Client.php
@@ -108,7 +108,7 @@ final class Client implements FlushableClientInterface
      */
     public function captureEvent(array $payload, ?Scope $scope = null): ?string
     {
-        $event = $this->prepareEvent($payload, $scope);
+        $event = $this->prepareEvent($payload, $scope, $this->options->shouldAttachStacktrace());
 
         if (null === $event) {
             return null;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.2
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Fixes #939: the `Client::captureEvent` method should consider the `attach_stacktrace`, instead it doesn't (it was done on purpose for some reason because there was a test for this, but I cannot remember/understand why we chose like that)