### PR TITLE
Use is_iterable instead of is_array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enforce a timeout for connecting to the server and for the requests instead of waiting indefinitely (#979)
 - Add `RequestFetcherInterface` to allow customizing the request data attached to the logged event (#984)
 - Log internal debug and error messages to a PSR-3 compatible logger (#989)
+- Make `AbstractSerializer` to accept `Traversable` values using `is_iterable` instead of `is_array` (#991)
 
 ## 2.3.2 (2020-03-06)
 

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -103,7 +103,7 @@ abstract class AbstractSerializer
                 return $this->serializeCallableWithoutTypeHint($value);
             }
 
-            if (\is_array($value)) {
+            if (is_iterable($value)) {
                 $serializedArray = [];
 
                 foreach ($value as $k => $v) {

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -30,6 +30,24 @@ final class SerializerTest extends AbstractSerializerTest
     /**
      * @dataProvider serializeAllObjectsDataProvider
      */
+    public function testTraversablesAreArrays(bool $serializeAllObjects): void
+    {
+        $serializer = $this->createSerializer();
+
+        if ($serializeAllObjects) {
+            $serializer->setSerializeAllObjects(true);
+        }
+
+        $content = [1, 2, 3];
+        $traversable = new \ArrayIterator($content);
+        $result = $this->invokeSerialization($serializer, $traversable);
+
+        $this->assertSame([1, 2, 3], $result);
+    }
+
+    /**
+     * @dataProvider serializeAllObjectsDataProvider
+     */
     public function testIntsAreInts(bool $serializeAllObjects): void
     {
         $serializer = $this->createSerializer();


### PR DESCRIPTION
What about using `is_iterable` to allow Traversable objects to be processed automatically?

If the check is only to be able to do a foreach, I think it's safe.