### PR TITLE
Fix client creation with proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix client creation with proxy (#951)
+
 ## 2.3.0 (2020-01-08)
 
 - Add `in_app_include` option to whitelist paths that should be marked as part of the app (#909)

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -111,9 +111,9 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 $this->httpClient = new CurlHttpClient($this->responseFactory, $this->streamFactory, [
                     CURLOPT_PROXY => $options->getHttpProxy(),
                 ]);
+            } else {
+                throw new \RuntimeException('The "http_proxy" option requires either the "php-http/curl-client" or the "php-http/guzzle6-adapter" package to be installed.');
             }
-
-            throw new \RuntimeException('The "http_proxy" option requires either the "php-http/curl-client" or the "php-http/guzzle6-adapter" package to be installed.');
         }
 
         if (null === $httpClient) {


### PR DESCRIPTION
The exception has always been thrown, no matter if vendors were present or not.