### PR TITLE
jean85/pretty-package-versions <1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.6",
-        "jean85/pretty-package-versions": "^1.2",
+        "jean85/pretty-package-versions": ">=1.2 <1.4",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
         "php-http/discovery": "^1.6.1",


### PR DESCRIPTION
jean85/pretty-package-versions version 1.4 dropped support for composer 1.x

currently running "composer outdated --strict -m" returns that version is available, but it is not installed as `jean85/pretty-package-versions 1.4.0 requires composer-runtime-api ^2.0 -> no matching package found.`
