### PR TITLE
Add timeout option to limit the request duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `timeout` option to limit the request duration
+
 ## 2.3.1 (2020-01-23)
 
 - Allow unsetting the stack trace on an `Event` by calling `Event::setStacktrace(null)` (#961)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,6 +35,9 @@ parameters:
             message: '/^Access to constant PROXY on an unknown class GuzzleHttp\\RequestOptions\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
+            message: '/^Access to constant TIMEOUT on an unknown class GuzzleHttp\\RequestOptions\.$/'
+            path: src/HttpClient/HttpClientFactory.php
+        -
             message: '/^Property Sentry\\HttpClient\\HttpClientFactory::\$httpClient \(Http\\Client\\HttpAsyncClient\|null\) does not accept Http\\Client\\Curl\\Client.$/'
             path: src/HttpClient/HttpClientFactory.php
         -

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -109,14 +109,15 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 $guzzleConfig = [];
 
                 if (null !== $options->getHttpProxy()) {
+                    /** @psalm-suppress UndefinedClass */
                     $guzzleConfig[GuzzleHttpClientOptions::PROXY] = $options->getHttpProxy();
                 }
 
                 if (null !== $options->getTimeout()) {
+                    /** @psalm-suppress UndefinedClass */
                     $guzzleConfig[GuzzleHttpClientOptions::TIMEOUT] = $options->getTimeout() / 1000;
                 }
 
-                /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $this->httpClient = GuzzleHttpClient::createWithConfig($guzzleConfig);
             } elseif (class_exists(CurlHttpClient::class)) {
                 $curlConfig = [];
@@ -129,7 +130,6 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                     $curlConfig[CURLOPT_TIMEOUT] = $options->getTimeout() / 1000;
                 }
 
-                /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $this->httpClient = new CurlHttpClient($this->responseFactory, $this->streamFactory, $curlConfig);
             } else {
                 throw new \RuntimeException('The "http_proxy" and "timeout" options require either the "php-http/curl-client" or the "php-http/guzzle6-adapter" package to be installed.');

--- a/src/Options.php
+++ b/src/Options.php
@@ -815,7 +815,7 @@ final class Options
             'send_default_pii' => false,
             'max_value_length' => 1024,
             'http_proxy' => null,
-            'timeout' => 0,
+            'timeout' => null,
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],

--- a/src/Options.php
+++ b/src/Options.php
@@ -221,6 +221,26 @@ final class Options
     }
 
     /**
+     * Gets the timeout in milliseconds. Zero means unlimited.
+     */
+    public function getTimeout(): ?int
+    {
+        return $this->options['timeout'];
+    }
+
+    /**
+     * Sets a timeout to avoid blocking Sentry threads because establishing a connection is taking too long.
+     *
+     * @param int $timeout The timeout in milliseconds (zero = unlimited)
+     */
+    public function setTimeout(int $timeout): void
+    {
+        $options = array_merge($this->options, ['timeout' => $timeout]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Gets the list of exception classes that should be ignored when sending
      * events to Sentry.
      *
@@ -795,6 +815,7 @@ final class Options
             'send_default_pii' => false,
             'max_value_length' => 1024,
             'http_proxy' => null,
+            'timeout' => 0,
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
@@ -825,6 +846,7 @@ final class Options
         $resolver->setAllowedTypes('default_integrations', 'bool');
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
+        $resolver->setAllowedTypes('timeout', ['null', 'int']);
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -99,4 +99,25 @@ final class HttpClientFactoryTest extends TestCase
             'http_proxy' => 'http://example.com',
         ]));
     }
+
+    public function testCreateThrowsIfTimeoutOptionIsUsedWithCustomHttpClient(): void
+    {
+        $httpClientFactory = new HttpClientFactory(
+            UriFactoryDiscovery::find(),
+            MessageFactoryDiscovery::find(),
+            StreamFactoryDiscovery::find(),
+            $this->createMock(HttpAsyncClientInterface::class),
+            'sentry.php.test',
+            '1.2.3'
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The "timeout" option does not work together with a custom HTTP client.');
+
+        $httpClientFactory->create(new Options([
+            'dsn' => 'http://public@example.com/sentry/1',
+            'default_integrations' => false,
+            'timeout' => 1500,
+        ]));
+    }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -70,6 +70,7 @@ final class OptionsTest extends TestCase
             ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
             ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
             ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
+            ['timeout', '1500', 'getTimeout', 'setTimeout'],
             ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
             ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
         ];

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -70,7 +70,7 @@ final class OptionsTest extends TestCase
             ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
             ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
             ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
-            ['timeout', '1500', 'getTimeout', 'setTimeout'],
+            ['timeout', 1500, 'getTimeout', 'setTimeout'],
             ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
             ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
         ];


### PR DESCRIPTION
Added the timeout option, similar to https://docs.sentry.io/clients/java/config/#timeout-advanced

Let me know if something is missing. I implemented tests like the ones for the http_proxy option.