### PR TITLE
Encapsulate the event ID into its own value object

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -172,12 +172,10 @@ final class Event implements \JsonSerializable
      *
      * @return string|EventId
      */
-    public function getId(bool $returnAsString = true, bool $throwDeprecation = true)
+    public function getId(bool $returnAsString = true)
     {
         if ($returnAsString) {
-            if ($throwDeprecation) {
-                @trigger_error(sprintf('Calling the method %s() and expecting it to return a string is deprecated since version 2.4 and will stop working in 3.0.', __METHOD__), E_USER_DEPRECATED);
-            }
+            @trigger_error(sprintf('Calling the method %s() and expecting it to return a string is deprecated since version 2.4 and will stop working in 3.0.', __METHOD__), E_USER_DEPRECATED);
 
             return (string) $this->id;
         }

--- a/src/Event.php
+++ b/src/Event.php
@@ -19,7 +19,7 @@ use Sentry\Context\UserContext;
 final class Event implements \JsonSerializable
 {
     /**
-     * @var string The UUID
+     * @var EventId The ID
      */
     private $id;
 
@@ -150,14 +150,13 @@ final class Event implements \JsonSerializable
     private $sdkVersion;
 
     /**
-     * Event constructor.
+     * Class constructor.
      *
-     * @throws \InvalidArgumentException
-     * @throws \Exception
+     * @param EventId|null $eventId The ID of the event
      */
-    public function __construct()
+    public function __construct(?EventId $eventId = null)
     {
-        $this->id = str_replace('-', '', uuid_create(UUID_TYPE_RANDOM));
+        $this->id = $eventId ?? EventId::generate();
         $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $this->level = Severity::error();
         $this->serverOsContext = new ServerOsContext();
@@ -173,7 +172,7 @@ final class Event implements \JsonSerializable
      */
     public function getId(): string
     {
-        return $this->id;
+        return (string) $this->id;
     }
 
     /**
@@ -579,7 +578,7 @@ final class Event implements \JsonSerializable
     public function toArray(): array
     {
         $data = [
-            'event_id' => $this->id,
+            'event_id' => (string) $this->id,
             'timestamp' => $this->timestamp,
             'level' => (string) $this->level,
             'platform' => 'php',

--- a/src/Event.php
+++ b/src/Event.php
@@ -169,10 +169,20 @@ final class Event implements \JsonSerializable
 
     /**
      * Gets the UUID of this event.
+     *
+     * @return string|EventId
      */
-    public function getId(): string
+    public function getId(bool $returnAsString = true, bool $throwDeprecation = true)
     {
-        return (string) $this->id;
+        if ($returnAsString) {
+            if ($throwDeprecation) {
+                @trigger_error(sprintf('Calling the method %s() and expecting it to return a string is deprecated since version 2.4 and will stop working in 3.0.', __METHOD__), E_USER_DEPRECATED);
+            }
+
+            return (string) $this->id;
+        }
+
+        return $this->id;
     }
 
     /**

--- a/src/EventId.php
+++ b/src/EventId.php
@@ -38,9 +38,6 @@ final class EventId
         return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
     }
 
-    /**
-     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
-     */
     public function __toString(): string
     {
         return $this->value;

--- a/src/EventId.php
+++ b/src/EventId.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+/**
+ * This class represents an event ID.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class EventId
+{
+    /**
+     * @var string The ID
+     */
+    private $value;
+
+    /**
+     * Class constructor.
+     *
+     * @param string $value The ID
+     */
+    public function __construct(string $value)
+    {
+        if (!preg_match('/^[a-f0-9]{32}$/i', $value)) {
+            throw new \InvalidArgumentException('The $value argument must be a 32 characters long hexadecimal string.');
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * Generates a new event ID.
+     */
+    public static function generate(): self
+    {
+        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
+    }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+     */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -142,7 +142,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
             }
         }
 
-        return $event->getId();
+        return (string) $event->getId(false);
     }
 
     /**

--- a/src/Transport/NullTransport.php
+++ b/src/Transport/NullTransport.php
@@ -20,6 +20,6 @@ class NullTransport implements TransportInterface
      */
     public function send(Event $event): ?string
     {
-        return $event->getId();
+        return (string) $event->getId(false);
     }
 }

--- a/src/Transport/SpoolTransport.php
+++ b/src/Transport/SpoolTransport.php
@@ -43,7 +43,7 @@ final class SpoolTransport implements TransportInterface
     public function send(Event $event): ?string
     {
         if ($this->spool->queueEvent($event)) {
-            return $event->getId();
+            return (string) $event->getId(false);
         }
 
         return null;

--- a/tests/EventIdTest.php
+++ b/tests/EventIdTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\EventId;
+
+final class EventIdTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $value = '566e3688a61d4bc888951642d6f14a19';
+
+        $this->assertSame($value, (string) new EventId($value));
+    }
+
+    /**
+     * @dataProvider constructorThrowsOnInvalidValueDataProvider
+     */
+    public function testConstructorThrowsOnInvalidValue(string $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The $value argument must be a 32 characters long hexadecimal string.');
+
+        new EventId($value);
+    }
+
+    public function constructorThrowsOnInvalidValueDataProvider(): \Generator
+    {
+        yield 'Value too long' => ['566e3688a61d4bc888951642d6f14a199'];
+        yield 'Value too short' => ['566e3688a61d4bc888951642d6f14a1'];
+        yield 'Value with invalid characters' => ['566e3688a61d4bc888951642d6f14a1g'];
+    }
+}

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -23,7 +23,7 @@ final class EventTest extends TestCase
         $event1 = new Event();
         $event2 = new Event();
 
-        $this->assertNotEquals($event1->getId(), $event2->getId());
+        $this->assertNotEquals($event1->getId(false), $event2->getId(false));
     }
 
     public function testToArray(): void
