### PR TITLE
Allow to pass either a PSR-17 or a Httplug stream factory to the constructor of the GzipEncoderPlugin class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Make `AbstractSerializer` to accept `Traversable` values using `is_iterable` instead of `is_array` (#991)
 - Refactor the `ModulesIntegration` integration to improve its code and its tests (#990)
 - Extract the parsing and validation logic of the DSN into its own value object (#995)
+- Support passing either a Httplug or PSR-17 stream factory to the `GzipEncoderPlugin` class (#1012)
 - Add missing validation for the `context_lines` option and fix its behavior when passing `null` to make it working as described in the documentation (#1003)
 
 ## 2.3.2 (2020-03-06)

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "php-http/discovery": "^1.6.1",
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
+        "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0",
         "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     tipsOfTheDay: false
+    treatPhpDocTypesAsCertain: false
     level: 8
     paths:
         - src

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -50,7 +50,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     private $responseFactory;
 
     /**
-     * @var StreamFactoryInterface The PSR-7 stream factory
+     * @var StreamFactoryInterface The PSR-17 stream factory
      */
     private $streamFactory;
 

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -6,9 +6,10 @@ namespace Sentry\HttpClient\Plugin;
 
 use Http\Client\Common\Plugin as PluginInterface;
 use Http\Discovery\StreamFactoryDiscovery;
-use Http\Message\StreamFactory as StreamFactoryInterface;
+use Http\Message\StreamFactory as HttplugStreamFactoryInterface;
 use Http\Promise\Promise as PromiseInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * This plugin encodes the request body by compressing it with Gzip.
@@ -18,18 +19,18 @@ use Psr\Http\Message\RequestInterface;
 final class GzipEncoderPlugin implements PluginInterface
 {
     /**
-     * @var StreamFactoryInterface The PSR-17 stream factory
+     * @var HttplugStreamFactoryInterface|StreamFactoryInterface The PSR-17 stream factory
      */
     private $streamFactory;
 
     /**
      * Constructor.
      *
-     * @param StreamFactoryInterface|null $streamFactory The stream factory
+     * @param HttplugStreamFactoryInterface|StreamFactoryInterface|null $streamFactory The stream factory
      *
      * @throws \RuntimeException If the zlib extension is not enabled
      */
-    public function __construct(?StreamFactoryInterface $streamFactory = null)
+    public function __construct($streamFactory = null)
     {
         if (!\extension_loaded('zlib')) {
             throw new \RuntimeException('The "zlib" extension must be enabled to use this plugin.');
@@ -37,6 +38,8 @@ final class GzipEncoderPlugin implements PluginInterface
 
         if (null === $streamFactory) {
             @trigger_error(sprintf('A PSR-17 stream factory is needed as argument of the constructor of the "%s" class since version 2.1.3 and will be required in 3.0.', self::class), E_USER_DEPRECATED);
+        } elseif (!$streamFactory instanceof HttplugStreamFactoryInterface && !$streamFactory instanceof StreamFactoryInterface) {
+            throw new \InvalidArgumentException(sprintf('The $streamFactory argument must be an instance of either the "%s" or the "%s" interface.', HttplugStreamFactoryInterface::class, StreamFactoryInterface::class));
         }
 
         $this->streamFactory = $streamFactory ?? StreamFactoryDiscovery::find();

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -6,20 +6,64 @@ namespace Sentry\Tests\HttpClient\Plugin;
 
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Discovery\StreamFactoryDiscovery;
+use Http\Message\StreamFactory as HttplugStreamFactoryInterface;
 use Http\Promise\Promise as PromiseInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Sentry\HttpClient\Plugin\GzipEncoderPlugin;
 
+/**
+ * @requires extension zlib
+ */
 final class GzipEncoderPluginTest extends TestCase
 {
     /**
-     * @requires extension zlib
+     * @dataProvider constructorThrowsIfArgumentsAreInvalidDataProvider
      */
+    public function testConstructorThrowsIfArgumentsAreInvalid($streamFactory, bool $shouldThrowException): void
+    {
+        if ($shouldThrowException) {
+            $this->expectException(\InvalidArgumentException::class);
+            $this->expectExceptionMessage('The $streamFactory argument must be an instance of either the "Http\Message\StreamFactory" or the "Psr\Http\Message\StreamFactoryInterface" interface.');
+        } else {
+            $this->expectNotToPerformAssertions();
+        }
+
+        new GzipEncoderPlugin($streamFactory);
+    }
+
+    public function constructorThrowsIfArgumentsAreInvalidDataProvider(): \Generator
+    {
+        yield [
+            'foo',
+            true,
+        ];
+
+        yield [
+            $this->createMock(StreamFactoryInterface::class),
+            false,
+        ];
+
+        yield [
+            $this->createMock(HttplugStreamFactoryInterface::class),
+            false,
+        ];
+    }
+
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation A PSR-17 stream factory is needed as argument of the constructor of the "Sentry\HttpClient\Plugin\GzipEncoderPlugin" class since version 2.1.3 and will be required in 3.0.
+     */
+    public function testConstructorThrowsDeprecationIfNoStreamFactoryIsProvided(): void
+    {
+        new GzipEncoderPlugin();
+    }
+
     public function testHandleRequest(): void
     {
         $plugin = new GzipEncoderPlugin(StreamFactoryDiscovery::find());
-        $nextCallableCalled = false;
         $expectedPromise = $this->createMock(PromiseInterface::class);
         $request = MessageFactoryDiscovery::find()->createRequest(
             'POST',
@@ -33,18 +77,14 @@ final class GzipEncoderPluginTest extends TestCase
             $expectedPromise,
             $plugin->handleRequest(
                 $request,
-                function (RequestInterface $requestArg) use (&$nextCallableCalled, $expectedPromise): PromiseInterface {
-                    $nextCallableCalled = true;
-
+                function (RequestInterface $requestArg) use ($expectedPromise): PromiseInterface {
                     $this->assertSame('gzip', $requestArg->getHeaderLine('Content-Encoding'));
                     $this->assertSame(gzcompress('foo', -1, ZLIB_ENCODING_GZIP), (string) $requestArg->getBody());
 
                     return $expectedPromise;
                 },
-                static function () {}
+                static function (): void {}
             )
         );
-
-        $this->assertTrue($nextCallableCalled);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes (kind of)
| License       | MIT

Fixes #1006 by allowing to pass to the constructor of the `GzipEncoderPlugin` class either a PSR-17 stream factory or Httplug's stream factory. In `3.0` we hopefully can drop support for Httplug `1.x` and rely exclusively on the PSR standards