### PR TITLE
Changed HttpTransport to use sync requests instead of promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Hard-limit concurrent requests in `HttpTransport` and removed pre-init of promises (fixes "too many open files" errors) (#981)
 - Fix `http_proxy` option not being applied (#978)
 
 ## 2.3.1 (2020-01-23)


### PR DESCRIPTION
The problem of the current implementation of HttpTransport is:

- In the `send()` function, the request is immediately initiated using `sendAsyncRequest()`
- This already opens file-descriptors and uses resources for the connection
- As we do not have an event-loop, the initiated connection "hangs" until the shutdown-function is reached and `cleanupPendingRequests()` finalizes the requests

For "normal" PHP scripts, this may not be a big problem, but:

- For long-running scripts the HTTP connection may **timeout in the meantime**
- When generating more events than allowed **maximum filedescriptors** (normally 1024) in one script run, then everything will crash/hang/whatever with really strange errors
- A lot of events will lead to **_much_ more memory usage** while script run (e.g. ~250MB for 1024 PHP-Notices)

This patch just puts the requests into pendingRequests directly instead of promises, and uses `sendRequest()` later instead of `sendAsyncRequest()`.

I also noticed the deprecation of "delaySendingUntilShutdown" and i saw the RFC for making it configurable in #910 - I don't know what the final goal would be - personally I prefer a configuration option as both scenarios have pro's and con's. And with this patch, the "delaySendingUntilShutdown" should lead to less problems.