### PR TITLE
Log internal debug and error messages to a PSR-3 compatible logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Enforce a timeout for connecting to the server and for the requests instead of waiting indefinitely (#979)
 - Add `RequestFetcherInterface` to allow customizing the request data attached to the logged event (#984)
+- Log internal debug and error messages to a PSR-3 compatible logger (#989)
 
 ## 2.3.2 (2020-03-06)
 

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-message-implementation": "^1.0",
+        "psr/log": "^1.1",
         "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.0",
         "symfony/polyfill-uuid": "^1.13.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-message-implementation": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.0",
         "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.0",
         "symfony/polyfill-uuid": "^1.13.1"
     },

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ namespace Sentry;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sentry\Integration\Handler;
 use Sentry\Integration\IgnoreErrorsIntegration;
 use Sentry\Integration\IntegrationInterface;
@@ -47,7 +48,7 @@ final class Client implements FlushableClientInterface
     private $eventFactory;
 
     /**
-     * @var LoggerInterface|null The PSR-3 logger
+     * @var LoggerInterface The PSR-3 logger
      */
     private $logger;
 
@@ -72,7 +73,7 @@ final class Client implements FlushableClientInterface
         $this->transport = $transport;
         $this->eventFactory = $eventFactory;
         $this->integrations = Handler::setupIntegrations($options->getIntegrations());
-        $this->logger = $logger;
+        $this->logger = $logger ?? new NullLogger();
     }
 
     /**
@@ -171,38 +172,36 @@ final class Client implements FlushableClientInterface
      */
     private function prepareEvent(array $payload, ?Scope $scope = null): ?Event
     {
-        $sampleRate = $this->options->getSampleRate();
-
-        if ($sampleRate < 1 && mt_rand(1, 100) / 100.0 > $sampleRate) {
-            if (null !== $this->logger) {
-                $this->logger->info('The event will be discarded because it has been sampled.');
-            }
-
-            return null;
-        }
-
         if ($this->options->shouldAttachStacktrace() && !isset($payload['exception']) && !isset($payload['stacktrace'])) {
             $event = $this->eventFactory->createWithStacktrace($payload);
         } else {
             $event = $this->eventFactory->create($payload);
         }
 
+        $sampleRate = $this->options->getSampleRate();
+
+        if ($sampleRate < 1 && mt_rand(1, 100) / 100.0 > $sampleRate) {
+            $this->logger->info('The event will be discarded because it has been sampled.', ['event' => $event]);
+
+            return null;
+        }
+
         if (null !== $scope) {
+            $previousEvent = $event;
             $event = $scope->applyToEvent($event, $payload);
 
             if (null === $event) {
-                if (null !== $this->logger) {
-                    $this->logger->info('The event will be discarded because one of the event processors returned `null`.');
-                }
+                $this->logger->info('The event will be discarded because one of the event processors returned `null`.', ['event' => $previousEvent]);
 
                 return null;
             }
         }
 
+        $previousEvent = $event;
         $event = ($this->options->getBeforeSendCallback())($event);
 
-        if (null === $event && null !== $this->logger) {
-            $this->logger->info('The event will be discarded because the "before_send" callback returned `null`.');
+        if (null === $event) {
+            $this->logger->info('The event will be discarded because the "before_send" callback returned `null`.', ['event' => $previousEvent]);
         }
 
         return $event;

--- a/src/ClientBuilderInterface.php
+++ b/src/ClientBuilderInterface.php
@@ -8,6 +8,7 @@ use Http\Client\Common\Plugin as PluginInterface;
 use Http\Client\HttpAsyncClient;
 use Http\Message\MessageFactory as MessageFactoryInterface;
 use Http\Message\UriFactory as UriFactoryInterface;
+use Psr\Log\LoggerInterface;
 use Sentry\Serializer\RepresentationSerializerInterface;
 use Sentry\Serializer\SerializerInterface;
 use Sentry\Transport\TransportFactoryInterface;
@@ -19,6 +20,7 @@ use Sentry\Transport\TransportInterface;
  * @author Stefano Arlandini <sarlandini@alice.it>
  *
  * @method self setTransportFactory(TransportFactoryInterface $transportFactory)
+ * @method self setLogger(LoggerInterface $logger)
  */
 interface ClientBuilderInterface
 {

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -53,6 +53,8 @@ final class GzipEncoderPlugin implements PluginInterface
             $requestBody->rewind();
         }
 
+        // Instead of using a stream filter we have to compress the whole request
+        // body in one go to work around a PHP bug. See https://github.com/getsentry/sentry-php/pull/877
         $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
 
         if (false === $encodedBody) {

--- a/src/Integration/Handler.php
+++ b/src/Integration/Handler.php
@@ -7,6 +7,8 @@ namespace Sentry\Integration;
 /**
  * This class handles the state of already installed integrations.
  * It makes sure to call {@link IntegrationInterface::setupOnce} only once per integration.
+ *
+ * @internal since version 2.4
  */
 final class Handler
 {

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -27,7 +27,7 @@ final class Handler extends AbstractProcessingHandler
      * Constructor.
      *
      * @param HubInterface $hub    The hub to which errors are reported
-     * @param int          $level  The minimum logging level at which this
+     * @param int|string   $level  The minimum logging level at which this
      *                             handler will be triggered
      * @param bool         $bubble Whether the messages that are handled can
      *                             bubble up the stack or not
@@ -45,7 +45,7 @@ final class Handler extends AbstractProcessingHandler
     protected function write(array $record): void
     {
         $payload = [
-            'level' => $this->getSeverityFromLevel($record['level']),
+            'level' => self::getSeverityFromLevel($record['level']),
             'message' => $record['message'],
             'logger' => 'monolog.' . $record['channel'],
         ];
@@ -79,7 +79,7 @@ final class Handler extends AbstractProcessingHandler
      *
      * @param int $level The Monolog log level
      */
-    private function getSeverityFromLevel(int $level): Severity
+    private static function getSeverityFromLevel(int $level): Severity
     {
         switch ($level) {
             case Logger::DEBUG:

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -182,7 +182,7 @@ final class Hub implements HubInterface
             return false;
         }
 
-        $breadcrumb = \call_user_func($beforeBreadcrumbCallback, $breadcrumb);
+        $breadcrumb = $beforeBreadcrumbCallback($breadcrumb);
 
         if (null !== $breadcrumb) {
             $this->getScope()->addBreadcrumb($breadcrumb, $maxBreadcrumbs);

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -316,7 +316,7 @@ final class Scope
         }
 
         foreach (array_merge(self::$globalEventProcessors, $this->eventProcessors) as $processor) {
-            $event = \call_user_func($processor, $event, $payload);
+            $event = $processor($event, $payload);
 
             if (null === $event) {
                 return null;

--- a/src/Transport/DefaultTransportFactory.php
+++ b/src/Transport/DefaultTransportFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Transport;
 
 use Http\Message\MessageFactory as MessageFactoryInterface;
+use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\Options;
 
@@ -25,15 +26,22 @@ final class DefaultTransportFactory implements TransportFactoryInterface
     private $httpClientFactory;
 
     /**
+     * @var LoggerInterface|null A PSR-3 logger
+     */
+    private $logger;
+
+    /**
      * Constructor.
      *
      * @param MessageFactoryInterface    $messageFactory    The PSR-7 message factory
      * @param HttpClientFactoryInterface $httpClientFactory The HTTP client factory
+     * @param LoggerInterface|null       $logger            A PSR-3 logger
      */
-    public function __construct(MessageFactoryInterface $messageFactory, HttpClientFactoryInterface $httpClientFactory)
+    public function __construct(MessageFactoryInterface $messageFactory, HttpClientFactoryInterface $httpClientFactory, ?LoggerInterface $logger = null)
     {
         $this->messageFactory = $messageFactory;
         $this->httpClientFactory = $httpClientFactory;
+        $this->logger = $logger;
     }
 
     /**
@@ -50,7 +58,8 @@ final class DefaultTransportFactory implements TransportFactoryInterface
             $this->httpClientFactory->create($options),
             $this->messageFactory,
             true,
-            false
+            false,
+            $this->logger
         );
     }
 }

--- a/src/Util/PHPVersion.php
+++ b/src/Util/PHPVersion.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Sentry\Util;
 
+/**
+ * This class is an helper utility to parse the version of PHP and convert it
+ * to a normalized form.
+ *
+ * @internal since version 2.4
+ */
 final class PHPVersion
 {
     private const VERSION_PARSING_REGEX = '/^(?<base>\d\.\d\.\d{1,2})(?<extra>-(beta|rc)-?(\d+)?(-dev)?)?/i';

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -344,7 +344,9 @@ class ClientTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('info')
-            ->with('The event will be discarded because it has been sampled.');
+            ->with('The event will be discarded because it has been sampled.', $this->callback(static function (array $context): bool {
+                return isset($context['event']) && $context['event'] instanceof Event;
+            }));
 
         $client = ClientBuilder::create(['sample_rate' => 0])
             ->setLogger($logger)
@@ -359,7 +361,9 @@ class ClientTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('info')
-            ->with('The event will be discarded because the "before_send" callback returned `null`.');
+            ->with('The event will be discarded because the "before_send" callback returned `null`.', $this->callback(static function (array $context): bool {
+                return isset($context['event']) && $context['event'] instanceof Event;
+            }));
 
         $options = [
             'before_send' => static function () {
@@ -380,7 +384,9 @@ class ClientTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
             ->method('info')
-            ->with('The event will be discarded because one of the event processors returned `null`.');
+            ->with('The event will be discarded because one of the event processors returned `null`.', $this->callback(static function (array $context): bool {
+                return isset($context['event']) && $context['event'] instanceof Event;
+            }));
 
         $client = ClientBuilder::create([])
             ->setLogger($logger)

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -10,6 +10,7 @@ use Http\Promise\FulfilledPromise;
 use Http\Promise\RejectedPromise;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sentry\Event;
 use Sentry\Exception\MissingProjectIdCredentialException;
 use Sentry\Options;
@@ -26,14 +27,18 @@ final class HttpTransportTest extends TestCase
     {
         $promise = new FulfilledPromise('foo');
 
-        /** @var HttpAsyncClient|MockObject $httpClient */
+        /** @var HttpAsyncClient&MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
         $httpClient->expects($this->once())
             ->method('sendAsyncRequest')
             ->willReturn($promise);
 
-        $config = new Options(['dsn' => 'http://public@example.com/sentry/1']);
-        $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find(), true, false);
+        $transport = new HttpTransport(
+            new Options(['dsn' => 'http://public@example.com/sentry/1']),
+            $httpClient,
+            MessageFactoryDiscovery::find(),
+            true
+        );
 
         $this->assertAttributeEmpty('pendingRequests', $transport);
 
@@ -50,14 +55,18 @@ final class HttpTransportTest extends TestCase
     {
         $promise = new RejectedPromise(new \Exception());
 
-        /** @var HttpAsyncClient|MockObject $httpClient */
+        /** @var HttpAsyncClient&MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
         $httpClient->expects($this->once())
             ->method('sendAsyncRequest')
             ->willReturn($promise);
 
-        $config = new Options(['dsn' => 'http://public@example.com/sentry/1']);
-        $transport = new HttpTransport($config, $httpClient, MessageFactoryDiscovery::find(), false, false);
+        $transport = new HttpTransport(
+            new Options(['dsn' => 'http://public@example.com/sentry/1']),
+            $httpClient,
+            MessageFactoryDiscovery::find(),
+            false
+        );
 
         $transport->send(new Event());
 
@@ -70,8 +79,81 @@ final class HttpTransportTest extends TestCase
 
         /** @var HttpAsyncClient&MockObject $httpClient */
         $httpClient = $this->createMock(HttpAsyncClient::class);
-        $transport = new HttpTransport(new Options(), $httpClient, MessageFactoryDiscovery::find(), true, false);
+        $transport = new HttpTransport(
+            new Options(),
+            $httpClient,
+            MessageFactoryDiscovery::find(),
+            false
+        );
 
         $transport->send(new Event());
+    }
+
+    public function testSendLogsErrorMessageIfSendingFailed(): void
+    {
+        $exception = new \Exception('foo');
+
+        /** @var LoggerInterface&MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with('Failed to send the event to Sentry. Reason: "foo".', ['exception' => $exception]);
+
+        /** @var HttpAsyncClient&MockObject $httpClient */
+        $httpClient = $this->createMock(HttpAsyncClient::class);
+        $httpClient->expects($this->once())
+            ->method('sendAsyncRequest')
+            ->willReturn(new RejectedPromise($exception));
+
+        $transport = new HttpTransport(
+            new Options(['dsn' => 'http://public@example.com/sentry/1']),
+            $httpClient,
+            MessageFactoryDiscovery::find(),
+            false,
+            true,
+            $logger
+        );
+
+        $transport->send(new Event());
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecationMessage Delaying the sending of the events using the "Sentry\Transport\HttpTransport" class is deprecated since version 2.2 and will not work in 3.0.
+     */
+    public function testCloseLogsErrorMessageIfSendingFailed(): void
+    {
+        $exception = new \Exception('foo');
+
+        /** @var LoggerInterface&MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))
+            ->method('error')
+            ->with('Failed to send the event to Sentry. Reason: "foo".', ['exception' => $exception]);
+
+        /** @var HttpAsyncClient&MockObject $httpClient */
+        $httpClient = $this->createMock(HttpAsyncClient::class);
+        $httpClient->expects($this->exactly(2))
+            ->method('sendAsyncRequest')
+            ->willReturnOnConsecutiveCalls(
+                new RejectedPromise($exception),
+                new RejectedPromise($exception)
+            );
+
+        $transport = new HttpTransport(
+            new Options(['dsn' => 'http://public@example.com/sentry/1']),
+            $httpClient,
+            MessageFactoryDiscovery::find(),
+            true,
+            true,
+            $logger
+        );
+
+        // Send multiple events to assert that they all gets the chance of
+        // being sent regardless of which fails
+        $transport->send(new Event());
+        $transport->send(new Event());
+        $transport->close();
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Starting from the work done in #907, I've added support for logging some debug and error messages to a PSR-3 compatible logger. In the future we may want to log additional info, for example when we will implement rate limit handling for the `HttpTransport` transport