### PR TITLE
Cleanup the Monolog handler from deprecated features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [BC BREAK] The `Scope::setUser()` method now always merges the given data with the existing one instead of replacing it as a whole (#1047)
 - [BC BREAK] Remove the `Context::CONTEXT_USER`, `Context::CONTEXT_RUNTIME`, `Context::CONTEXT_TAGS`, `Context::CONTEXT_EXTRA`, `Context::CONTEXT_SERVER_OS` constants (#1047)
 - [BC BREAK] Use PSR-17 factories in place of the Httplug's ones and return a promise from the transport (#1066)
+- [BC BREAK] The Monolog handler does not set anymore tags and extras on the event object (#1068)
 
 ### 2.4.1 (2020-07-03)
 

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -58,18 +58,6 @@ final class Handler extends AbstractProcessingHandler
             $scope->setExtra('monolog.channel', $record['channel']);
             $scope->setExtra('monolog.level', $record['level_name']);
 
-            if (isset($record['context']['extra']) && \is_array($record['context']['extra'])) {
-                foreach ($record['context']['extra'] as $key => $value) {
-                    $scope->setExtra((string) $key, $value);
-                }
-            }
-
-            if (isset($record['context']['tags']) && \is_array($record['context']['tags'])) {
-                foreach ($record['context']['tags'] as $key => $value) {
-                    $scope->setTag($key, $value);
-                }
-            }
-
             $this->hub->captureEvent($payload);
         });
     }
@@ -84,9 +72,6 @@ final class Handler extends AbstractProcessingHandler
         switch ($level) {
             case Logger::DEBUG:
                 return Severity::debug();
-            case Logger::INFO:
-            case Logger::NOTICE:
-                return Severity::info();
             case Logger::WARNING:
                 return Severity::warning();
             case Logger::ERROR:
@@ -95,6 +80,8 @@ final class Handler extends AbstractProcessingHandler
             case Logger::ALERT:
             case Logger::EMERGENCY:
                 return Severity::fatal();
+            case Logger::INFO:
+            case Logger::NOTICE:
             default:
                 return Severity::info();
         }

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -19,29 +19,26 @@ final class HandlerTest extends TestCase
     /**
      * @dataProvider handleDataProvider
      */
-    public function testHandle(array $record, array $expectedPayload, array $expectedExtra, array $expectedTags): void
+    public function testHandle(array $record, array $expectedPayload, array $expectedExtra): void
     {
-        $scope = new Scope();
-
         /** @var ClientInterface&MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureEvent')
-            ->with($expectedPayload, $this->callback(function (Scope $scopeArg) use ($expectedExtra, $expectedTags): bool {
+            ->with($expectedPayload, $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
                 $event = $scopeArg->applyToEvent(new Event(), []);
 
                 $this->assertNotNull($event);
                 $this->assertSame($expectedExtra, $event->getExtraContext()->toArray());
-                $this->assertSame($expectedTags, $event->getTagsContext()->toArray());
 
                 return true;
             }));
 
-        $handler = new Handler(new Hub($client, $scope));
+        $handler = new Handler(new Hub($client, new Scope()));
         $handler->handle($record);
     }
 
-    public function handleDataProvider(): \Generator
+    public function handleDataProvider(): iterable
     {
         yield [
             [
@@ -61,7 +58,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::DEBUG),
             ],
-            [],
         ];
 
         yield [
@@ -82,7 +78,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::INFO),
             ],
-            [],
         ];
 
         yield [
@@ -103,7 +98,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::NOTICE),
             ],
-            [],
         ];
 
         yield [
@@ -124,7 +118,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::WARNING),
             ],
-            [],
         ];
 
         yield [
@@ -145,7 +138,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::ERROR),
             ],
-            [],
         ];
 
         yield [
@@ -166,7 +158,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::CRITICAL),
             ],
-            [],
         ];
 
         yield [
@@ -187,7 +178,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::ALERT),
             ],
-            [],
         ];
 
         yield [
@@ -208,43 +198,6 @@ final class HandlerTest extends TestCase
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::EMERGENCY),
             ],
-            [],
-        ];
-
-        yield [
-            [
-                'message' => 'foo bar',
-                'level' => Logger::WARNING,
-                'level_name' => Logger::getLevelName(Logger::WARNING),
-                'context' => [
-                    'extra' => [
-                        'foo.extra' => 'foo extra value',
-                        'bar.extra' => 'bar extra value',
-                    ],
-                    'tags' => [
-                        'foo.tag' => 'foo tag value',
-                        'bar.tag' => 'bar tag value',
-                    ],
-                ],
-                'channel' => 'channel.foo',
-                'datetime' => new \DateTimeImmutable(),
-                'extra' => [],
-            ],
-            [
-                'level' => Severity::warning(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
-            [
-                'monolog.channel' => 'channel.foo',
-                'monolog.level' => Logger::getLevelName(Logger::WARNING),
-                'foo.extra' => 'foo extra value',
-                'bar.extra' => 'bar extra value',
-            ],
-            [
-                'foo.tag' => 'foo tag value',
-                'bar.tag' => 'bar tag value',
-            ],
         ];
 
         yield [
@@ -254,14 +207,6 @@ final class HandlerTest extends TestCase
                 'level_name' => Logger::getLevelName(Logger::WARNING),
                 'context' => [
                     'exception' => new \Exception('exception message'),
-                    'extra' => [
-                        'foo.extra' => 'foo extra value',
-                        'bar.extra' => 'bar extra value',
-                    ],
-                    'tags' => [
-                        'foo.tag' => 'foo tag value',
-                        'bar.tag' => 'bar tag value',
-                    ],
                 ],
                 'channel' => 'channel.foo',
                 'datetime' => new \DateTimeImmutable(),
@@ -276,39 +221,7 @@ final class HandlerTest extends TestCase
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::WARNING),
-                'foo.extra' => 'foo extra value',
-                'bar.extra' => 'bar extra value',
             ],
-            [
-                'foo.tag' => 'foo tag value',
-                'bar.tag' => 'bar tag value',
-            ],
-        ];
-
-        yield [
-            [
-                'message' => 'foo bar',
-                'level' => Logger::INFO,
-                'level_name' => Logger::getLevelName(Logger::INFO),
-                'channel' => 'channel.foo',
-                'context' => [
-                    'extra' => [
-                        1 => 'numeric key',
-                    ],
-                ],
-                'extra' => [],
-            ],
-            [
-                'level' => Severity::info(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
-            [
-                'monolog.channel' => 'channel.foo',
-                'monolog.level' => Logger::getLevelName(Logger::INFO),
-                '0' => 'numeric key',
-            ],
-            [],
         ];
     }
 }


### PR DESCRIPTION
With this PR I'm going to revert the support of our Monolog handler for setting tags and extras on the events. The reason of this change is that, as discussed multiple times in the past, we don't want to rely on pulling more information than necessary from the unstructured data of the record's context because the same keys may be used by the user for things that have nothing to do with Sentry