### PR TITLE
Ability to pass fingerprint via Monolog context

### DIFF
--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -70,6 +70,10 @@ final class Handler extends AbstractProcessingHandler
                 }
             }
 
+            if (isset($record['context']['fingerprint']) && \is_array($record['context']['fingerprint'])) {
+                $scope->setFingerprint($record['context']['fingerprint']);
+            }
+
             $this->hub->captureEvent($payload);
         });
     }


### PR DESCRIPTION
Hi.

Will be great if developer can pass fingerprint for Sentry event via Monolog context.

`$this->logger->error('some error', ['fingerprint' => ['group','by','that']]);`

Thanks for yours time.