### PR TITLE
Extract all the logic related to the DSN to its own class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Log internal debug and error messages to a PSR-3 compatible logger (#989)
 - Make `AbstractSerializer` to accept `Traversable` values using `is_iterable` instead of `is_array` (#991)
 - Refactor the `ModulesIntegration` integration to improve its code and its tests (#990)
+- Extract the parsing and validation logic of the DSN into its own value object (#995)
 
 ## 2.3.2 (2020-03-06)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,6 +38,33 @@ parameters:
         -
             message: '/^Call to an undefined method Sentry\\Integration\\IntegrationInterface::processEvent\(\)\.$/'
             path: src/Integration/ModulesIntegration.php
+        -
+            message: '/^Parameter #2 \$str of function explode expects string, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #1 \$haystack of function strrpos expects string, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #1 \$str of function substr expects string, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #2 \$host of class Sentry\\Dsn constructor expects string, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #3 \$port of class Sentry\\Dsn constructor expects int, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #5 \$path of class Sentry\\Dsn constructor expects string, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #6 \$publicKey of class Sentry\\Dsn constructor expects string, int\|string given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #7 \$secretKey of class Sentry\\Dsn constructor expects string\|null, int\|string\|null given\.$/'
+            path: src/Dsn.php
+        -
+            message: '/^Parameter #1 \$c of function ctype_digit expects int\|string, string\|null given\.$/'
+            path: src/Dsn.php
     excludes_analyse:
         - tests/resources
         - tests/Fixtures

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -183,7 +183,7 @@ final class Dsn
     /**
      * Gets the URL of the API endpoint to use to post an event to Sentry.
      */
-    public function getApiEndpointUrl(): string
+    public function getStoreApiEndpointUrl(): string
     {
         $url = $this->scheme . '://' . $this->host;
 

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+/**
+ * This class represents a Sentry DSN that can be obtained from the Settings
+ * page of a project.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class Dsn
+{
+    /**
+     * @var string The protocol to be used to access the resource
+     */
+    private $scheme;
+
+    /**
+     * @var string The host that holds the resource
+     */
+    private $host;
+
+    /**
+     * @var int The port on which the resource is exposed
+     */
+    private $port;
+
+    /**
+     * @var string The public key to authenticate the SDK
+     */
+    private $publicKey;
+
+    /**
+     * @var string|null The secret key to authenticate the SDK
+     */
+    private $secretKey;
+
+    /**
+     * @var int The ID of the resource to access
+     */
+    private $projectId;
+
+    /**
+     * @var string The specific resource that the web client wants to access
+     */
+    private $path;
+
+    /**
+     * Class constructor.
+     *
+     * @param string      $scheme    The protocol to be used to access the resource
+     * @param string      $host      The host that holds the resource
+     * @param int         $port      The port on which the resource is exposed
+     * @param int         $projectId The ID of the resource to access
+     * @param string      $path      The specific resource that the web client wants to access
+     * @param string      $publicKey The public key to authenticate the SDK
+     * @param string|null $secretKey The secret key to authenticate the SDK
+     */
+    private function __construct(string $scheme, string $host, int $port, int $projectId, string $path, string $publicKey, ?string $secretKey)
+    {
+        $this->scheme = $scheme;
+        $this->host = $host;
+        $this->port = $port;
+        $this->publicKey = $publicKey;
+        $this->secretKey = $secretKey;
+        $this->path = $path;
+        $this->projectId = $projectId;
+    }
+
+    /**
+     * Creates an instance of this class by parsing the given string.
+     *
+     * @param string $value The string to parse
+     */
+    public static function createFromString(string $value): self
+    {
+        $parsedDsn = parse_url($value);
+
+        if (false === $parsedDsn) {
+            throw new \InvalidArgumentException(sprintf('The "%s" DSN is invalid.', $value));
+        }
+
+        foreach (['scheme', 'host', 'path', 'user'] as $component) {
+            if (!isset($parsedDsn[$component]) || (isset($parsedDsn[$component]) && empty($parsedDsn[$component]))) {
+                throw new \InvalidArgumentException(sprintf('The "%s" DSN must contain a scheme, a host, a user and a path component.', $value));
+            }
+        }
+
+        if (isset($parsedDsn['pass']) && empty($parsedDsn['pass'])) {
+            throw new \InvalidArgumentException(sprintf('The "%s" DSN must contain a valid secret key.', $value));
+        }
+
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
+        if (!\in_array($parsedDsn['scheme'], ['http', 'https'], true)) {
+            throw new \InvalidArgumentException(sprintf('The scheme of the "%s" DSN must be either "http" or "https".', $value));
+        }
+
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
+        $segmentPaths = explode('/', $parsedDsn['path']);
+        $projectId = array_pop($segmentPaths);
+
+        if (!ctype_digit($projectId)) {
+            throw new \InvalidArgumentException('"%s" DSN must contain a valid project ID.');
+        }
+
+        $lastSlashPosition = strrpos($parsedDsn['path'], '/');
+        $path = $parsedDsn['path'];
+
+        if (false !== $lastSlashPosition) {
+            $path = substr($parsedDsn['path'], 0, $lastSlashPosition);
+        }
+
+        /** @psalm-suppress PossiblyUndefinedArrayOffset */
+        return new self(
+            $parsedDsn['scheme'],
+            $parsedDsn['host'],
+            $parsedDsn['port'] ?? ('http' === $parsedDsn['scheme'] ? 80 : 443),
+            (int) $projectId,
+            $path,
+            $parsedDsn['user'],
+            $parsedDsn['pass'] ?? null
+        );
+    }
+
+    /**
+     * Gets the protocol to be used to access the resource.
+     */
+    public function getScheme(): string
+    {
+        return $this->scheme;
+    }
+
+    /**
+     * Gets the host that holds the resource.
+     */
+    public function getHost(): string
+    {
+        return $this->host;
+    }
+
+    /**
+     * Gets the port on which the resource is exposed.
+     */
+    public function getPort(): int
+    {
+        return $this->port;
+    }
+
+    /**
+     * Gets the specific resource that the web client wants to access.
+     */
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Gets the ID of the resource to access.
+     */
+    public function getProjectId(): int
+    {
+        return $this->projectId;
+    }
+
+    /**
+     * Gets the public key to authenticate the SDK.
+     */
+    public function getPublicKey(): string
+    {
+        return $this->publicKey;
+    }
+
+    /**
+     * Gets the secret key to authenticate the SDK.
+     */
+    public function getSecretKey(): ?string
+    {
+        return $this->secretKey;
+    }
+
+    /**
+     * Gets the URL of the API endpoint to use to post an event to Sentry.
+     */
+    public function getApiEndpointUrl(): string
+    {
+        $url = $this->scheme . '://' . $this->host;
+
+        if (('http' === $this->scheme && 80 !== $this->port) || ('https' === $this->scheme && 443 !== $this->port)) {
+            $url .= ':' . $this->port;
+        }
+
+        if (null !== $this->path) {
+            $url .= $this->path;
+        }
+
+        $url .= '/api/' . $this->projectId . '/store/';
+
+        return $url;
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+     */
+    public function __toString(): string
+    {
+        $url = $this->scheme . '://' . $this->publicKey;
+
+        if (null !== $this->secretKey) {
+            $url .= ':' . $this->secretKey;
+        }
+
+        $url .= '@' . $this->host;
+
+        if (('http' === $this->scheme && 80 !== $this->port) || ('https' === $this->scheme && 443 !== $this->port)) {
+            $url .= ':' . $this->port;
+        }
+
+        if (null !== $this->path) {
+            $url .= $this->path;
+        }
+
+        $url .= '/' . $this->projectId;
+
+        return $url;
+    }
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -8,6 +8,8 @@ namespace Sentry\Exception;
  * This interface must be implemented by all exception classes of this library.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
+ *
+ * @deprecated since version 2.4, to be removed in 3.0
  */
 interface ExceptionInterface
 {

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -8,8 +8,6 @@ namespace Sentry\Exception;
  * This interface must be implemented by all exception classes of this library.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
- *
- * @deprecated since version 2.4, to be removed in 3.0
  */
 interface ExceptionInterface
 {

--- a/src/Exception/MissingProjectIdCredentialException.php
+++ b/src/Exception/MissingProjectIdCredentialException.php
@@ -6,9 +6,13 @@ namespace Sentry\Exception;
 
 use Throwable;
 
+@trigger_error(sprintf('The %s class is deprecated since version 2.4 and will be removed in 3.0.', MissingProjectIdCredentialException::class), E_USER_DEPRECATED);
+
 /**
  * This exception is thrown during the sending of an event when the project ID
  * is not provided in the DSN.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0
  */
 final class MissingProjectIdCredentialException extends \RuntimeException
 {

--- a/src/Exception/MissingPublicKeyCredentialException.php
+++ b/src/Exception/MissingPublicKeyCredentialException.php
@@ -6,9 +6,13 @@ namespace Sentry\Exception;
 
 use Throwable;
 
+@trigger_error(sprintf('The %s class is deprecated since version 2.4 and will be removed in 3.0.', MissingProjectIdCredentialException::class), E_USER_DEPRECATED);
+
 /**
  * This exception is thrown during the sending of an event when the public key
  * is not provided in the DSN.
+ *
+ * @deprecated since version 2.4, to be removed in 3.0
  */
 final class MissingPublicKeyCredentialException extends \RuntimeException
 {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -7,7 +7,6 @@ namespace Sentry\HttpClient;
 use GuzzleHttp\RequestOptions as GuzzleHttpClientOptions;
 use Http\Adapter\Guzzle6\Client as GuzzleHttpClient;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
-use Http\Client\Common\Plugin\BaseUriPlugin;
 use Http\Client\Common\Plugin\DecoderPlugin;
 use Http\Client\Common\Plugin\ErrorPlugin;
 use Http\Client\Common\Plugin\HeaderSetPlugin;
@@ -101,7 +100,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
      */
     public function create(Options $options): HttpAsyncClientInterface
     {
-        if (null === $options->getDsn()) {
+        if (null === $options->getDsn(false)) {
             throw new \RuntimeException('Cannot create an HTTP client without the Sentry DSN set in the options.');
         }
 
@@ -136,7 +135,6 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         }
 
         $httpClientPlugins = [
-            new BaseUriPlugin($this->uriFactory->createUri($options->getDsn())),
             new HeaderSetPlugin(['User-Agent' => $this->sdkIdentifier . '/' . $this->sdkVersion]),
             new AuthenticationPlugin(new SentryAuthentication($options, $this->sdkIdentifier, $this->sdkVersion)),
             new RetryPlugin(['retries' => $options->getSendAttempts()]),

--- a/src/HttpClient/PluggableHttpClientFactory.php
+++ b/src/HttpClient/PluggableHttpClientFactory.php
@@ -36,6 +36,8 @@ final class PluggableHttpClientFactory implements HttpClientFactoryInterface
      */
     public function __construct(HttpClientFactoryInterface $decoratedHttpClientFactory, array $httpClientPlugins)
     {
+        @trigger_error(sprintf('The "%s" class is deprecated since version 2.3 and will be removed in 3.0.', self::class), E_USER_DEPRECATED);
+
         $this->decoratedHttpClientFactory = $decoratedHttpClientFactory;
         $this->httpClientPlugins = $httpClientPlugins;
     }

--- a/src/Severity.php
+++ b/src/Severity.php
@@ -164,7 +164,7 @@ final class Severity
     }
 
     /**
-     * {@inheritdoc}
+     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
      */
     public function __toString(): string
     {

--- a/src/Transport/DefaultTransportFactory.php
+++ b/src/Transport/DefaultTransportFactory.php
@@ -49,7 +49,7 @@ final class DefaultTransportFactory implements TransportFactoryInterface
      */
     public function create(Options $options): TransportInterface
     {
-        if (null === $options->getDsn()) {
+        if (null === $options->getDsn(false)) {
             return new NullTransport();
         }
 

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -11,8 +11,8 @@ use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
 use Http\Message\RequestFactory as RequestFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Sentry\Dsn;
 use Sentry\Event;
-use Sentry\Exception\MissingProjectIdCredentialException;
 use Sentry\Options;
 use Sentry\Util\JSON;
 
@@ -25,9 +25,9 @@ use Sentry\Util\JSON;
 final class HttpTransport implements TransportInterface, ClosableTransportInterface
 {
     /**
-     * @var Options The Raven client configuration
+     * @var Options The Sentry client options
      */
-    private $config;
+    private $options;
 
     /**
      * @var HttpAsyncClientInterface The HTTP client
@@ -60,7 +60,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
     /**
      * Constructor.
      *
-     * @param Options                  $config                    The Raven client configuration
+     * @param Options                  $options                   The Sentry client configuration
      * @param HttpAsyncClientInterface $httpClient                The HTTP client
      * @param RequestFactoryInterface  $requestFactory            The PSR-7 request factory
      * @param bool                     $delaySendingUntilShutdown This flag controls whether to delay
@@ -74,7 +74,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
      * @param LoggerInterface|null     $logger                    An instance of a PSR-3 logger
      */
     public function __construct(
-        Options $config,
+        Options $options,
         HttpAsyncClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
         bool $delaySendingUntilShutdown = true,
@@ -85,7 +85,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
             @trigger_error(sprintf('Delaying the sending of the events using the "%s" class is deprecated since version 2.2 and will not work in 3.0.', __CLASS__), E_USER_DEPRECATED);
         }
 
-        $this->config = $config;
+        $this->options = $options;
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->delaySendingUntilShutdown = $delaySendingUntilShutdown;
@@ -111,15 +111,15 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
      */
     public function send(Event $event): ?string
     {
-        $projectId = $this->config->getProjectId();
+        $dsn = $this->options->getDsn(false);
 
-        if (null === $projectId) {
-            throw new MissingProjectIdCredentialException();
+        if (!$dsn instanceof Dsn) {
+            throw new \RuntimeException(sprintf('The DSN option must be set to use the "%s" transport.', self::class));
         }
 
         $request = $this->requestFactory->createRequest(
             'POST',
-            sprintf('/api/%d/store/', $projectId),
+            $dsn->getApiEndpointUrl(),
             ['Content-Type' => 'application/json'],
             JSON::encode($event->toArray())
         );

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -119,7 +119,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
 
         $request = $this->requestFactory->createRequest(
             'POST',
-            $dsn->getApiEndpointUrl(),
+            $dsn->getStoreApiEndpointUrl(),
             ['Content-Type' => 'application/json'],
             JSON::encode($event->toArray())
         );

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\Transport;
 
 use Sentry\Event;
-use Sentry\Exception\MissingProjectIdCredentialException;
 
 /**
  * This interface must be implemented by all classes willing to provide a way
@@ -21,8 +20,6 @@ interface TransportInterface
      * @param Event $event The event
      *
      * @return string|null Returns the ID of the event or `null` if it failed to be sent
-     *
-     * @throws MissingProjectIdCredentialException If the project ID is missing in the DSN
      */
     public function send(Event $event): ?string;
 }

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -7,9 +7,7 @@ namespace Sentry\Tests;
 use Http\Client\Common\Plugin as PluginInterface;
 use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
 use Http\Discovery\MessageFactoryDiscovery;
-use Http\Discovery\UriFactoryDiscovery;
 use Http\Message\MessageFactory as MessageFactoryInterface;
-use Http\Message\UriFactory as UriFactoryInterface;
 use Http\Promise\FulfilledPromise;
 use Http\Promise\Promise as PromiseInterface;
 use Jean85\PrettyVersions;
@@ -54,26 +52,6 @@ final class ClientBuilderTest extends TestCase
         $transport = $this->getObjectAttribute($clientBuilder->getClient(), 'transport');
 
         $this->assertInstanceOf(NullTransport::class, $transport);
-    }
-
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Method Sentry\ClientBuilder::setUriFactory() is deprecated since version 2.3 and will be removed in 3.0.
-     */
-    public function testSetUriFactory(): void
-    {
-        /** @var UriFactoryInterface&MockObject $uriFactory */
-        $uriFactory = $this->createMock(UriFactoryInterface::class);
-        $uriFactory->expects($this->once())
-            ->method('createUri')
-            ->willReturn(UriFactoryDiscovery::find()->createUri('http://www.example.com'));
-
-        $client = ClientBuilder::create(['dsn' => 'http://public@example.com/sentry/1'])
-            ->setUriFactory($uriFactory)
-            ->getClient();
-
-        $client->captureMessage('foo');
     }
 
     /**

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Dsn;
+
+final class DsnTest extends TestCase
+{
+    /**
+     * @dataProvider createFromStringDataProvider
+     */
+    public function testCreateFromString(
+        string $value,
+        string $expectedScheme,
+        string $expectedHost,
+        int $expectedPort,
+        string $expectedPublicKey,
+        ?string $expectedSecretKey,
+        int $expectedProjectId,
+        string $expectedPath
+    ): void {
+        $dsn = Dsn::createFromString($value);
+
+        $this->assertSame($expectedScheme, $dsn->getScheme());
+        $this->assertSame($expectedHost, $dsn->getHost());
+        $this->assertSame($expectedPort, $dsn->getPort());
+        $this->assertSame($expectedPublicKey, $dsn->getPublicKey());
+        $this->assertSame($expectedSecretKey, $dsn->getSecretKey());
+        $this->assertSame($expectedProjectId, $dsn->getProjectId());
+        $this->assertSame($expectedPath, $dsn->getPath());
+    }
+
+    public function createFromStringDataProvider(): \Generator
+    {
+        yield [
+            'http://public@example.com/sentry/1',
+            'http',
+            'example.com',
+            80,
+            'public',
+            null,
+            1,
+            '/sentry',
+        ];
+
+        yield [
+            'http://public@example.com/1',
+            'http',
+            'example.com',
+            80,
+            'public',
+            null,
+            1,
+            '',
+        ];
+
+        yield [
+            'http://public:secret@example.com/1',
+            'http',
+            'example.com',
+            80,
+            'public',
+            'secret',
+            1,
+            '',
+        ];
+
+        yield [
+            'http://public@example.com:80/1',
+            'http',
+            'example.com',
+            80,
+            'public',
+            null,
+            1,
+            '',
+        ];
+
+        yield [
+            'http://public@example.com:8080/1',
+            'http',
+            'example.com',
+            8080,
+            'public',
+            null,
+            1,
+            '',
+        ];
+
+        yield [
+            'https://public@example.com/1',
+            'https',
+            'example.com',
+            443,
+            'public',
+            null,
+            1,
+            '',
+        ];
+
+        yield [
+            'https://public@example.com:443/1',
+            'https',
+            'example.com',
+            443,
+            'public',
+            null,
+            1,
+            '',
+        ];
+
+        yield [
+            'https://public@example.com:4343/1',
+            'https',
+            'example.com',
+            4343,
+            'public',
+            null,
+            1,
+            '',
+        ];
+    }
+
+    /**
+     * @dataProvider createFromStringThrowsExceptionIfValueIsInvalidDataProvider
+     */
+    public function testCreateFromStringThrowsExceptionIfValueIsInvalid(string $value, string $expectedExceptionMessage): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        Dsn::createFromString($value);
+    }
+
+    public function createFromStringThrowsExceptionIfValueIsInvalidDataProvider(): \Generator
+    {
+        yield 'invalid DSN' => [
+            ':',
+            'The ":" DSN is invalid.',
+        ];
+
+        yield 'missing scheme' => [
+            '://public@example.com/sentry/1',
+            'The "://public@example.com/sentry/1" DSN must contain a scheme, a host, a user and a path component.',
+        ];
+
+        yield 'missing public key' => [
+            'http://:secret@example.com/sentry/1',
+            'The "http://:secret@example.com/sentry/1" DSN must contain a scheme, a host, a user and a path component.',
+        ];
+
+        yield 'missing secret key' => [
+            'http://public:@example.com/sentry/1',
+            'The "http://public:@example.com/sentry/1" DSN must contain a valid secret key.',
+        ];
+
+        yield 'missing host' => [
+            '/sentry/1',
+            'The "/sentry/1" DSN must contain a scheme, a host, a user and a path component.',
+        ];
+
+        yield 'missing path' => [
+            'http://public@example.com',
+            'The "http://public@example.com" DSN must contain a scheme, a host, a user and a path component.',
+        ];
+
+        yield 'unsupported scheme' => [
+            'tcp://public:secret@example.com/1',
+            'The scheme of the "tcp://public:secret@example.com/1" DSN must be either "http" or "https".',
+        ];
+    }
+}

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -172,4 +172,62 @@ final class DsnTest extends TestCase
             'The scheme of the "tcp://public:secret@example.com/1" DSN must be either "http" or "https".',
         ];
     }
+
+    /**
+     * @dataProvider getStoreApiEndpointUrlDataProvider
+     */
+    public function testGetStoreApiEndpointUrl(string $value, string $expectedUrl): void
+    {
+        $dsn = Dsn::createFromString($value);
+
+        $this->assertSame($expectedUrl, $dsn->getStoreApiEndpointUrl());
+    }
+
+    public function getStoreApiEndpointUrlDataProvider(): \Generator
+    {
+        yield [
+            'http://public@example.com/sentry/1',
+            'http://example.com/sentry/api/1/store/',
+        ];
+
+        yield [
+            'http://public@example.com/1',
+            'http://example.com/api/1/store/',
+        ];
+
+        yield [
+            'http://public@example.com:8080/sentry/1',
+            'http://example.com:8080/sentry/api/1/store/',
+        ];
+
+        yield [
+            'https://public@example.com/sentry/1',
+            'https://example.com/sentry/api/1/store/',
+        ];
+
+        yield [
+            'https://public@example.com:4343/sentry/1',
+            'https://example.com:4343/sentry/api/1/store/',
+        ];
+    }
+
+    /**
+     * @dataProvider toStringDataProvider
+     */
+    public function testToString(string $value): void
+    {
+        $this->assertSame($value, (string) Dsn::createFromString($value));
+    }
+
+    public function toStringDataProvider(): array
+    {
+        return [
+            ['http://public@example.com/sentry/1'],
+            ['http://public:secret@example.com/sentry/1'],
+            ['http://public@example.com/1'],
+            ['http://public@example.com:8080/sentry/1'],
+            ['https://public@example.com/sentry/1'],
+            ['https://public@example.com:4343/sentry/1'],
+        ];
+    }
 }

--- a/tests/Exception/MissingProjectIdCredentialExceptionTest.php
+++ b/tests/Exception/MissingProjectIdCredentialExceptionTest.php
@@ -9,6 +9,10 @@ use Sentry\Exception\MissingProjectIdCredentialException;
 
 final class MissingProjectIdCredentialExceptionTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecationMessage The Sentry\Exception\MissingProjectIdCredentialException class is deprecated since version 2.4 and will be removed in 3.0.
+     */
     public function testGetMessage(): void
     {
         $exception = new MissingProjectIdCredentialException();

--- a/tests/Exception/MissingPublicKeyCredentialExceptionTest.php
+++ b/tests/Exception/MissingPublicKeyCredentialExceptionTest.php
@@ -9,6 +9,10 @@ use Sentry\Exception\MissingPublicKeyCredentialException;
 
 final class MissingPublicKeyCredentialExceptionTest extends TestCase
 {
+    /**
+     * @group legacy
+     * @expectedDeprecationMessage The Sentry\Exception\MissingPublicKeyCredentialExceptionTest class is deprecated since version 2.4 and will be removed in 3.0.
+     */
     public function testGetMessage(): void
     {
         $exception = new MissingPublicKeyCredentialException();

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -37,15 +37,15 @@ final class HttpClientFactoryTest extends TestCase
             'enable_compression' => $isCompressionEnabled,
         ]));
 
-        $httpClient->sendAsyncRequest(MessageFactoryDiscovery::find()->createRequest('POST', '/foo', [], 'foo bar'));
+        $httpClient->sendAsyncRequest(MessageFactoryDiscovery::find()->createRequest('POST', 'http://example.com/sentry/foo', [], 'foo bar'));
 
         /** @var RequestInterface|bool $httpRequest */
         $httpRequest = $mockHttpClient->getLastRequest();
 
         $this->assertInstanceOf(RequestInterface::class, $httpRequest);
         $this->assertSame('http://example.com/sentry/foo', (string) $httpRequest->getUri());
-        $this->assertSame('sentry.php.test/1.2.3', (string) $httpRequest->getHeaderLine('User-Agent'));
-        $this->assertSame('Sentry sentry_version=7, sentry_client=sentry.php.test/1.2.3, sentry_key=public', (string) $httpRequest->getHeaderLine('X-Sentry-Auth'));
+        $this->assertSame('sentry.php.test/1.2.3', $httpRequest->getHeaderLine('User-Agent'));
+        $this->assertSame('Sentry sentry_version=7, sentry_client=sentry.php.test/1.2.3, sentry_key=public', $httpRequest->getHeaderLine('X-Sentry-Auth'));
         $this->assertSame($expectedRequestBody, (string) $httpRequest->getBody());
     }
 

--- a/tests/HttpClient/PluggableHttpClientFactoryTest.php
+++ b/tests/HttpClient/PluggableHttpClientFactoryTest.php
@@ -14,6 +14,9 @@ use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\HttpClient\PluggableHttpClientFactory;
 use Sentry\Options;
 
+/**
+ * @group legacy
+ */
 final class PluggableHttpClientFactoryTest extends TestCase
 {
     public function testCreate(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

I realized that the `Options` class was getting bigger and bigger and that some logic related to how the DSN is parsed was leaking in it, breaking the single-responsibility principle. Plus, there are currently some other issues:

- There is no proper way to pass around the DSN as it's stored as a simple `string`
- There is no way to retrieve some specific information like the port or the server in an independent manner. We are currently exposing only the public key, the secret key and the host where the events should be sent to

This led to me to think about refactoring the parsing logic to extract it into a value object. A few workarounds had to be taken to maintain BC that can be safely removed in `3.0`, but the code should look clean and readable anyway