### PR TITLE
Fix unreliable test comparing timestamps

### DIFF
--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -12,6 +12,7 @@ use Sentry\Event;
 use Sentry\Severity;
 use Sentry\Stacktrace;
 use Sentry\Util\PHPVersion;
+use Symfony\Bridge\PhpUnit\ClockMock;
 
 /**
  * @group time-sensitive
@@ -40,6 +41,8 @@ final class EventTest extends TestCase
 
     public function testToArray(): void
     {
+        ClockMock::register(Event::class);
+
         $event = new Event();
 
         $expected = [
@@ -70,6 +73,8 @@ final class EventTest extends TestCase
 
     public function testToArrayMergesCustomContextsWithDefaultContexts(): void
     {
+        ClockMock::register(Event::class);
+
         $event = new Event();
         $event->setContext('foo', ['foo' => 'bar']);
         $event->setContext('bar', ['bar' => 'foo']);


### PR DESCRIPTION
The amount of times this test fails annoys me and since there is no easy way for us to restart tests it's just better to fix the "problem".

Example (but there are many): https://ci.appveyor.com/project/sentry/sentry-php/builds/34276992/job/mi61ululink3kbfl

No changelog needed, just a QoL improvement.