### PR TITLE
Avoid capturing the request body in the RequestIntegration integration when the stream size is unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix `Options::setEnvironment` method not accepting `null` values (#1057)
+- Fix the capture of the request body in the `RequestIntegration` integration when the stream size is unknown (#1064)
 
 ### 2.4.2 (2020-07-24)
 

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -185,11 +185,13 @@ final class RequestIntegration implements IntegrationInterface
     {
         $maxRequestBodySize = $options->getMaxRequestBodySize();
         $requestBody = $serverRequest->getBody();
+        $requestBodySize = $requestBody->getSize();
 
         if (
+            null === $requestBodySize ||
             'none' === $maxRequestBodySize ||
-            ('small' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH) ||
-            ('medium' === $maxRequestBodySize && $requestBody->getSize() > self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH)
+            ('small' === $maxRequestBodySize && $requestBodySize > self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH) ||
+            ('medium' === $maxRequestBodySize && $requestBodySize > self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH)
         ) {
             return null;
         }

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -444,9 +444,26 @@ final class RequestIntegrationTest extends TestCase
                 'data' => '{',
             ],
         ];
+
+        yield [
+            [
+                'max_request_body_size' => 'always',
+            ],
+            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->getStreamMock(null)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Content-Type' => ['application/json'],
+                ],
+            ],
+        ];
     }
 
-    private function getStreamMock(int $size, string $content = ''): StreamInterface
+    private function getStreamMock(?int $size, string $content = ''): StreamInterface
     {
         /** @var MockObject|StreamInterface $stream */
         $stream = $this->createMock(StreamInterface::class);
@@ -454,7 +471,7 @@ final class RequestIntegrationTest extends TestCase
             ->method('getSize')
             ->willReturn($size);
 
-        $stream->expects($this->any())
+        $stream->expects(null === $size ? $this->never() : $this->any())
             ->method('getContents')
             ->willReturn($content);
 


### PR DESCRIPTION
Little bugfix for #1065. The `StreamInterface::getSize()` method can return `null` and in that case we should skip reading the request body of the request regardless of any other condition to avoid issues such as out of memory