### PR TITLE
Revert "Add support for iterables in the serializer (#991)"

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -103,7 +103,7 @@ abstract class AbstractSerializer
                 return $this->serializeCallableWithoutTypeHint($value);
             }
 
-            if (is_iterable($value)) {
+            if (\is_array($value)) {
                 $serializedArray = [];
 
                 foreach ($value as $k => $v) {

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -67,27 +67,20 @@ abstract class AbstractSerializerTest extends TestCase
 
     public function traversableDataProvider(): \Generator
     {
-        $getArray = static function (): array {
-            return [
-                'a' => 'foo',
-                'b' => 'bar',
-            ];
-        };
-
-        yield [$getArray(), new \ArrayIterator($getArray())];
+        yield [new \ArrayIterator(['foo', 'bar']), ['foo', 'bar']];
 
         // Also test with a non-rewindable non-cloneable iterator:
         $newGenerator = static function (array $array): \Generator {
             yield from $array;
         };
 
-        yield [$getArray(), $newGenerator($getArray())];
+        yield [$newGenerator(['foo', 'bar']), ['foo', 'bar']];
     }
 
     /**
      * @dataProvider traversableDataProvider
      */
-    public function testTraversablesAreNotConsumed(array $array, \Traversable $traversable): void
+    public function testTraversablesAreNotConsumed(\Traversable $traversable, array $array): void
     {
         $serializer = $this->createSerializer();
 

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -30,24 +30,6 @@ final class SerializerTest extends AbstractSerializerTest
     /**
      * @dataProvider serializeAllObjectsDataProvider
      */
-    public function testTraversablesAreArrays(bool $serializeAllObjects): void
-    {
-        $serializer = $this->createSerializer();
-
-        if ($serializeAllObjects) {
-            $serializer->setSerializeAllObjects(true);
-        }
-
-        $content = [1, 2, 3];
-        $traversable = new \ArrayIterator($content);
-        $result = $this->invokeSerialization($serializer, $traversable);
-
-        $this->assertSame([1, 2, 3], $result);
-    }
-
-    /**
-     * @dataProvider serializeAllObjectsDataProvider
-     */
     public function testIntsAreInts(bool $serializeAllObjects): void
     {
         $serializer = $this->createSerializer();


### PR DESCRIPTION
Fixes #1028 "After 2.3.2->2.4.0 update, Behat stops on the first feature involving an exception"

Reverts #991 "Use is_iterable instead of is_array" and adds a non-regression test