### PR TITLE
Allow setting the environment to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `Options::setEnvironment` method not accepting `null` values (#1057)
+
 ### 2.4.2 (2020-07-24)
 
 - Fix typehint errors while instantiating the Httplug cURL client by forcing the usage of PSR-17 complaint factories (#1052)

--- a/src/Options.php
+++ b/src/Options.php
@@ -193,9 +193,9 @@ final class Options
     /**
      * Sets the environment.
      *
-     * @param string $environment The environment
+     * @param string|null $environment The environment
      */
-    public function setEnvironment(string $environment): void
+    public function setEnvironment(?string $environment): void
     {
         $options = array_merge($this->options, ['environment' => $environment]);
 


### PR DESCRIPTION
Null is a valid value for the environment option (it means no environment is specified).

This allow setting the environment to null in the Option class.