### PR TITLE
Fix the http_proxy option not being applied correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `http_proxy` option not being applied (#978)
+
 ## 2.3.1 (2020-01-23)
 
 - Allow unsetting the stack trace on an `Event` by calling `Event::setStacktrace(null)` (#961)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,9 +35,6 @@ parameters:
             message: '/^Access to constant PROXY on an unknown class GuzzleHttp\\RequestOptions\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
-            message: '/^Property Sentry\\HttpClient\\HttpClientFactory::\$httpClient \(Http\\Client\\HttpAsyncClient\|null\) does not accept Http\\Client\\Curl\\Client.$/'
-            path: src/HttpClient/HttpClientFactory.php
-        -
             message: '/^Access to an undefined property Sentry\\Integration\\IntegrationInterface::\$options\.$/'
             path: src/Integration/IgnoreErrorsIntegration.php
         -

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -103,12 +103,12 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         if (null === $httpClient && null !== $options->getHttpProxy()) {
             if (class_exists(GuzzleHttpClient::class)) {
                 /** @psalm-suppress InvalidPropertyAssignmentValue */
-                $this->httpClient = GuzzleHttpClient::createWithConfig([
+                $httpClient = GuzzleHttpClient::createWithConfig([
                     GuzzleHttpClientOptions::PROXY => $options->getHttpProxy(),
                 ]);
             } elseif (class_exists(CurlHttpClient::class)) {
                 /** @psalm-suppress InvalidPropertyAssignmentValue */
-                $this->httpClient = new CurlHttpClient($this->responseFactory, $this->streamFactory, [
+                $httpClient = new CurlHttpClient($this->responseFactory, $this->streamFactory, [
                     CURLOPT_PROXY => $options->getHttpProxy(),
                 ]);
             } else {


### PR DESCRIPTION
Fixes [sentry-laravel issue 328](https://github.com/getsentry/sentry-laravel/issues/328)

Proxy config being overwritten under certain circumstances.