### PR TITLE
allow the stacktrace to be set to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix client creation with proxy (#951)
+- Allow unsetting the stack trace on an `Event` by calling `Event::setStacktrace(null)` (#961)
 
 ## 2.3.0 (2020-01-08)
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -552,9 +552,9 @@ final class Event implements \JsonSerializable
     /**
      * Sets the stacktrace that generated this event.
      *
-     * @param Stacktrace $stacktrace The stacktrace instance
+     * @param Stacktrace|null $stacktrace The stacktrace instance
      */
-    public function setStacktrace(Stacktrace $stacktrace): void
+    public function setStacktrace(?Stacktrace $stacktrace): void
     {
         $this->stacktrace = $stacktrace;
     }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -10,6 +10,7 @@ use Sentry\Breadcrumb;
 use Sentry\Client;
 use Sentry\Event;
 use Sentry\Severity;
+use Sentry\Stacktrace;
 use Sentry\Util\PHPVersion;
 
 /**
@@ -251,6 +252,20 @@ final class EventTest extends TestCase
             ['fingerprint', ['foo', 'bar'], ['fingerprint' => ['foo', 'bar']]],
             ['environment', 'foo', ['environment' => 'foo']],
         ];
+    }
+
+    public function testSetStacktrace(): void
+    {
+        $stacktrace = $this->createMock(Stacktrace::class);
+
+        $event = new Event();
+        $event->setStacktrace($stacktrace);
+
+        $this->assertSame($stacktrace, $event->getStacktrace());
+
+        $event->setStacktrace(null);
+
+        $this->assertNull($event->getStacktrace());
     }
 
     public function testEventJsonSerialization(): void


### PR DESCRIPTION
as part of fixing #957 application-side in a before_send hook, it turend out that even though the $stacktrace field is nullable, the setter didn't allow setting it to `null` because of an erroneous type hint

see [this comment](https://github.com/getsentry/sentry-php/issues/957#issuecomment-575385598) by @ste93cry 