### PR TITLE
Trim path from anonymous class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add missing validation for the `context_lines` option and fix its behavior when passing `null` to make it working as described in the documentation (#1003)
+- Trim the file path from the anonymous class name in the stacktrace according to the `prefixes` option (#1016)
 
 ## 2.3.2 (2020-03-06)
 

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -18,6 +18,8 @@ class Stacktrace implements \JsonSerializable
 {
     private const INTERNAL_FRAME_FILENAME = '[internal]';
 
+    private const ANONYMOUS_CLASS_PREFIX = "class@anonymous\x00";
+
     /**
      * @var Options The client options
      */
@@ -129,6 +131,10 @@ class Stacktrace implements \JsonSerializable
         }
 
         if (isset($backtraceFrame['class']) && isset($backtraceFrame['function'])) {
+            if (0 === strpos($backtraceFrame['class'], self::ANONYMOUS_CLASS_PREFIX)) {
+                $backtraceFrame['class'] = self::ANONYMOUS_CLASS_PREFIX . $this->stripPrefixFromFilePath(substr($backtraceFrame['class'], \strlen(self::ANONYMOUS_CLASS_PREFIX)));
+            }
+
             $functionName = sprintf(
                 '%s::%s',
                 preg_replace('/0x[a-fA-F0-9]+$/', '', $backtraceFrame['class']),

--- a/tests/Fixtures/backtraces/anonymous_frame_with_memory_address.json
+++ b/tests/Fixtures/backtraces/anonymous_frame_with_memory_address.json
@@ -3,7 +3,12 @@
     "line": 12,
     "backtrace": [
         {
-            "class": "class@anonymous/path/to/app/consumer.php0x7fc3bc369418",
+            "class": "class@anonymous\u0000/path/to/app/consumer.php0x7fc3bc369418",
+            "function": "messageCallback",
+            "type": "->"
+        },
+        {
+            "class": "class@anonymous\u0000/path-prefix/path/to/app/consumer.php0x7fc3bc369418",
             "function": "messageCallback",
             "type": "->"
         }

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -418,7 +418,7 @@ final class StacktraceTest extends TestCase
         ];
     }
 
-    public function testFromBacktrace(): void
+    public function testCreateFromBacktrace(): void
     {
         $fixture = $this->getJsonFixture('backtraces/exception.json');
         $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
@@ -428,7 +428,7 @@ final class StacktraceTest extends TestCase
         $this->assertFrameEquals($frames[2], 'TestClass::triggerError', 'path/to/file', 12);
     }
 
-    public function testFromBacktraceWithAnonymousFrame(): void
+    public function testCreateFromBacktraceWithAnonymousFrame(): void
     {
         $fixture = $this->getJsonFixture('backtraces/anonymous_frame.json');
         $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
@@ -438,8 +438,9 @@ final class StacktraceTest extends TestCase
         $this->assertFrameEquals($frames[2], 'TestClass::triggerError', 'path/to/file', 12);
     }
 
-    public function testFromBacktraceWithAnonymousClass(): void
+    public function testCreateFromBacktraceWithAnonymousClass(): void
     {
+        $this->options->setPrefixes(['/path-prefix']);
         $fixture = $this->getJsonFixture('backtraces/anonymous_frame_with_memory_address.json');
         $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
 
@@ -451,7 +452,13 @@ final class StacktraceTest extends TestCase
         );
         $this->assertFrameEquals(
             $frames[1],
-            'class@anonymous/path/to/app/consumer.php::messageCallback',
+            "class@anonymous\x00/path/to/app/consumer.php::messageCallback",
+            '[internal]',
+            0
+        );
+        $this->assertFrameEquals(
+            $frames[2],
+            "class@anonymous\x00/path/to/app/consumer.php::messageCallback",
             'path/to/file',
             12
         );

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -441,6 +441,7 @@ final class StacktraceTest extends TestCase
     public function testCreateFromBacktraceWithAnonymousClass(): void
     {
         $this->options->setPrefixes(['/path-prefix']);
+
         $fixture = $this->getJsonFixture('backtraces/anonymous_frame_with_memory_address.json');
         $frames = Stacktrace::createFromBacktrace($this->options, $this->serializer, $this->representationSerializer, $fixture['backtrace'], $fixture['file'], $fixture['line'])->getFrames();
 
@@ -456,6 +457,7 @@ final class StacktraceTest extends TestCase
             '[internal]',
             0
         );
+
         $this->assertFrameEquals(
             $frames[2],
             "class@anonymous\x00/path/to/app/consumer.php::messageCallback",


### PR DESCRIPTION
The anonymous class name contains absolute path which is useless and should be stripped.