@@ -31,7 +31,7 @@ final class EventTest extends TestCase
         $event = new Event();
 
         $expected = [
-            'event_id' => $event->getId(),
+            'event_id' => $event->getId(true, false),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'level' => 'error',
             'platform' => 'php',
@@ -64,7 +64,7 @@ final class EventTest extends TestCase
         $event->setContext('runtime', ['baz' => 'baz']);
 
         $expected = [
-            'event_id' => $event->getId(),
+            'event_id' => $event->getId(true, false),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'level' => 'error',
             'platform' => 'php',

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -26,12 +26,24 @@ final class EventTest extends TestCase
         $this->assertNotEquals($event1->getId(false), $event2->getId(false));
     }
 
+    /**
+     * @group legacy
+     *
+     * @expectedDeprecation Calling the method Sentry\Event::getId() and expecting it to return a string is deprecated since version 2.4 and will stop working in 3.0.
+     */
+    public function testGetEventIdThrowsDeprecationErrorIfExpectingStringReturnType(): void
+    {
+        $event = new Event();
+
+        $this->assertSame($event->getId(), (string) $event->getId(false));
+    }
+
     public function testToArray(): void
     {
         $event = new Event();
 
         $expected = [
-            'event_id' => $event->getId(true, false),
+            'event_id' => (string) $event->getId(false),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'level' => 'error',
             'platform' => 'php',
@@ -64,7 +76,7 @@ final class EventTest extends TestCase
         $event->setContext('runtime', ['baz' => 'baz']);
 
         $expected = [
-            'event_id' => $event->getId(true, false),
+            'event_id' => (string) $event->getId(false),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'level' => 'error',
             'platform' => 'php',

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -23,8 +23,6 @@ final class EventTest extends TestCase
         $event1 = new Event();
         $event2 = new Event();
 
-        $this->assertRegExp('/^[a-z0-9]{32}$/', $event1->getId());
-        $this->assertRegExp('/^[a-z0-9]{32}$/', $event2->getId());
         $this->assertNotEquals($event1->getId(), $event2->getId());
     }
 

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -15,6 +15,6 @@ final class NullTransportTest extends TestCase
         $transport = new NullTransport();
         $event = new Event();
 
-        $this->assertEquals($event->getId(), $transport->send($event));
+        $this->assertSame($event->getId(), $transport->send($event));
     }
 }

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -15,6 +15,6 @@ final class NullTransportTest extends TestCase
         $transport = new NullTransport();
         $event = new Event();
 
-        $this->assertSame($event->getId(true, false), $transport->send($event));
+        $this->assertSame((string) $event->getId(false), $transport->send($event));
     }
 }

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -15,6 +15,6 @@ final class NullTransportTest extends TestCase
         $transport = new NullTransport();
         $event = new Event();
 
-        $this->assertSame($event->getId(), $transport->send($event));
+        $this->assertSame($event->getId(true, false), $transport->send($event));
     }
 }

--- a/tests/Transport/SpoolTransportTest.php
+++ b/tests/Transport/SpoolTransportTest.php
@@ -48,7 +48,7 @@ final class SpoolTransportTest extends TestCase
         $eventId = $this->transport->send($event);
 
         if ($isSendingSuccessful) {
-            $this->assertSame($event->getId(true, false), $eventId);
+            $this->assertSame((string) $event->getId(false), $eventId);
         } else {
             $this->assertNull($eventId);
         }

--- a/tests/Transport/SpoolTransportTest.php
+++ b/tests/Transport/SpoolTransportTest.php
@@ -13,7 +13,7 @@ use Sentry\Transport\SpoolTransport;
 final class SpoolTransportTest extends TestCase
 {
     /**
-     * @var SpoolInterface|MockObject
+     * @var SpoolInterface&MockObject
      */
     protected $spool;
 
@@ -48,7 +48,7 @@ final class SpoolTransportTest extends TestCase
         $eventId = $this->transport->send($event);
 
         if ($isSendingSuccessful) {
-            $this->assertSame($event->getId(), $eventId);
+            $this->assertSame($event->getId(true, false), $eventId);
         } else {
             $this->assertNull($eventId);
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 2.4
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes (kind of)
| License       | MIT

Small refactor to start encapsulating the ID of an event inside its own value object. The idea behind this change is to typehint this information in `3.0` in all methods that accepts or returns it instead of accepting a generic `string` value that noone can guarantee to be valid without validating it every time