### PR TITLE
Cleanup the deprecated returning of an event ID as a string instead of as a value object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [BC BREAK] Remove the deprecated code that made the `Hub` class a singleton (#1038)
 - [BC BREAK] Remove deprecated code that permitted to register the error, fatal error and exception handlers at once (#1037)
 - [BC BREAK] Change the default value for the `error_types` option from `E_ALL` to the value get from `error_reporting()` (#1037)
+- [BC BREAK] Remove deprecated code to return the event ID as a `string` rather than an object instance from the transport, the client and the hub (#1036)
 
 ### 2.4.1 (2020-07-03)
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -9,3 +9,16 @@
 - The signature of the `FatalErrorListenerIntegration::__construct()` method changed to not accept any parameter
 - The `ErrorListenerIntegration` integration does not get called anymore when a fatal error occurs
 - The default value of the `error_types` option changed to the value get from `error_reporting()`
+- The signature of the `captureMessage()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `captureException()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `captureEvent()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `captureLastError()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `ClientInterface::captureMessage()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `ClientInterface::captureException()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `ClientInterface::captureEvent()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `ClientInterface::captureLastError()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `HubInterface::captureMessage()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `HubInterface::captureException()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `HubInterface::captureEvent()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `HubInterface::captureLastError()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `Event::getId()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -9,16 +9,7 @@
 - The signature of the `FatalErrorListenerIntegration::__construct()` method changed to not accept any parameter
 - The `ErrorListenerIntegration` integration does not get called anymore when a fatal error occurs
 - The default value of the `error_types` option changed to the value get from `error_reporting()`
-- The signature of the `captureMessage()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `captureException()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `captureEvent()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `captureLastError()` global function changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `ClientInterface::captureMessage()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `ClientInterface::captureException()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `ClientInterface::captureEvent()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `ClientInterface::captureLastError()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `HubInterface::captureMessage()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `HubInterface::captureException()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `HubInterface::captureEvent()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
-- The signature of the `HubInterface::captureLastError()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `capture*()` global functions changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `ClientInterface::capture*()` methods changed to return an instance of the `Sentry\EventId` class instead of a `string`
+- The signature of the `HubInterface::capture*e()` methods changed to return an instance of the `Sentry\EventId` class instead of a `string`
 - The signature of the `Event::getId()` method changed to return an instance of the `Sentry\EventId` class instead of a `string`

--- a/src/Client.php
+++ b/src/Client.php
@@ -88,7 +88,7 @@ final class Client implements FlushableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?string
+    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?EventId
     {
         $payload = [
             'message' => $message,
@@ -101,7 +101,7 @@ final class Client implements FlushableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception, ?Scope $scope = null): ?string
+    public function captureException(\Throwable $exception, ?Scope $scope = null): ?EventId
     {
         if (!isset($this->integrations[IgnoreErrorsIntegration::class]) && $this->options->isExcludedException($exception, false)) {
             return null;
@@ -113,7 +113,7 @@ final class Client implements FlushableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureEvent($payload, ?Scope $scope = null): ?string
+    public function captureEvent($payload, ?Scope $scope = null): ?EventId
     {
         $event = $this->prepareEvent($payload, $scope);
 
@@ -127,7 +127,7 @@ final class Client implements FlushableClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(?Scope $scope = null): ?string
+    public function captureLastError(?Scope $scope = null): ?EventId
     {
         $error = error_get_last();
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -26,7 +26,7 @@ interface ClientInterface
      * @param Severity   $level   The level of the message to be sent
      * @param Scope|null $scope   An optional scope keeping the state
      */
-    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?string;
+    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?EventId;
 
     /**
      * Logs an exception.
@@ -34,14 +34,14 @@ interface ClientInterface
      * @param \Throwable $exception The exception object
      * @param Scope|null $scope     An optional scope keeping the state
      */
-    public function captureException(\Throwable $exception, ?Scope $scope = null): ?string;
+    public function captureException(\Throwable $exception, ?Scope $scope = null): ?EventId;
 
     /**
      * Logs the most recent error (obtained with {@link error_get_last}).
      *
      * @param Scope|null $scope An optional scope keeping the state
      */
-    public function captureLastError(?Scope $scope = null): ?string;
+    public function captureLastError(?Scope $scope = null): ?EventId;
 
     /**
      * Captures a new event using the provided data.
@@ -49,7 +49,7 @@ interface ClientInterface
      * @param array<string, mixed>|Event $payload The data of the event being captured
      * @param Scope|null                 $scope   An optional scope keeping the state
      */
-    public function captureEvent($payload, ?Scope $scope = null): ?string;
+    public function captureEvent($payload, ?Scope $scope = null): ?EventId;
 
     /**
      * Returns the integration instance if it is installed on the client.

--- a/src/Event.php
+++ b/src/Event.php
@@ -187,18 +187,10 @@ final class Event implements \JsonSerializable
     }
 
     /**
-     * Gets the UUID of this event.
-     *
-     * @return string|EventId
+     * Gets the ID of this event.
      */
-    public function getId(bool $returnAsString = true)
+    public function getId(): EventId
     {
-        if ($returnAsString) {
-            @trigger_error(sprintf('Calling the method %s() and expecting it to return a string is deprecated since version 2.4 and will stop working in 3.0.', __METHOD__), E_USER_DEPRECATED);
-
-            return (string) $this->id;
-        }
-
         return $this->id;
     }
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -6,6 +6,7 @@ namespace Sentry\State;
 
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
+use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
 use Sentry\Tracing\Transaction;
@@ -22,7 +23,7 @@ final class Hub implements HubInterface
     private $stack = [];
 
     /**
-     * @var string|null The ID of the last captured event
+     * @var EventId|null The ID of the last captured event
      */
     private $lastEventId;
 
@@ -48,7 +49,7 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function getLastEventId(): ?string
+    public function getLastEventId(): ?EventId
     {
         return $this->lastEventId;
     }
@@ -111,7 +112,7 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?string
+    public function captureMessage(string $message, ?Severity $level = null): ?EventId
     {
         $client = $this->getClient();
 
@@ -125,7 +126,7 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception): ?string
+    public function captureException(\Throwable $exception): ?EventId
     {
         $client = $this->getClient();
 
@@ -139,7 +140,7 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureEvent($payload): ?string
+    public function captureEvent($payload): ?EventId
     {
         $client = $this->getClient();
 
@@ -153,7 +154,7 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(): ?string
+    public function captureLastError(): ?EventId
     {
         $client = $this->getClient();
 

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -6,6 +6,7 @@ namespace Sentry\State;
 
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
+use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\SentrySdk;
 use Sentry\Severity;
@@ -54,7 +55,7 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function getLastEventId(): ?string
+    public function getLastEventId(): ?EventId
     {
         return SentrySdk::getCurrentHub()->getLastEventId();
     }
@@ -102,7 +103,7 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?string
+    public function captureMessage(string $message, ?Severity $level = null): ?EventId
     {
         return SentrySdk::getCurrentHub()->captureMessage($message, $level);
     }
@@ -110,7 +111,7 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception): ?string
+    public function captureException(\Throwable $exception): ?EventId
     {
         return SentrySdk::getCurrentHub()->captureException($exception);
     }
@@ -118,7 +119,7 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureEvent($payload): ?string
+    public function captureEvent($payload): ?EventId
     {
         return SentrySdk::getCurrentHub()->captureEvent($payload);
     }
@@ -126,7 +127,7 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(): ?string
+    public function captureLastError(): ?EventId
     {
         return SentrySdk::getCurrentHub()->captureLastError();
     }

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -7,6 +7,7 @@ namespace Sentry\State;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
 use Sentry\Tracing\Transaction;
@@ -27,7 +28,7 @@ interface HubInterface
     /**
      * Gets the ID of the last captured event.
      */
-    public function getLastEventId(): ?string;
+    public function getLastEventId(): ?EventId;
 
     /**
      * Creates a new scope to store context information that will be layered on
@@ -74,26 +75,26 @@ interface HubInterface
      * @param string   $message The message
      * @param Severity $level   The severity level of the message
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?string;
+    public function captureMessage(string $message, ?Severity $level = null): ?EventId;
 
     /**
      * Captures an exception event and sends it to Sentry.
      *
      * @param \Throwable $exception The exception
      */
-    public function captureException(\Throwable $exception): ?string;
+    public function captureException(\Throwable $exception): ?EventId;
 
     /**
      * Captures a new event using the provided data.
      *
      * @param Event|array<string, mixed> $payload The data of the event being captured
      */
-    public function captureEvent($payload): ?string;
+    public function captureEvent($payload): ?EventId;
 
     /**
      * Captures an event that logs the last occurred error.
      */
-    public function captureLastError(): ?string;
+    public function captureLastError(): ?EventId;
 
     /**
      * Records a new breadcrumb which will be attached to future events. They

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -6,6 +6,7 @@ namespace Sentry\Tracing;
 
 use Sentry\Context\Context;
 use Sentry\Context\TagsContext;
+use Sentry\EventId;
 
 /**
  * This class stores all the information about a Span.
@@ -112,9 +113,9 @@ class Span implements \JsonSerializable
      *
      * @param float|null $endTimestamp Takes an endTimestamp if the end should not be the time when you call this function
      *
-     * @return string|null Finish for a span always returns null
+     * @return EventId|null Finish for a span always returns null
      */
-    public function finish($endTimestamp = null): ?string
+    public function finish($endTimestamp = null): ?EventId
     {
         $this->endTimestamp = $endTimestamp ?? microtime(true);
 

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Tracing;
 
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Severity;
 use Sentry\State\HubInterface;
 
@@ -74,9 +75,9 @@ final class Transaction extends Span
     /**
      * {@inheritdoc}
      *
-     * @return string|null Finish for a transaction returns the eventId or null in case we didn't send it
+     * @return EventId|null Finish for a transaction returns the eventId or null in case we didn't send it
      */
-    public function finish($endTimestamp = null): ?string
+    public function finish($endTimestamp = null): ?EventId
     {
         if (null !== $this->endTimestamp) {
             // Transaction was already finished once and we don't want to re-flush it

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sentry\Dsn;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Options;
 use Sentry\Util\JSON;
 
@@ -109,7 +110,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
     /**
      * {@inheritdoc}
      */
-    public function send(Event $event): ?string
+    public function send(Event $event): ?EventId
     {
         $dsn = $this->options->getDsn(false);
 
@@ -151,7 +152,7 @@ final class HttpTransport implements TransportInterface, ClosableTransportInterf
             }
         }
 
-        return (string) $event->getId(false);
+        return $event->getId();
     }
 
     /**

--- a/src/Transport/NullTransport.php
+++ b/src/Transport/NullTransport.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Transport;
 
 use Sentry\Event;
+use Sentry\EventId;
 
 /**
  * This transport fakes the sending of events by just ignoring them.
@@ -18,8 +19,8 @@ class NullTransport implements TransportInterface
     /**
      * {@inheritdoc}
      */
-    public function send(Event $event): ?string
+    public function send(Event $event): ?EventId
     {
-        return (string) $event->getId(false);
+        return $event->getId();
     }
 }

--- a/src/Transport/SpoolTransport.php
+++ b/src/Transport/SpoolTransport.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Transport;
 
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Spool\SpoolInterface;
 
 /**
@@ -40,10 +41,10 @@ final class SpoolTransport implements TransportInterface
     /**
      * {@inheritdoc}
      */
-    public function send(Event $event): ?string
+    public function send(Event $event): ?EventId
     {
         if ($this->spool->queueEvent($event)) {
-            return (string) $event->getId(false);
+            return $event->getId();
         }
 
         return null;

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Transport;
 
 use Sentry\Event;
+use Sentry\EventId;
 
 /**
  * This interface must be implemented by all classes willing to provide a way
@@ -19,7 +20,7 @@ interface TransportInterface
      *
      * @param Event $event The event
      *
-     * @return string|null Returns the ID of the event or `null` if it failed to be sent
+     * @return EventId|null Returns the ID of the event or `null` if it failed to be sent
      */
-    public function send(Event $event): ?string;
+    public function send(Event $event): ?EventId;
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -25,7 +25,7 @@ function init(array $options = []): void
  * @param string   $message The message
  * @param Severity $level   The severity level of the message
  */
-function captureMessage(string $message, ?Severity $level = null): ?string
+function captureMessage(string $message, ?Severity $level = null): ?EventId
 {
     return SentrySdk::getCurrentHub()->captureMessage($message, $level);
 }
@@ -35,7 +35,7 @@ function captureMessage(string $message, ?Severity $level = null): ?string
  *
  * @param \Throwable $exception The exception
  */
-function captureException(\Throwable $exception): ?string
+function captureException(\Throwable $exception): ?EventId
 {
     return SentrySdk::getCurrentHub()->captureException($exception);
 }
@@ -45,7 +45,7 @@ function captureException(\Throwable $exception): ?string
  *
  * @param array<string, mixed> $payload The data of the event being captured
  */
-function captureEvent(array $payload): ?string
+function captureEvent(array $payload): ?EventId
 {
     return SentrySdk::getCurrentHub()->captureEvent($payload);
 }
@@ -53,7 +53,7 @@ function captureEvent(array $payload): ?string
 /**
  * Logs the most recent error (obtained with {@link error_get_last}).
  */
-function captureLastError(): ?string
+function captureLastError(): ?EventId
 {
     return SentrySdk::getCurrentHub()->captureLastError();
 }

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -17,6 +17,7 @@ use Psr\Http\Message\RequestInterface;
 use Sentry\Client;
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\FlushableClientInterface;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
@@ -82,17 +83,19 @@ final class ClientBuilderTest extends TestCase
      */
     public function testSetTransport(): void
     {
+        $eventId = EventId::generate();
+
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
             ->method('send')
-            ->willReturn('ddb4a0b9ab1941bf92bd2520063663e3');
+            ->willReturn($eventId);
 
         $client = ClientBuilder::create(['dsn' => 'http://public@example.com/sentry/1'])
             ->setTransport($transport)
             ->getClient();
 
-        $this->assertSame('ddb4a0b9ab1941bf92bd2520063663e3', $client->captureMessage('foo'));
+        $this->assertSame($eventId, $client->captureMessage('foo'));
     }
 
     /**

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -23,19 +23,7 @@ final class EventTest extends TestCase
         $event1 = new Event();
         $event2 = new Event();
 
-        $this->assertNotEquals($event1->getId(false), $event2->getId(false));
-    }
-
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Calling the method Sentry\Event::getId() and expecting it to return a string is deprecated since version 2.4 and will stop working in 3.0.
-     */
-    public function testGetEventIdThrowsDeprecationErrorIfExpectingStringReturnType(): void
-    {
-        $event = new Event();
-
-        $this->assertSame($event->getId(), (string) $event->getId(false));
+        $this->assertNotEquals($event1->getId(), $event2->getId());
     }
 
     public function testToArray(): void
@@ -43,7 +31,7 @@ final class EventTest extends TestCase
         $event = new Event();
 
         $expected = [
-            'event_id' => (string) $event->getId(false),
+            'event_id' => (string) $event->getId(),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'platform' => 'php',
             'sdk' => [
@@ -76,7 +64,7 @@ final class EventTest extends TestCase
         $event->setContext('runtime', ['baz' => 'baz']);
 
         $expected = [
-            'event_id' => (string) $event->getId(false),
+            'event_id' => (string) $event->getId(),
             'timestamp' => gmdate('Y-m-d\TH:i:s\Z'),
             'platform' => 'php',
             'sdk' => [

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\Severity;
@@ -36,20 +37,23 @@ final class FunctionsTest extends TestCase
 
     public function testCaptureMessage(): void
     {
+        $eventId = EventId::generate();
+
         /** @var ClientInterface|MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureMessage')
             ->with('foo', Severity::debug())
-            ->willReturn('92db40a886c0458288c7c83935a350ef');
+            ->willReturn($eventId);
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $this->assertEquals('92db40a886c0458288c7c83935a350ef', captureMessage('foo', Severity::debug()));
+        $this->assertSame($eventId, captureMessage('foo', Severity::debug()));
     }
 
     public function testCaptureException(): void
     {
+        $eventId = EventId::generate();
         $exception = new \RuntimeException('foo');
 
         /** @var ClientInterface|MockObject $client */
@@ -57,39 +61,44 @@ final class FunctionsTest extends TestCase
         $client->expects($this->once())
             ->method('captureException')
             ->with($exception)
-            ->willReturn('2b867534eead412cbdb882fd5d441690');
+            ->willReturn($eventId);
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureException($exception));
+        $this->assertSame($eventId, captureException($exception));
     }
 
     public function testCaptureEvent(): void
     {
+        $eventId = EventId::generate();
+
         /** @var ClientInterface|MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureEvent')
             ->with(['message' => 'foo'])
-            ->willReturn('2b867534eead412cbdb882fd5d441690');
+            ->willReturn($eventId);
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $this->assertEquals('2b867534eead412cbdb882fd5d441690', captureEvent(['message' => 'foo']));
+        $this->assertSame($eventId, captureEvent(['message' => 'foo']));
     }
 
     public function testCaptureLastError()
     {
+        $eventId = EventId::generate();
+
         /** @var ClientInterface|MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
-            ->method('captureLastError');
+            ->method('captureLastError')
+            ->willReturn($eventId);
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
         @trigger_error('foo', E_USER_NOTICE);
 
-        captureLastError();
+        $this->assertSame($eventId, captureLastError());
     }
 
     public function testAddBreadcrumb(): void

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -15,6 +15,6 @@ final class NullTransportTest extends TestCase
         $transport = new NullTransport();
         $event = new Event();
 
-        $this->assertSame((string) $event->getId(false), $transport->send($event));
+        $this->assertSame($event->getId(), $transport->send($event));
     }
 }

--- a/tests/Transport/SpoolTransportTest.php
+++ b/tests/Transport/SpoolTransportTest.php
@@ -48,7 +48,7 @@ final class SpoolTransportTest extends TestCase
         $eventId = $this->transport->send($event);
 
         if ($isSendingSuccessful) {
-            $this->assertSame((string) $event->getId(false), $eventId);
+            $this->assertSame($event->getId(), $eventId);
         } else {
             $this->assertNull($eventId);
         }

--- a/tests/phpt/error_handler_captures_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_fatal_error.phpt
@@ -10,6 +10,7 @@ namespace Sentry\Tests;
 use Sentry\ClientBuilder;
 use Sentry\ErrorHandler;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\Transport\TransportFactoryInterface;
@@ -27,7 +28,7 @@ $transportFactory = new class implements TransportFactoryInterface {
     public function create(Options $options): TransportInterface
     {
         return new class implements TransportInterface {
-            public function send(Event $event): ?string
+            public function send(Event $event): ?EventId
             {
                 echo 'Transport called' . PHP_EOL;
 

--- a/tests/phpt/error_handler_respects_error_reporting.phpt
+++ b/tests/phpt/error_handler_respects_error_reporting.phpt
@@ -9,6 +9,7 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\Transport\TransportFactoryInterface;
@@ -26,7 +27,7 @@ $transportFactory = new class implements TransportFactoryInterface {
     public function create(Options $options): TransportInterface
     {
         return new class implements TransportInterface {
-            public function send(Event $event): ?string
+            public function send(Event $event): ?EventId
             {
                 echo 'Transport called' . PHP_EOL;
 

--- a/tests/phpt/error_listener_integration_respects_error_types_option.phpt
+++ b/tests/phpt/error_listener_integration_respects_error_types_option.phpt
@@ -9,6 +9,7 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Options;
 use Sentry\SentrySdk;
@@ -27,7 +28,7 @@ $transportFactory = new class implements TransportFactoryInterface {
     public function create(Options $options): TransportInterface
     {
         return new class implements TransportInterface {
-            public function send(Event $event): ?string
+            public function send(Event $event): ?EventId
             {
                 echo 'Transport called';
 

--- a/tests/phpt/fatal_error_integration_captures_fatal_error.phpt
+++ b/tests/phpt/fatal_error_integration_captures_fatal_error.phpt
@@ -9,6 +9,7 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Options;
 use Sentry\SentrySdk;
@@ -27,7 +28,7 @@ $transportFactory = new class implements TransportFactoryInterface {
     public function create(Options $options): TransportInterface
     {
         return new class implements TransportInterface {
-            public function send(Event $event): ?string
+            public function send(Event $event): ?EventId
             {
                 echo 'Transport called' . PHP_EOL;
 

--- a/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
+++ b/tests/phpt/fatal_error_integration_respects_error_types_option.phpt
@@ -9,6 +9,7 @@ namespace Sentry\Tests;
 
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\EventId;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Options;
 use Sentry\SentrySdk;
@@ -27,7 +28,7 @@ $transportFactory = new class implements TransportFactoryInterface {
     public function create(Options $options): TransportInterface
     {
         return new class implements TransportInterface {
-            public function send(Event $event): ?string
+            public function send(Event $event): ?EventId
             {
                 echo 'Transport called (it should not have been)' . PHP_EOL;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

This PR cleanups the codebase from the deprecations triggered by #1013 