### PR TITLE
Cleanup the deprecations triggered by Hub::getCurrent() and Hub::setCurrent()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [BC BREAK] Remove the deprecated code that made the `Hub` class a singleton
+
 ### 2.4.1 (2020-07-03)
 
 - Fix HTTP client connection timeouts not being applied if an HTTP proxy is specified (#1033)

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,3 @@
+# Upgrade 2.x to 3.0
+
+- Removed the `HubInterface::getCurrentHub()` and `HubInterface::setCurrentHub()` methods. Use `SentrySdk::getCurrentHub()` and `SentrySdk::setCurrentHub()` instead.

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -7,7 +7,6 @@ namespace Sentry\State;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Integration\IntegrationInterface;
-use Sentry\SentrySdk;
 use Sentry\Severity;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
@@ -191,28 +190,6 @@ final class Hub implements HubInterface
         }
 
         return null !== $breadcrumb;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function getCurrent(): HubInterface
-    {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::getCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return SentrySdk::getCurrentHub();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function setCurrent(HubInterface $hub): HubInterface
-    {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::setCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
-
-        SentrySdk::setCurrentHub($hub);
-
-        return $hub;
     }
 
     /**

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -142,26 +142,6 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public static function getCurrent(): HubInterface
-    {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::getCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return SentrySdk::getCurrentHub();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public static function setCurrent(HubInterface $hub): HubInterface
-    {
-        @trigger_error(sprintf('The %s() method is deprecated since version 2.2 and will be removed in 3.0. Use SentrySdk::getCurrentHub() instead.', __METHOD__), E_USER_DEPRECATED);
-
-        return SentrySdk::setCurrentHub($hub);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getIntegration(string $className): ?IntegrationInterface
     {
         return SentrySdk::getCurrentHub()->getIntegration($className);

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -107,26 +107,6 @@ interface HubInterface
     public function addBreadcrumb(Breadcrumb $breadcrumb): bool;
 
     /**
-     * Returns the current global Hub.
-     *
-     * @return HubInterface
-     *
-     * @deprecated since version 2.2, to be removed in 3.0
-     */
-    public static function getCurrent(): self;
-
-    /**
-     * Sets the Hub as the current.
-     *
-     * @param HubInterface $hub The Hub that will become the current one
-     *
-     * @return HubInterface
-     *
-     * @deprecated since version 2.2, to be removed in 3.0
-     */
-    public static function setCurrent(self $hub): self;
-
-    /**
      * Gets the integration whose FQCN matches the given one if it's available on the current client.
      *
      * @param string $className The FQCN of the integration


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 3.0
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| License       | MIT

Cleanup of the deprecations introduced in #847