### PR TITLE
Gzip encoding should not unnecessarily read entire stream

### DIFF
--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -129,7 +129,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         ];
 
         if ($options->isCompressionEnabled()) {
-            $httpClientPlugins[] = new GzipEncoderPlugin($this->streamFactory);
+            $httpClientPlugins[] = new GzipEncoderPlugin();
             $httpClientPlugins[] = new DecoderPlugin();
         }
 

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace Sentry\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin as PluginInterface;
-use Http\Discovery\StreamFactoryDiscovery;
-use Http\Message\StreamFactory as StreamFactoryInterface;
+use Http\Message\Encoding\GzipEncodeStream;
 use Http\Promise\Promise as PromiseInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -18,28 +17,15 @@ use Psr\Http\Message\RequestInterface;
 final class GzipEncoderPlugin implements PluginInterface
 {
     /**
-     * @var StreamFactoryInterface The PSR-17 stream factory
-     */
-    private $streamFactory;
-
-    /**
      * Constructor.
-     *
-     * @param StreamFactoryInterface|null $streamFactory The stream factory
      *
      * @throws \RuntimeException If the zlib extension is not enabled
      */
-    public function __construct(?StreamFactoryInterface $streamFactory = null)
+    public function __construct()
     {
         if (!\extension_loaded('zlib')) {
             throw new \RuntimeException('The "zlib" extension must be enabled to use this plugin.');
         }
-
-        if (null === $streamFactory) {
-            @trigger_error(sprintf('A PSR-17 stream factory is needed as argument of the constructor of the "%s" class since version 2.1.3 and will be required in 3.0.', self::class), E_USER_DEPRECATED);
-        }
-
-        $this->streamFactory = $streamFactory ?? StreamFactoryDiscovery::find();
     }
 
     /**
@@ -53,14 +39,10 @@ final class GzipEncoderPlugin implements PluginInterface
             $requestBody->rewind();
         }
 
-        $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
-
-        if (false === $encodedBody) {
-            throw new \RuntimeException('Failed to GZIP-encode the request body.');
-        }
+        $encodedStream = new GzipEncodeStream($requestBody);
 
         $request = $request->withHeader('Content-Encoding', 'gzip');
-        $request = $request->withBody($this->streamFactory->createStream($encodedBody));
+        $request = $request->withBody($encodedStream);
 
         return $next($request);
     }

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\Tests\HttpClient\Plugin;
 
 use Http\Discovery\MessageFactoryDiscovery;
-use Http\Discovery\StreamFactoryDiscovery;
 use Http\Promise\Promise as PromiseInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -18,7 +18,7 @@ final class GzipEncoderPluginTest extends TestCase
      */
     public function testHandleRequest(): void
     {
-        $plugin = new GzipEncoderPlugin(StreamFactoryDiscovery::find());
+        $plugin = new GzipEncoderPlugin();
         $nextCallableCalled = false;
         $expectedPromise = $this->createMock(PromiseInterface::class);
         $request = MessageFactoryDiscovery::find()->createRequest(


### PR DESCRIPTION
Reading the entire stream will cause the stream to be loaded into memory, which may take up a lot of memory.

Instead, gzip the stream on demand by wrapping it into a `\Http\Message\Encoding\GzipEncodeStream`. This removes the necessity to read the entire stream at once. 