### PR TITLE
Fix passing incorrect PSR factories to curl client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix typehint errors while instantiating the Httplug cURL client by forcing the usage of PSR-17 complaint factories (#1052)
+
 ### 2.4.1 (2020-07-03)
 
 - Fix HTTP client connection timeouts not being applied if an HTTP proxy is specified (#1033)

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -136,7 +136,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 }
 
                 /** @psalm-suppress InvalidPropertyAssignmentValue */
-                $httpClient = new CurlHttpClient($this->responseFactory, $this->streamFactory, $curlConfig);
+                $httpClient = new CurlHttpClient(null, null, $curlConfig);
             } elseif (null !== $options->getHttpProxy()) {
                 throw new \RuntimeException('The "http_proxy" option requires either the "php-http/curl-client" or the "php-http/guzzle6-adapter" package to be installed.');
             }


### PR DESCRIPTION
We are passing our internal response and stream factories to the curl http client, which are deprecated, however it expects actual PSR namespaced classes we are not using yet internally (because BC).

Setting them to null causes the curl client to discover it's own fixing: #1039 & #1041.

I think this should be released as `1.4.2` as soon as we can 😄