### PR TITLE
Array and string offset access syntax with curly braces is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: php
 sudo: false
+dist: trusty
 php:
   - 5.4
   - 5.5

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.8.0",
         "phpunit/phpunit": "^4.8.35 || ^5.7",
-        "monolog/monolog": "*"
+        "monolog/monolog": "^1.0"
     },
     "require": {
         "php": "^5.3|^7.0",

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -328,7 +328,7 @@ class Raven_Client
         // we need app_path to have a trailing slash otherwise
         // base path detection becomes complex if the same
         // prefix is matched
-        if ($path{0} === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
+        if ($path[0] === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
             $path .= DIRECTORY_SEPARATOR;
         }
         return $path;

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -328,7 +328,7 @@ class Raven_Client
         // we need app_path to have a trailing slash otherwise
         // base path detection becomes complex if the same
         // prefix is matched
-        if ($path[0] === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
+        if (substr($path, 0,1) === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
             $path .= DIRECTORY_SEPARATOR;
         }
         return $path;

--- a/lib/Raven/Client.php
+++ b/lib/Raven/Client.php
@@ -328,7 +328,7 @@ class Raven_Client
         // we need app_path to have a trailing slash otherwise
         // base path detection becomes complex if the same
         // prefix is matched
-        if (substr($path, 0,1) === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
+        if (substr($path, 0, 1) === DIRECTORY_SEPARATOR && substr($path, -1) !== DIRECTORY_SEPARATOR) {
             $path .= DIRECTORY_SEPARATOR;
         }
         return $path;

--- a/lib/Raven/Compat.php
+++ b/lib/Raven/Compat.php
@@ -102,7 +102,7 @@ class Raven_Compat
      */
     public static function _json_encode($value, $depth = 513)
     {
-        if (ini_get('xdebug.extended_info') !== false) {
+        if (extension_loaded('xdebug')) {
             ini_set('xdebug.max_nesting_level', 2048);
         }
         return self::_json_encode_lowlevel($value, $depth);


### PR DESCRIPTION
I know that version 1.0 is not designated for php 7.4 but this deprecation is older . 