### PR TITLE
Fix typos

### DIFF
--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -7,7 +7,7 @@ namespace Sentry;
 use Sentry\Exception\InvalidArgumentException;
 
 /**
- * This class stores all the informations about a breadcrumb.
+ * This class stores all the information about a breadcrumb.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -436,11 +436,11 @@ final class ErrorHandler
         } catch (\Throwable $previousExceptionHandlerException) {
             // This `catch` statement is here to forcefully override the
             // $previousExceptionHandlerException variable with the exception
-            // we just catched
+            // we just caught
         }
 
         // If the instance of the exception we're handling is the same as the one
-        // catched from the previous exception handler then we give it back to the
+        // caught from the previous exception handler then we give it back to the
         // native PHP handler to prevent an infinite loop
         if ($exception === $previousExceptionHandlerException) {
             // Disable the fatal error handler or the error will be reported twice

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\Integration;
 
-use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Sentry\Event;

--- a/src/Serializer/RepresentationSerializer.php
+++ b/src/Serializer/RepresentationSerializer.php
@@ -14,6 +14,7 @@ class RepresentationSerializer extends AbstractSerializer implements Representat
      * {@inheritdoc}
      *
      * @psalm-suppress InvalidReturnType
+     * @psalm-suppress InvalidReturnStatement
      */
     public function representationSerialize($value)
     {


### PR DESCRIPTION
Hi,

This tiny PR will fix : 

- 1 typo in `src/Breadcrumb.php`
- 2 typos in `src/ErrorHandler.php`



Best! :robot: