### PR TITLE
do not auto-attach a backtrace when logging an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix client creation with proxy (#951)
 - Allow unsetting the stack trace on an `Event` by calling `Event::setStacktrace(null)` (#961)
+- Fix sending of both `event.stacktrace` and `event.exceptions` when `attach_stacktrace = true` (#960)
 
 ## 2.3.0 (2020-01-08)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -85,7 +85,7 @@ final class Client implements FlushableClientInterface
             'level' => $level,
         ];
 
-        $event = $this->prepareEvent($payload, $scope, $this->options->shouldAttachStacktrace());
+        $event = $this->prepareEvent($payload, $scope);
 
         if (null === $event) {
             return null;
@@ -111,7 +111,7 @@ final class Client implements FlushableClientInterface
      */
     public function captureEvent(array $payload, ?Scope $scope = null): ?string
     {
-        $event = $this->prepareEvent($payload, $scope, $this->options->shouldAttachStacktrace());
+        $event = $this->prepareEvent($payload, $scope);
 
         if (null === $event) {
             return null;
@@ -162,13 +162,12 @@ final class Client implements FlushableClientInterface
     /**
      * Assembles an event and prepares it to be sent of to Sentry.
      *
-     * @param array      $payload        the payload that will be converted to an Event
-     * @param Scope|null $scope          optional scope which enriches the Event
-     * @param bool       $withStacktrace True if the event should have and attached stacktrace
+     * @param array      $payload the payload that will be converted to an Event
+     * @param Scope|null $scope   optional scope which enriches the Event
      *
      * @return Event|null returns ready to send Event, however depending on options it can be discarded
      */
-    private function prepareEvent(array $payload, ?Scope $scope = null, bool $withStacktrace = false): ?Event
+    private function prepareEvent(array $payload, ?Scope $scope = null): ?Event
     {
         $sampleRate = $this->getOptions()->getSampleRate();
 
@@ -176,12 +175,7 @@ final class Client implements FlushableClientInterface
             return null;
         }
 
-        // when 'exception' is set, no backtrace should be auto-attached (#957)
-        if (
-            $withStacktrace
-            && !isset($payload['exception'])
-            && !isset($payload['stacktrace'])
-        ) {
+        if ($this->getOptions()->shouldAttachStacktrace() && !isset($payload['exception']) && !isset($payload['stacktrace'])) {
             $event = $this->eventFactory->createWithStacktrace($payload);
         } else {
             $event = $this->eventFactory->create($payload);

--- a/src/Client.php
+++ b/src/Client.php
@@ -85,13 +85,7 @@ final class Client implements FlushableClientInterface
             'level' => $level,
         ];
 
-        $event = $this->prepareEvent($payload, $scope);
-
-        if (null === $event) {
-            return null;
-        }
-
-        return $this->transport->send($event);
+        return $this->captureEvent($payload, $scope);
     }
 
     /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -176,7 +176,12 @@ final class Client implements FlushableClientInterface
             return null;
         }
 
-        if ($withStacktrace) {
+        // when 'exception' is set, no backtrace should be auto-attached (#957)
+        if (
+            $withStacktrace
+            && !isset($payload['exception'])
+            && !isset($payload['stacktrace'])
+        ) {
             $event = $this->eventFactory->createWithStacktrace($payload);
         } else {
             $event = $this->eventFactory->create($payload);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -166,13 +166,34 @@ class ClientTest extends TestCase
         $this->assertEquals('500a339f3ab2450b96dee542adf36ba7', $client->captureEvent($payload));
     }
 
-    public function captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider(): array
+    public function captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider(): \Generator
     {
-        return [
-            [true, [], true],
-            [false, [], false],
-            [true, ['exception' => new \Exception()], false],
-            [false, ['exception' => new \Exception()], false],
+        yield 'Stacktrace attached when attach_stacktrace = true and both payload.exception and payload.stacktrace are unset' => [
+            true,
+            [],
+            true,
+        ];
+
+        yield 'No stacktrace attached when attach_stacktrace = false' => [
+            false,
+            [],
+            false,
+        ];
+
+        yield 'No stacktrace attached when attach_stacktrace = true and payload.exception is set' => [
+            true,
+            [
+                'exception' => new \Exception(),
+            ],
+            false,
+        ];
+
+        yield 'No stacktrace attached when attach_stacktrace = false and payload.exception is set' => [
+            true,
+            [
+                'exception' => new \Exception(),
+            ],
+            false,
         ];
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -140,7 +140,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider
      */
-    public function testCaptureEventAttachesStacktraceAccordingToAttachStacktraceOption(bool $shouldAttachStacktrace): void
+    public function testCaptureEventAttachesStacktraceAccordingToAttachStacktraceOption(bool $attachStacktraceOption, array $payload, bool $shouldAttachStacktrace): void
     {
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
@@ -159,18 +159,20 @@ class ClientTest extends TestCase
             }))
             ->willReturn('500a339f3ab2450b96dee542adf36ba7');
 
-        $client = ClientBuilder::create(['attach_stacktrace' => $shouldAttachStacktrace])
+        $client = ClientBuilder::create(['attach_stacktrace' => $attachStacktraceOption])
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        $this->assertEquals('500a339f3ab2450b96dee542adf36ba7', $client->captureEvent([]));
+        $this->assertEquals('500a339f3ab2450b96dee542adf36ba7', $client->captureEvent($payload));
     }
 
     public function captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider(): array
     {
         return [
-            [true],
-            [false],
+            [true, [], true],
+            [false, [], false],
+            [true, ['exception' => new \Exception()], false],
+            [false, ['exception' => new \Exception()], false],
         ];
     }
 


### PR DESCRIPTION
this fixes #957.

The sentry server prefers the event's stacktrace over an attached exception's stacktrace, so if a stacktrace is attached to an event containing an exception, the web interface would show the backtrace to where the exception was captured rather than the exception's backtrace.