### PR TITLE
Add the FrameContextifierIntegration integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Refactor the `ModulesIntegration` integration to improve its code and its tests (#990)
 - Extract the parsing and validation logic of the DSN into its own value object (#995)
 - Support passing either a Httplug or PSR-17 stream factory to the `GzipEncoderPlugin` class (#1012)
-- Add the `FrameContextifierIntegration` integration and deprecate the `context_lines` option (#1011)
+- Add the `FrameContextifierIntegration` integration (#1011)
 - Add missing validation for the `context_lines` option and fix its behavior when passing `null` to make it working as described in the documentation (#1003)
 
 ## 2.3.2 (2020-03-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Refactor the `ModulesIntegration` integration to improve its code and its tests (#990)
 - Extract the parsing and validation logic of the DSN into its own value object (#995)
 - Support passing either a Httplug or PSR-17 stream factory to the `GzipEncoderPlugin` class (#1012)
+- Add the `FrameContextifierIntegration` integration and deprecate the `context_lines` option (#1011)
 - Add missing validation for the `context_lines` option and fix its behavior when passing `null` to make it working as described in the documentation (#1003)
 
 ## 2.3.2 (2020-03-06)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,43 +8,22 @@ parameters:
         - '/Argument of an invalid type object supplied for foreach, only iterables are supported/'
         - "/^Parameter #1 \\$function of function register_shutdown_function expects callable\\(\\): void, 'register_shutdown…' given\\.$/"
         -
-            message: /^Cannot assign offset 'os' to array\|string\.$/
-            path: src/Event.php
-        -
-            message: '/^array\|string does not accept array<string, string>\.$/'
-            path: src/Event.php
-        -
             message: '/^Argument of an invalid type array\|object supplied for foreach, only iterables are supported\.$/'
             path: src/Util/JSON.php
         -
             message: '/^Access to constant (?:PROXY|TIMEOUT|CONNECT_TIMEOUT) on an unknown class GuzzleHttp\\RequestOptions\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
-            message: '/^Parameter #2 \$str of function explode expects string, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #1 \$haystack of function strrpos expects string, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #1 \$str of function substr expects string, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #2 \$host of class Sentry\\Dsn constructor expects string, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #3 \$port of class Sentry\\Dsn constructor expects int, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #5 \$path of class Sentry\\Dsn constructor expects string, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #6 \$publicKey of class Sentry\\Dsn constructor expects string, int\|string given\.$/'
-            path: src/Dsn.php
-        -
-            message: '/^Parameter #7 \$secretKey of class Sentry\\Dsn constructor expects string\|null, int\|string\|null given\.$/'
-            path: src/Dsn.php
-        -
             message: '/^Parameter #1 \$c of function ctype_digit expects int\|string, string\|null given\.$/'
+            path: src/Dsn.php
+        -
+            message: "/^Offset 'scheme' does not exist on array\\(\\?'scheme' => string, \\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string\\)\\.$/"
+            path: src/Dsn.php
+        -
+            message: "/^Offset 'path' does not exist on array\\(\\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string, 'scheme' => 'http'|'https'\\)\\.$/"
+            path: src/Dsn.php
+        -
+            message: "/^Offset 'user' does not exist on array\\('scheme' => 'http'\\|'https', \\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string\\)\\.$/"
             path: src/Dsn.php
         -
             message: '/^Method Sentry\\Monolog\\Handler::write\(\) has parameter \$record with no value type specified in iterable type array\.$/'
@@ -54,6 +33,12 @@ parameters:
             path: src/Serializer/RepresentationSerializer.php
         -
             message: '/^Method Sentry\\Client::getIntegration\(\) should return T of Sentry\\Integration\\IntegrationInterface\|null but returns Sentry\\Integration\\IntegrationInterface\|null\.$/'
+            path: src/Client.php
+        -
+            message: '/^Method Sentry\\EventFactoryInterface::createWithStacktrace\(\) invoked with 2 parameters, 1 required\.$/'
+            path: src/Client.php
+        -
+            message: '/^Method Sentry\\EventFactoryInterface::create\(\) invoked with 2 parameters, 1 required\.$/'
             path: src/Client.php
     excludes_analyse:
         - tests/resources

--- a/src/Client.php
+++ b/src/Client.php
@@ -167,8 +167,6 @@ final class Client implements FlushableClientInterface
      *
      * @param array<string, mixed> $payload The payload that will be converted to an Event
      * @param Scope|null           $scope   Optional scope which enriches the Event
-     *
-     * @return Event|null returns ready to send Event, however depending on options it can be discarded
      */
     private function prepareEvent(array $payload, ?Scope $scope = null): ?Event
     {

--- a/src/Event.php
+++ b/src/Event.php
@@ -531,7 +531,7 @@ final class Event implements \JsonSerializable
     /**
      * Gets the exception.
      *
-     * @return array<string, mixed>
+     * @return array<int, array<string, mixed>>
      *
      * @psalm-return list<array{
      *     type: class-string,
@@ -545,9 +545,9 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Sets the exception.
+     * Sets the exceptions.
      *
-     * @param array<int, array<string, mixed>> $exceptions The exception
+     * @param array<int, array<string, mixed>> $exceptions The exceptions
      *
      * @psalm-param list<array{
      *     type: class-string,

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -61,15 +61,18 @@ final class EventFactory implements EventFactoryInterface
      */
     public function createWithStacktrace(array $payload): Event
     {
-        $event = $this->create($payload);
-
-        if (!$event->getStacktrace()) {
-            $stacktrace = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS), __FILE__, __LINE__);
-
-            $event->setStacktrace($stacktrace);
+        if (!isset($payload['stacktrace']) || !$payload['stacktrace'] instanceof Stacktrace) {
+            $payload['stacktrace'] = Stacktrace::createFromBacktrace(
+                $this->options,
+                $this->serializer,
+                $this->representationSerializer,
+                debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS),
+                __FILE__,
+                __LINE__ - 6
+            );
         }
 
-        return $event;
+        return $this->create($payload);
     }
 
     /**
@@ -120,8 +123,10 @@ final class EventFactory implements EventFactoryInterface
     /**
      * Stores the given exception in the passed event.
      *
-     * @param Event      $event     The event that will be enriched with the exception
-     * @param \Throwable $exception The exception that will be processed and added to the event
+     * @param Event      $event     The event that will be enriched with the
+     *                              exception
+     * @param \Throwable $exception The exception that will be processed and
+     *                              added to the event
      */
     private function addThrowableToEvent(Event $event, \Throwable $exception): void
     {

--- a/src/Integration/FrameContextifierIntegration.php
+++ b/src/Integration/FrameContextifierIntegration.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Integration;
+
+use Psr\Log\LoggerInterface;
+use Sentry\Event;
+use Sentry\SentrySdk;
+use Sentry\Stacktrace;
+use Sentry\State\Scope;
+
+/**
+ * This integration reads excerpts of code around the line that originated an
+ * error.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class FrameContextifierIntegration implements IntegrationInterface
+{
+    /**
+     * @var int The maximum number of lines of code to read
+     */
+    private $contextLines;
+
+    /**
+     * @var LoggerInterface|null A PSR-3 logger
+     */
+    private $logger;
+
+    /**
+     * Creates a new instance of this integration.
+     *
+     * @param int             $contextLines The maximum number of lines of code to read
+     * @param LoggerInterface $logger       A PSR-3 logger
+     */
+    public function __construct(int $contextLines = 5, ?LoggerInterface $logger = null)
+    {
+        if ($contextLines < 0) {
+            throw new \InvalidArgumentException(sprintf('The value of the $maxLinesToFetch argument must be greater than or equal to 0. Got: "%d".', $contextLines));
+        }
+
+        $this->contextLines = $contextLines;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setupOnce(): void
+    {
+        Scope::addGlobalEventProcessor(static function (Event $event): Event {
+            $client = SentrySdk::getCurrentHub()->getClient();
+
+            // Avoid doing double work if the deprecated `context_lines` option
+            // is still in use. Since the option can change at runtime, it's safer
+            // to check its value here every time rather than when deciding whether
+            // the integration should be added or not to the client
+            if (null === $client || null !== $client->getOptions()->getContextLines(false)) {
+                return $event;
+            }
+
+            $integration = $client->getIntegration(self::class);
+
+            if (null === $integration) {
+                return $event;
+            }
+
+            if (null !== $event->getStacktrace()) {
+                $integration->addContextToStacktraceFrames($event->getStacktrace());
+            }
+
+            foreach ($event->getExceptions() as $exception) {
+                if (!isset($exception['stacktrace'])) {
+                    continue;
+                }
+
+                $integration->addContextToStacktraceFrames($exception['stacktrace']);
+            }
+
+            return $event;
+        });
+    }
+
+    /**
+     * Contextifies the frames of the given stacktrace.
+     *
+     * @param Stacktrace $stacktrace The stacktrace object
+     */
+    private function addContextToStacktraceFrames(Stacktrace $stacktrace): void
+    {
+        foreach ($stacktrace->getFrames() as $frame) {
+            if ($frame->isInternal()) {
+                continue;
+            }
+
+            $sourceCodeExcerpt = $this->getSourceCodeExcerpt($frame->getAbsoluteFilePath(), $frame->getLine());
+
+            $frame->setPreContext($sourceCodeExcerpt['pre_context']);
+            $frame->setContextLine($sourceCodeExcerpt['context_line']);
+            $frame->setPostContext($sourceCodeExcerpt['post_context']);
+        }
+    }
+
+    /**
+     * Gets an excerpt of the source code around a given line.
+     *
+     * @param string $filePath   The file path
+     * @param int    $lineNumber The line to centre about
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     pre_context: string[],
+     *     context_line: string|null,
+     *     post_context: string[]
+     * }
+     */
+    private function getSourceCodeExcerpt(string $filePath, int $lineNumber): array
+    {
+        $frame = [
+            'pre_context' => [],
+            'context_line' => null,
+            'post_context' => [],
+        ];
+
+        $target = max(0, ($lineNumber - ($this->contextLines + 1)));
+        $currentLineNumber = $target + 1;
+
+        try {
+            $file = new \SplFileObject($filePath);
+            $file->seek($target);
+
+            while (!$file->eof()) {
+                /** @var string $line */
+                $line = $file->current();
+                $line = rtrim($line, "\r\n");
+
+                if ($currentLineNumber === $lineNumber) {
+                    $frame['context_line'] = $line;
+                } elseif ($currentLineNumber < $lineNumber) {
+                    $frame['pre_context'][] = $line;
+                } elseif ($currentLineNumber > $lineNumber) {
+                    $frame['post_context'][] = $line;
+                }
+
+                ++$currentLineNumber;
+
+                if ($currentLineNumber > $lineNumber + $this->contextLines) {
+                    break;
+                }
+
+                $file->next();
+            }
+        } catch (\Throwable $exception) {
+            if (null !== $this->logger) {
+                $this->logger->warning(sprintf('Failed to get the source code excerpt for the file "%s".', $filePath));
+            }
+        }
+
+        return $frame;
+    }
+}

--- a/src/Options.php
+++ b/src/Options.php
@@ -144,18 +144,9 @@ final class Options
 
     /**
      * Gets the number of lines of code context to capture, or null if none.
-     *
-     * @param bool $throwDeprecation Whether to throw a deprecation error when
-     *                               this function is called
-     *
-     * @deprecated since version 2.4, to be removed in 3.0
      */
-    public function getContextLines(bool $throwDeprecation = true): ?int
+    public function getContextLines(): ?int
     {
-        if ($throwDeprecation) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 2.4 and will be removed in 3.0. Use the "Sentry\Integration\FrameContextifierIntegration" integration instead.', __METHOD__), E_USER_DEPRECATED);
-        }
-
         return $this->options['context_lines'];
     }
 
@@ -163,8 +154,6 @@ final class Options
      * Sets the number of lines of code context to capture, or null if none.
      *
      * @param int|null $contextLines The number of lines of code
-     *
-     * @deprecated since version 2.4, to be removed in 3.0
      */
     public function setContextLines(?int $contextLines): void
     {
@@ -814,7 +803,7 @@ final class Options
             'prefixes' => explode(PATH_SEPARATOR, get_include_path()),
             'sample_rate' => 1,
             'attach_stacktrace' => false,
-            'context_lines' => null,
+            'context_lines' => 5,
             'enable_compression' => true,
             'environment' => $_SERVER['SENTRY_ENVIRONMENT'] ?? null,
             'project_root' => null,
@@ -957,15 +946,9 @@ final class Options
      *
      * @param SymfonyOptions $options The options
      * @param int|null       $value   The actual value of the option
-     *
-     * @deprecated since version 2.4, to be removed in 3.0
      */
     private function normalizeContextLinesOption(SymfonyOptions $options, ?int $value): ?int
     {
-        if (null !== $value) {
-            @trigger_error('The "context_lines" option is deprecated since version 2.4 and will be removed in 3.0. Use the "Sentry\Integration\FrameContextifierIntegration" integration instead.', E_USER_DEPRECATED);
-        }
-
         return $value;
     }
 
@@ -1072,8 +1055,6 @@ final class Options
      * Validates that the value passed to the "context_lines" option is valid.
      *
      * @param int|null $contextLines The value to validate
-     *
-     * @deprecated since version 2.4, to be removed in 3.0
      */
     private function validateContextLinesOption(?int $contextLines): bool
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -869,7 +869,6 @@ final class Options
         $resolver->setAllowedValues('context_lines', \Closure::fromCallable([$this, 'validateContextLinesOption']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
-        $resolver->setNormalizer('context_lines', \Closure::fromCallable([$this, 'normalizeContextLinesOption']));
         $resolver->setNormalizer('project_root', function (SymfonyOptions $options, ?string $value) {
             if (null === $value) {
                 return null;
@@ -938,18 +937,6 @@ final class Options
         }
 
         return Dsn::createFromString($value);
-    }
-
-    /**
-     * Normalizes the value of the "context_lines" option and throws a deprecation
-     * warning to favor the integration instead.
-     *
-     * @param SymfonyOptions $options The options
-     * @param int|null       $value   The actual value of the option
-     */
-    private function normalizeContextLinesOption(SymfonyOptions $options, ?int $value): ?int
-    {
-        return $value;
     }
 
     /**

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -21,6 +21,7 @@ use Sentry\FlushableClientInterface;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
+use Sentry\Integration\FrameContextifierIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\RequestIntegration;
 use Sentry\Integration\TransactionIntegration;
@@ -210,6 +211,7 @@ final class ClientBuilderTest extends TestCase
                     ExceptionListenerIntegration::class,
                     RequestIntegration::class,
                     TransactionIntegration::class,
+                    FrameContextifierIntegration::class,
                 ],
             ],
             [
@@ -221,6 +223,7 @@ final class ClientBuilderTest extends TestCase
                     ExceptionListenerIntegration::class,
                     RequestIntegration::class,
                     TransactionIntegration::class,
+                    FrameContextifierIntegration::class,
                     StubIntegration::class,
                 ],
             ],

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -69,7 +69,7 @@ class ClientTest extends TestCase
     /**
      * @dataProvider captureExceptionDoesNothingIfExcludedExceptionsOptionMatchesDataProvider
      */
-    public function testCaptureExceptionDoesNothingIfExcludedExceptionsOptionMatches(bool $shouldCapture, string $excluded, \Throwable $thrown): void
+    public function testCaptureExceptionDoesNothingIfExcludedExceptionsOptionMatches(bool $shouldCapture, string $excluded, \Throwable $thrownException): void
     {
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
@@ -88,7 +88,7 @@ class ClientTest extends TestCase
             ->getClient();
 
         SentrySdk::getCurrentHub()->bindClient($client);
-        SentrySdk::getCurrentHub()->captureException($thrown);
+        SentrySdk::getCurrentHub()->captureException($thrownException);
     }
 
     public function captureExceptionDoesNothingIfExcludedExceptionsOptionMatchesDataProvider(): array

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -262,6 +262,27 @@ class ClientTest extends TestCase
     /**
      * @group legacy
      *
+     * @dataProvider captureEventThrowsDeprecationErrorIfContextLinesOptionIsNotNullAndFrameContextifierIntegrationIsNotUsedDataProvider
+     *
+     * @expectedDeprecation Relying on the "Sentry\Stacktrace" class to contexify the frames of the stacktrace is deprecated since version 2.4 and will stop working in 3.0. Set the $shouldReadSourceCodeExcerpts parameter to "false" and use the "Sentry\Integration\FrameContextifierIntegration" integration instead.
+     */
+    public function testCaptureEventThrowsDeprecationErrorIfContextLinesOptionIsNotNullAndFrameContextifierIntegrationIsNotUsed(array $payload): void
+    {
+        ClientBuilder::create(['attach_stacktrace' => true, 'default_integrations' => false])
+            ->getClient()
+            ->captureEvent($payload);
+    }
+
+    public function captureEventThrowsDeprecationErrorIfContextLinesOptionIsNotNullAndFrameContextifierIntegrationIsNotUsedDataProvider(): \Generator
+    {
+        yield [[]];
+
+        yield [['exception' => new \Exception()]];
+    }
+
+    /**
+     * @group legacy
+     *
      * @requires OSFAMILY Linux
      */
     public function testAppPathLinux(): void

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -133,7 +133,7 @@ class EventFactoryTest extends TestCase
             '1.2.3'
         );
 
-        $event = $eventFactory->create(['exception' => $exception]);
+        $event = $eventFactory->create(['exception' => $exception], false);
         $expectedData = [
             [
                 'type' => \Exception::class,
@@ -164,7 +164,7 @@ class EventFactoryTest extends TestCase
             '1.2.3'
         );
 
-        $event = $eventFactory->create(['exception' => $exception]);
+        $event = $eventFactory->create(['exception' => $exception], false);
 
         $this->assertTrue(Severity::error()->isEqualTo($event->getLevel()));
     }
@@ -182,7 +182,7 @@ class EventFactoryTest extends TestCase
             '1.2.3'
         );
 
-        $event = $eventFactory->createWithStacktrace([]);
+        $event = $eventFactory->createWithStacktrace([], false);
         $stacktrace = $event->getStacktrace();
 
         $this->assertInstanceOf(Stacktrace::class, $stacktrace);
@@ -194,5 +194,63 @@ class EventFactoryTest extends TestCase
             'src' . \DIRECTORY_SEPARATOR . 'EventFactory.php',
             ltrim($lastFrame->getFile(), \DIRECTORY_SEPARATOR)
         );
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider createThrowsDeprecationErrorIfLastArgumentIsNotSetToFalseDataProvider
+     *
+     * @expectedDeprecation Relying on the "Sentry\Stacktrace" class to contexify the frames of the stacktrace is deprecated since version 2.4 and will stop working in 3.0. Set the $shouldReadSourceCodeExcerpts parameter to "false" and use the "Sentry\Integration\FrameContextifierIntegration" integration instead.
+     */
+    public function testCreateThrowsDeprecationErrorIfLastArgumentIsNotSetToFalse(array ...$constructorArguments): void
+    {
+        $options = new Options();
+        $eventFactory = new EventFactory(
+            new Serializer($options),
+            $this->createMock(RepresentationSerializerInterface::class),
+            $options,
+            'sentry.sdk.identifier',
+            '1.2.3',
+            ...$constructorArguments
+        );
+
+        $eventFactory->create(['exception' => new \Exception()]);
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider createThrowsDeprecationErrorIfLastArgumentIsNotSetToFalseDataProvider
+     *
+     * @expectedDeprecation Relying on the "Sentry\Stacktrace" class to contexify the frames of the stacktrace is deprecated since version 2.4 and will stop working in 3.0. Set the $shouldReadSourceCodeExcerpts parameter to "false" and use the "Sentry\Integration\FrameContextifierIntegration" integration instead.
+     */
+    public function testCreateWithStacktraceThrowsDeprecationErrorIfLastArgumentIsNotSetToFalse(array ...$constructorArguments): void
+    {
+        $options = new Options();
+        $eventFactory = new EventFactory(
+            new Serializer($options),
+            $this->createMock(RepresentationSerializerInterface::class),
+            $options,
+            'sentry.sdk.identifier',
+            '1.2.3',
+            ...$constructorArguments
+        );
+
+        $eventFactory->createWithStacktrace([]);
+    }
+
+    public function createThrowsDeprecationErrorIfLastArgumentIsNotSetToFalseDataProvider(): \Generator
+    {
+        yield [[true]];
+
+        yield [[1]];
+
+        yield [['foo']];
+
+        yield [[new class() {
+        }]];
+
+        yield [[]];
     }
 }

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -56,7 +56,7 @@ final class GzipEncoderPluginTest extends TestCase
      *
      * @expectedDeprecation A PSR-17 stream factory is needed as argument of the constructor of the "Sentry\HttpClient\Plugin\GzipEncoderPlugin" class since version 2.1.3 and will be required in 3.0.
      */
-    public function testConstructorThrowsDeprecationIfNoStreamFactoryIsProvided(): void
+    public function testConstructorThrowsDeprecationErrorIfNoStreamFactoryIsProvided(): void
     {
         new GzipEncoderPlugin();
     }

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Integration;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\Integration\FrameContextifierIntegration;
+use Sentry\Options;
+use Sentry\SentrySdk;
+use Sentry\Serializer\RepresentationSerializerInterface;
+use Sentry\Serializer\SerializerInterface;
+use Sentry\Stacktrace;
+use Sentry\State\Scope;
+use function Sentry\withScope;
+
+final class FrameContextifierIntegrationTest extends TestCase
+{
+    /**
+     * @var MockObject&SerializerInterface
+     */
+    private $serializer;
+
+    /**
+     * @var MockObject&RepresentationSerializerInterface
+     */
+    private $representationSerializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = $this->createMock(SerializerInterface::class);
+        $this->representationSerializer = $this->createMock(RepresentationSerializerInterface::class);
+    }
+
+    public function testConstructorThrowsIfMaxLinesToFetchIsNotGreaterThanOrEqualToZero(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The value of the $maxLinesToFetch argument must be greater than or equal to 0. Got: "-1".');
+
+        new FrameContextifierIntegration(-1);
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider invokeDataProvider
+     */
+    public function testInvoke(string $fixtureFilePath, int $lineNumber, int $contextLines, int $preContextCount, int $postContextCount): void
+    {
+        $options = new Options();
+        $integration = new FrameContextifierIntegration($contextLines);
+        $integration->setupOnce();
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->with(FrameContextifierIntegration::class)
+            ->willReturn($integration);
+
+        $client->expects($this->once())
+            ->method('getOptions')
+            ->willReturn($options);
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        $stacktrace = new Stacktrace($options, $this->serializer, $this->representationSerializer);
+        $stacktrace->addFrame($fixtureFilePath, $lineNumber, ['function' => '[unknown]']);
+
+        $event = new Event();
+        $event->setStacktrace($stacktrace);
+
+        withScope(static function (Scope $scope) use (&$event): void {
+            $event = $scope->applyToEvent($event, []);
+        });
+
+        $this->assertNotNull($event);
+        $this->assertNotNull($event->getStacktrace());
+
+        $frames = $event->getStacktrace()->getFrames();
+
+        $this->assertCount(1, $frames);
+        $this->assertCount($preContextCount, $frames[0]->getPreContext());
+        $this->assertCount($postContextCount, $frames[0]->getPostContext());
+
+        $fileContent = explode("\n", $this->getFixtureFileContent($fixtureFilePath));
+
+        for ($i = 0; $i < $preContextCount; ++$i) {
+            $this->assertSame(rtrim($fileContent[$i + ($lineNumber - $preContextCount - 1)]), $frames[0]->getPreContext()[$i]);
+        }
+
+        $this->assertSame(rtrim($fileContent[$lineNumber - 1]), $frames[0]->getContextLine());
+
+        for ($i = 0; $i < $postContextCount; ++$i) {
+            $this->assertSame(rtrim($fileContent[$i + $lineNumber]), $frames[0]->getPostContext()[$i]);
+        }
+    }
+
+    public function invokeDataProvider(): \Generator
+    {
+        yield 'short file' => [
+            realpath(__DIR__ . '/../Fixtures/code/ShortFile.php'),
+            3,
+            2,
+            2,
+            2,
+        ];
+
+        yield 'long file with specified context' => [
+            realpath(__DIR__ . '/../Fixtures/code/LongFile.php'),
+            8,
+            2,
+            2,
+            2,
+        ];
+
+        yield 'long file near end of file' => [
+            realpath(__DIR__ . '/../Fixtures/code/LongFile.php'),
+            11,
+            5,
+            5,
+            2,
+        ];
+
+        yield 'long file near beginning of file' => [
+            realpath(__DIR__ . '/../Fixtures/code/LongFile.php'),
+            3,
+            5,
+            2,
+            5,
+        ];
+    }
+
+    public function testInvokeLogsWarningMessageIfSourceCodeExcerptCannotBeRetrievedForFrame(): void
+    {
+        /** @var MockObject&LoggerInterface $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('warning')
+            ->with('Failed to get the source code excerpt for the file "file.ext".');
+
+        $options = new Options();
+        $integration = new FrameContextifierIntegration(1, $logger);
+        $integration->setupOnce();
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->with(FrameContextifierIntegration::class)
+            ->willReturn($integration);
+
+        $client->expects($this->once())
+            ->method('getOptions')
+            ->willReturn($options);
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        $stacktrace = new Stacktrace(new Options(), $this->serializer, $this->representationSerializer);
+        $stacktrace->addFrame('[internal]', 0, []);
+        $stacktrace->addFrame('file.ext', 10, []);
+
+        $event = new Event();
+        $event->setStacktrace($stacktrace);
+
+        withScope(static function (Scope $scope) use (&$event): void {
+            $event = $scope->applyToEvent($event, []);
+        });
+
+        $this->assertNotNull($event);
+
+        foreach ($stacktrace->getFrames() as $frame) {
+            $this->assertNull($frame->getContextLine());
+            $this->assertEmpty($frame->getPreContext());
+            $this->assertEmpty($frame->getPostContext());
+        }
+    }
+
+    private function getFixtureFileContent(string $file): string
+    {
+        $fileContent = file_get_contents($file);
+
+        if (false === $fileContent) {
+            throw new \RuntimeException(sprintf('The fixture file at path "%s" could not be read.', $file));
+        }
+
+        return $fileContent;
+    }
+}

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -36,14 +36,6 @@ final class FrameContextifierIntegrationTest extends TestCase
         $this->representationSerializer = $this->createMock(RepresentationSerializerInterface::class);
     }
 
-    public function testConstructorThrowsIfMaxLinesToFetchIsNotGreaterThanOrEqualToZero(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The value of the $maxLinesToFetch argument must be greater than or equal to 0. Got: "-1".');
-
-        new FrameContextifierIntegration(-1);
-    }
-
     /**
      * @group legacy
      *
@@ -51,8 +43,8 @@ final class FrameContextifierIntegrationTest extends TestCase
      */
     public function testInvoke(string $fixtureFilePath, int $lineNumber, int $contextLines, int $preContextCount, int $postContextCount): void
     {
-        $options = new Options();
-        $integration = new FrameContextifierIntegration($contextLines);
+        $options = new Options(['context_lines' => $contextLines]);
+        $integration = new FrameContextifierIntegration();
         $integration->setupOnce();
 
         /** @var ClientInterface&MockObject $client */
@@ -68,7 +60,7 @@ final class FrameContextifierIntegrationTest extends TestCase
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $stacktrace = new Stacktrace($options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($options, $this->serializer, $this->representationSerializer, false);
         $stacktrace->addFrame($fixtureFilePath, $lineNumber, ['function' => '[unknown]']);
 
         $event = new Event();
@@ -144,7 +136,7 @@ final class FrameContextifierIntegrationTest extends TestCase
             ->with('Failed to get the source code excerpt for the file "file.ext".');
 
         $options = new Options();
-        $integration = new FrameContextifierIntegration(1, $logger);
+        $integration = new FrameContextifierIntegration($logger);
         $integration->setupOnce();
 
         /** @var ClientInterface&MockObject $client */
@@ -160,7 +152,7 @@ final class FrameContextifierIntegrationTest extends TestCase
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $stacktrace = new Stacktrace(new Options(), $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace(new Options(), $this->serializer, $this->representationSerializer, false);
         $stacktrace->addFrame('[internal]', 0, []);
         $stacktrace->addFrame('file.ext', 10, []);
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -27,7 +27,7 @@ final class RequestIntegrationTest extends TestCase
      *
      * @expectedDeprecation Passing the options as argument of the constructor of the "Sentry\Integration\RequestIntegration" class is deprecated since version 2.1 and will not work in 3.0.
      */
-    public function testConstructorThrowsDeprecationIfPassingOptions(): void
+    public function testConstructorThrowsDeprecationErrorIfPassingOptions(): void
     {
         new RequestIntegration(new Options([]));
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -9,6 +9,7 @@ use Sentry\Dsn;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
+use Sentry\Integration\FrameContextifierIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\RequestIntegration;
 use Sentry\Integration\TransactionIntegration;
@@ -65,8 +66,8 @@ final class OptionsTest extends TestCase
             ['tags', ['foo', 'bar'], 'getTags', 'setTags'],
             ['error_types', 0, 'getErrorTypes', 'setErrorTypes'],
             ['max_breadcrumbs', 50, 'getMaxBreadcrumbs', 'setMaxBreadcrumbs'],
-            ['before_send', function () {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
-            ['before_breadcrumb', function () {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
+            ['before_send', static function (): void {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
+            ['before_breadcrumb', static function (): void {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
             ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
             ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
             ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
@@ -319,6 +320,8 @@ final class OptionsTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider contextLinesOptionValidatesInputValueDataProvider
      */
     public function testContextLinesOptionValidatesInputValue(?int $value, ?string $expectedExceptionMessage): void
@@ -436,6 +439,7 @@ final class OptionsTest extends TestCase
                 new FatalErrorListenerIntegration(),
                 new RequestIntegration(),
                 new TransactionIntegration(),
+                new FrameContextifierIntegration(),
                 $integration,
             ],
         ];
@@ -490,6 +494,7 @@ final class OptionsTest extends TestCase
                 new FatalErrorListenerIntegration(),
                 new RequestIntegration(),
                 new TransactionIntegration(),
+                new FrameContextifierIntegration(),
             ],
         ];
     }

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -209,16 +209,10 @@ final class SerializerTest extends AbstractSerializerTest
     }
 
     /**
-     * @param Options $options|null
-     *
      * @return Serializer
      */
     protected function createSerializer(?Options $options = null): AbstractSerializer
     {
-        if (null === $options) {
-            $options = new Options();
-        }
-
-        return new Serializer($options);
+        return new Serializer($options ?? new Options());
     }
 }

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -296,6 +296,8 @@ final class StacktraceTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider addFrameRespectsContextLinesOptionDataProvider
      */
     public function testAddFrameRespectsContextLinesOption(string $fixture, int $lineNumber, ?int $contextLines, int $preContextCount, int $postContextCount): void

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -35,9 +35,19 @@ final class StacktraceTest extends TestCase
         $this->representationSerializer = new RepresentationSerializer($this->options);
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Relying on the "Sentry\Stacktrace" class to contexify the frames of the stacktrace is deprecated since version 2.4 and will stop working in 3.0. Set the $shouldReadSourceCodeExcerpts parameter to "false" and use the "Sentry\Integration\FrameContextifierIntegration" integration instead.
+     */
+    public function testConstructorThrowsDeprecationErrorIfLastArgumentIsNotSetToFalse(): void
+    {
+        new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+    }
+
     public function testGetFramesAndToArray(): void
     {
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
 
         $stacktrace->addFrame('path/to/file', 1, ['file' => 'path/to/file', 'line' => 1, 'class' => 'TestClass']);
         $stacktrace->addFrame('path/to/file', 2, ['file' => 'path/to/file', 'line' => 2, 'function' => 'test_function']);
@@ -54,7 +64,7 @@ final class StacktraceTest extends TestCase
 
     public function testStacktraceJsonSerialization(): void
     {
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
 
         $stacktrace->addFrame('path/to/file', 1, ['file' => 'path/to/file', 'line' => 1, 'function' => 'test_function']);
         $stacktrace->addFrame('path/to/file', 2, ['file' => 'path/to/file', 'line' => 2, 'function' => 'test_function', 'class' => 'TestClass']);
@@ -70,7 +80,7 @@ final class StacktraceTest extends TestCase
 
     public function testAddFrame(): void
     {
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
         $frames = [
             $this->getJsonFixture('frames/eval.json'),
             $this->getJsonFixture('frames/runtime_created.json'),
@@ -93,7 +103,7 @@ final class StacktraceTest extends TestCase
 
     public function testAddFrameSerializesMethodArguments(): void
     {
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
         $stacktrace->addFrame('path/to/file', 12, [
             'file' => 'path/to/file',
             'line' => 12,
@@ -112,7 +122,7 @@ final class StacktraceTest extends TestCase
     {
         $this->options->setPrefixes(['path/to/', 'path/to/app']);
 
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
 
         $stacktrace->addFrame('path/to/app/file', 12, ['function' => 'test_function_parent_parent_parent']);
         $stacktrace->addFrame('path/to/file', 12, ['function' => 'test_function_parent_parent']);
@@ -138,7 +148,8 @@ final class StacktraceTest extends TestCase
         $stacktrace = new Stacktrace(
             $options,
             new Serializer($options),
-            new RepresentationSerializer($options)
+            new RepresentationSerializer($options),
+            false
         );
 
         $stacktrace->addFrame($file, 0, ['function' => $functionName]);
@@ -299,6 +310,8 @@ final class StacktraceTest extends TestCase
      * @group legacy
      *
      * @dataProvider addFrameRespectsContextLinesOptionDataProvider
+     *
+     * @expectedDeprecation Relying on the "Sentry\Stacktrace" class to contexify the frames of the stacktrace is deprecated since version 2.4 and will stop working in 3.0. Set the $shouldReadSourceCodeExcerpts parameter to "false" and use the "Sentry\Integration\FrameContextifierIntegration" integration instead.
      */
     public function testAddFrameRespectsContextLinesOption(string $fixture, int $lineNumber, ?int $contextLines, int $preContextCount, int $postContextCount): void
     {
@@ -391,8 +404,7 @@ final class StacktraceTest extends TestCase
             $this->expectExceptionMessage('Invalid frame index to remove.');
         }
 
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
-
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
         $stacktrace->addFrame('path/to/file', 12, [
             'function' => 'test_function_parent',
         ]);
@@ -423,7 +435,7 @@ final class StacktraceTest extends TestCase
     public function testFromBacktrace(): void
     {
         $fixture = $this->getJsonFixture('backtraces/exception.json');
-        $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
+        $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'], false)->getFrames();
 
         $this->assertFrameEquals($frames[0], null, 'path/to/file', 16);
         $this->assertFrameEquals($frames[1], 'TestClass::crashyFunction', 'path/to/file', 7);
@@ -433,7 +445,7 @@ final class StacktraceTest extends TestCase
     public function testFromBacktraceWithAnonymousFrame(): void
     {
         $fixture = $this->getJsonFixture('backtraces/anonymous_frame.json');
-        $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
+        $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'], false)->getFrames();
 
         $this->assertFrameEquals($frames[0], null, 'path/to/file', 7);
         $this->assertFrameEquals($frames[1], 'call_user_func', '[internal]', 0);
@@ -443,7 +455,7 @@ final class StacktraceTest extends TestCase
     public function testFromBacktraceWithAnonymousClass(): void
     {
         $fixture = $this->getJsonFixture('backtraces/anonymous_frame_with_memory_address.json');
-        $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
+        $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'], false)->getFrames();
 
         $this->assertFrameEquals(
             $frames[0],
@@ -451,12 +463,39 @@ final class StacktraceTest extends TestCase
             '[internal]',
             0
         );
+
         $this->assertFrameEquals(
             $frames[1],
             'class@anonymous/path/to/app/consumer.php::messageCallback',
             'path/to/file',
             12
         );
+    }
+
+    /**
+     * @group legacy
+     *
+     * @dataProvider createFromBacktraceThrowsDeprecationErrorIfLastArgumentIsNotSetToFalseDataProvider
+     *
+     * @expectedDeprecation Relying on the "Sentry\Stacktrace" class to contexify the frames of the stacktrace is deprecated since version 2.4 and will stop working in 3.0. Set the $shouldReadSourceCodeExcerpts parameter to "false" and use the "Sentry\Integration\FrameContextifierIntegration" integration instead.
+     */
+    public function testCreateFromBacktraceThrowsDeprecationErrorIfLastArgumentIsNotSetToFalse(array ...$constructorArguments): void
+    {
+        Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, [], __FILE__, __LINE__, ...$constructorArguments);
+    }
+
+    public function createFromBacktraceThrowsDeprecationErrorIfLastArgumentIsNotSetToFalseDataProvider(): \Generator
+    {
+        yield [[true]];
+
+        yield [[1]];
+
+        yield [['foo']];
+
+        yield [[new class() {
+        }]];
+
+        yield [[]];
     }
 
     public function testGetFrameArgumentsDoesNotModifyCapturedArgs(): void
@@ -479,7 +518,7 @@ final class StacktraceTest extends TestCase
             'function' => 'a_test',
         ];
 
-        $stacktrace = new Stacktrace(new Options(['max_value_length' => 5]), $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace(new Options(['max_value_length' => 5]), $this->serializer, $this->representationSerializer, false);
         $result = $stacktrace->getFrameArguments($frame);
 
         // Check we haven't modified our vars.
@@ -503,7 +542,7 @@ final class StacktraceTest extends TestCase
             'function' => 'a_test',
         ];
 
-        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer);
+        $stacktrace = new Stacktrace($this->options, $this->serializer, $this->representationSerializer, false);
         $result = $stacktrace->getFrameArguments($frame);
 
         $this->assertEquals('bar', $result['foo']);

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -105,7 +105,7 @@ final class ScopeTest extends TestCase
      *
      * @expectedDeprecation Replacing the data is deprecated since version 2.3 and will stop working from version 3.0. Set the second argument to `true` to merge the data instead.
      */
-    public function testSetUserThrowsDeprecation(): void
+    public function testSetUserThrowsDeprecationError(): void
     {
         $scope = new Scope();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| License       | MIT

Porting of the [contextifyFramesIntegration integration](https://github.com/getsentry/sentry-go/blob/550a179aaa1655092edfba5d2ea4bfc1690736e5/integrations.go#L162) of the Go SDK. The main benefit of this change is that we're moving away from the `Stacktrace` class a lot of code that doesn't belongs there, advancing one more step towards making it a value object and DTO rather than a service that depends on the serializer, the client options, etc.