### PR TITLE
Add TYPO3 SDK integration package to the list of 3rd party vendors supporting SDK 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ The following integrations are available and maintained by members of the Sentry
 - [WordPress](https://wordpress.org/plugins/wp-sentry-integration/)
 - [ZendFramework](https://github.com/facile-it/sentry-module)
 - [SilverStripe](https://github.com/phptek/silverstripe-sentry)
+- [TYPO3](https://github.com/networkteam/sentry_client)
 - ... feel free to be famous, create a port to your favourite platform!
 
 ### 3rd party integrations using old SDK 1.x
 
 - [Neos CMS](https://github.com/networkteam/Netwokteam.Neos.SentryClient)
 - [OpenCart](https://github.com/BurdaPraha/oc_sentry)
-- [TYPO3](https://github.com/networkteam/sentry_client)
 
 ## Community
 


### PR DESCRIPTION
The TYPO3 client now uses sentry/sdk