### PR TITLE
Enforce a timeout for connecting to the server and for the requests instead of waiting indefinitely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enforce a timeout for connecting to the server and for the requests instead of waiting indefinitely (#979)
+
 ## 2.3.1 (2020-01-23)
 
 - Allow unsetting the stack trace on an `Event` by calling `Event::setStacktrace(null)` (#961)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -32,7 +32,7 @@ parameters:
             message: '/^Call to static method createWithConfig\(\) on an unknown class Http\\Adapter\\Guzzle6\\Client\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
-            message: '/^Access to constant PROXY on an unknown class GuzzleHttp\\RequestOptions\.$/'
+            message: '/^Access to constant (?:PROXY|TIMEOUT|CONNECT_TIMEOUT) on an unknown class GuzzleHttp\\RequestOptions\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
             message: '/^Property Sentry\\HttpClient\\HttpClientFactory::\$httpClient \(Http\\Client\\HttpAsyncClient\|null\) does not accept Http\\Client\\Curl\\Client.$/'

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -30,6 +30,17 @@ use Sentry\Options;
 final class HttpClientFactory implements HttpClientFactoryInterface
 {
     /**
+     * @var int The timeout of the request in seconds
+     */
+    private const DEFAULT_HTTP_TIMEOUT = 5;
+
+    /**
+     * @var int The default number of seconds to wait while trying to connect
+     *          to a server
+     */
+    private const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
+
+    /**
      * @var UriFactoryInterface The PSR-7 URI factory
      */
     private $uriFactory;
@@ -105,11 +116,15 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $this->httpClient = GuzzleHttpClient::createWithConfig([
                     GuzzleHttpClientOptions::PROXY => $options->getHttpProxy(),
+                    GuzzleHttpClientOptions::TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
+                    GuzzleHttpClientOptions::CONNECT_TIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
                 ]);
             } elseif (class_exists(CurlHttpClient::class)) {
                 /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $this->httpClient = new CurlHttpClient($this->responseFactory, $this->streamFactory, [
                     CURLOPT_PROXY => $options->getHttpProxy(),
+                    CURLOPT_TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
+                    CURLOPT_CONNECTTIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
                 ]);
             } else {
                 throw new \RuntimeException('The "http_proxy" option requires either the "php-http/curl-client" or the "php-http/guzzle6-adapter" package to be installed.');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

In #967 we decided to enforce a default value for both the timeouts of the connection to the server and for the requests to avoid the application to wait indefinitely while sending an event in the case something goes wrong. This PR is fixing this for both the HTTP clients supported out-of-the-box. To customize the values of these options it's still recommended to instantiate your own HTTP client and use it through the transport factory