### PR TITLE
Extract the logic to serialize the event into an event serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ More information can be found in our [Performance](https://docs.sentry.io/produc
 - [BC BREAK] Remove the `UserContext`, `ExtraContext` and `Context` classes and refactor the `ServerOsContext` and `RuntimeContext` classes (#1071)
 - [BC BREAK] Remove the `FlushableClientInterface` and the `ClosableTransportInterface` interfaces (#1079)
 - Add the `EnvironmentIntegration` integration to gather data for the `os` and `runtime` contexts (#1071)
+- Refactor how the event data gets serialized to JSON (#1077)
 
 ### 2.4.3 (2020-08-13)
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -104,3 +104,7 @@
 - Renamed the `Event::getServerOsContext()` method to `Event::getOsContext()`
 - The signature of the `Scope::setUser()` method changed ot accept a plain array
 - Removed the `FlushableClientInterface` and `ClosableTransportInterface` interfaces. Their methods have been moved to the corresponding `ClientInterface` and `TransportInterface` interfaces
+- Removed the `Event::toArray()` and `Event::jsonSerialize()` methods
+- Removed the `Breadcrumb::toArray()` and `Breadcrumb::jsonSerialize()` methods
+- Removed the `Frame::toArray()` and `Frame::jsonSerialize()` methods
+- Removed the `Stacktrace::toArray()` and `Stacktrace::jsonSerialize()` methods

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "guzzlehttp/promises": "^1.3",
         "guzzlehttp/psr7": "^1.6",
         "jean85/pretty-package-versions": "^1.2",
+        "ocramius/package-versions": "^1.8",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
         "php-http/discovery": "^1.6.1",

--- a/src/Breadcrumb.php
+++ b/src/Breadcrumb.php
@@ -11,7 +11,7 @@ use Sentry\Exception\InvalidArgumentException;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class Breadcrumb implements \JsonSerializable
+final class Breadcrumb
 {
     /**
      * This constant defines the default breadcrumb type.
@@ -301,23 +301,6 @@ final class Breadcrumb implements \JsonSerializable
     }
 
     /**
-     * Gets the breadcrumb as an array.
-     *
-     * @return array<string, mixed>
-     */
-    public function toArray(): array
-    {
-        return [
-            'type' => $this->type,
-            'category' => $this->category,
-            'level' => $this->level,
-            'message' => $this->message,
-            'timestamp' => $this->timestamp,
-            'data' => $this->metadata,
-        ];
-    }
-
-    /**
      * Helper method to create an instance of this class from an array of data.
      *
      * @param array $data Data used to populate the breadcrumb
@@ -339,15 +322,5 @@ final class Breadcrumb implements \JsonSerializable
             $data['message'] ?? null,
             $data['data'] ?? []
         );
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -180,7 +180,7 @@ final class Client implements ClientInterface
 
         $sampleRate = $this->options->getSampleRate();
 
-        if ('transaction' !== $event->getType() && $sampleRate < 1 && mt_rand(1, 100) / 100.0 > $sampleRate) {
+        if (EventType::transaction() !== $event->getType() && $sampleRate < 1 && mt_rand(1, 100) / 100.0 > $sampleRate) {
             $this->logger->info('The event will be discarded because it has been sampled.', ['event' => $event]);
 
             return null;

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -188,7 +188,13 @@ final class ClientBuilder implements ClientBuilderInterface
         $this->serializer = $this->serializer ?? new Serializer($this->options);
         $this->representationSerializer = $this->representationSerializer ?? new RepresentationSerializer($this->options);
 
-        return new EventFactory($this->serializer, $this->representationSerializer, $this->options, $this->sdkIdentifier, $this->sdkVersion);
+        return new EventFactory(
+            $this->serializer,
+            $this->representationSerializer,
+            $this->options,
+            $this->sdkIdentifier,
+            $this->sdkVersion
+        );
     }
 
     /**
@@ -206,6 +212,10 @@ final class ClientBuilder implements ClientBuilderInterface
             $this->sdkVersion
         );
 
-        return new DefaultTransportFactory($streamFactory, Psr17FactoryDiscovery::findRequestFactory(), $httpClientFactory, $this->logger);
+        return new DefaultTransportFactory(
+            $streamFactory, Psr17FactoryDiscovery::findRequestFactory(),
+            $httpClientFactory,
+            $this->logger
+        );
     }
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -213,7 +213,8 @@ final class ClientBuilder implements ClientBuilderInterface
         );
 
         return new DefaultTransportFactory(
-            $streamFactory, Psr17FactoryDiscovery::findRequestFactory(),
+            $streamFactory,
+            Psr17FactoryDiscovery::findRequestFactory(),
             $httpClientFactory,
             $this->logger
         );

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -86,6 +86,7 @@ final class EventFactory implements EventFactoryInterface
                 $event = $payload;
             } else {
                 $event = new Event();
+
                 if (isset($payload['logger'])) {
                     $event->setLogger($payload['logger']);
                 }

--- a/src/EventType.php
+++ b/src/EventType.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+/**
+ * This enum represents all the possible types of events that a Sentry server
+ * supports.
+ *
+ * @author Stefano Arlandini <sarlandini@alice.it>
+ */
+final class EventType
+{
+    /**
+     * @var string The value of the enum instance
+     */
+    private $value;
+
+    /**
+     * @var array<string, self> A list of cached enum instances
+     */
+    private static $instances = [];
+
+    private function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * Creates an instance of this enum for the "default" value.
+     */
+    public static function default(): self
+    {
+        return self::getInstance('default');
+    }
+
+    /**
+     * Creates an instance of this enum for the "transaction" value.
+     */
+    public static function transaction(): self
+    {
+        return self::getInstance('transaction');
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    private static function getInstance(string $value): self
+    {
+        if (!isset(self::$instances[$value])) {
+            self::$instances[$value] = new self($value);
+        }
+
+        return self::$instances[$value];
+    }
+}

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -9,7 +9,7 @@ namespace Sentry;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class Frame implements \JsonSerializable
+final class Frame
 {
     public const INTERNAL_FRAME_FILENAME = '[internal]';
 
@@ -32,7 +32,7 @@ final class Frame implements \JsonSerializable
     private $file;
 
     /**
-     * @var string The absolute path to the source file
+     * @var string|null The absolute path to the source file
      */
     private $absoluteFilePath;
 
@@ -92,7 +92,7 @@ final class Frame implements \JsonSerializable
         $this->file = $file;
         $this->line = $line;
         $this->rawFunctionName = $rawFunctionName;
-        $this->absoluteFilePath = $absoluteFilePath ?? $file;
+        $this->absoluteFilePath = $absoluteFilePath;
         $this->vars = $vars;
         $this->inApp = $inApp;
     }
@@ -125,7 +125,7 @@ final class Frame implements \JsonSerializable
     /**
      * Gets the absolute path to the source file.
      */
-    public function getAbsoluteFilePath(): string
+    public function getAbsoluteFilePath(): ?string
     {
         return $this->absoluteFilePath;
     }
@@ -246,62 +246,5 @@ final class Frame implements \JsonSerializable
     public function isInternal(): bool
     {
         return self::INTERNAL_FRAME_FILENAME === $this->file;
-    }
-
-    /**
-     * Returns an array representation of the data of this frame modeled according
-     * to the specifications of the Sentry SDK Stacktrace Interface.
-     *
-     * @psalm-return array{
-     *     function: string|null,
-     *     raw_function: string|null,
-     *     filename: string,
-     *     lineno: int,
-     *     in_app: bool,
-     *     abs_path: string,
-     *     pre_context?: string[],
-     *     context_line?: string,
-     *     post_context?: string[],
-     *     vars?: array<string, mixed>
-     * }
-     */
-    public function toArray(): array
-    {
-        $result = [
-            'function' => $this->functionName,
-            'raw_function' => $this->rawFunctionName,
-            'filename' => $this->file,
-            'lineno' => $this->line,
-            'in_app' => $this->inApp,
-            'abs_path' => $this->absoluteFilePath,
-        ];
-
-        if (0 !== \count($this->preContext)) {
-            $result['pre_context'] = $this->preContext;
-        }
-
-        if (null !== $this->contextLine) {
-            $result['context_line'] = $this->contextLine;
-        }
-
-        if (0 !== \count($this->postContext)) {
-            $result['post_context'] = $this->postContext;
-        }
-
-        if (!empty($this->vars)) {
-            $result['vars'] = $this->vars;
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
     }
 }

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -64,6 +64,7 @@ final class FrameBuilder
 
         $functionName = null;
         $rawFunctionName = null;
+        $strippedFilePath = $this->stripPrefixFromFilePath($file);
 
         if (isset($backtraceFrame['class']) && isset($backtraceFrame['function'])) {
             $functionName = $backtraceFrame['class'];
@@ -80,10 +81,10 @@ final class FrameBuilder
 
         return new Frame(
             $functionName,
-            $this->stripPrefixFromFilePath($file),
+            $strippedFilePath,
             $line,
             $rawFunctionName,
-            Frame::INTERNAL_FRAME_FILENAME !== $file ? $file : null,
+            Frame::INTERNAL_FRAME_FILENAME !== $file && $strippedFilePath !== $file ? $file : null,
             $this->getFunctionArguments($backtraceFrame),
             $this->isFrameInApp($file, $functionName)
         );

--- a/src/Integration/FrameContextifierIntegration.php
+++ b/src/Integration/FrameContextifierIntegration.php
@@ -78,7 +78,7 @@ final class FrameContextifierIntegration implements IntegrationInterface
     private function addContextToStacktraceFrames(int $maxContextLines, Stacktrace $stacktrace): void
     {
         foreach ($stacktrace->getFrames() as $frame) {
-            if ($frame->isInternal()) {
+            if ($frame->isInternal() || null === $frame->getAbsoluteFilePath()) {
                 continue;
             }
 

--- a/src/Serializer/EventSerializer.php
+++ b/src/Serializer/EventSerializer.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer;
+
+use Sentry\Breadcrumb;
+use Sentry\Event;
+use Sentry\EventType;
+use Sentry\ExceptionDataBag;
+use Sentry\Frame;
+use Sentry\Tracing\Span;
+use Sentry\Util\JSON;
+
+/**
+ * This is a simple implementation of a serializer that takes in input an event
+ * object and returns a serialized string ready to be sent off to Sentry.
+ */
+final class EventSerializer implements EventSerializerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize(Event $event): string
+    {
+        if (EventType::transaction() === $event->getType()) {
+            return $this->serializeAsEnvelope($event);
+        }
+
+        return $this->serializeAsEvent($event);
+    }
+
+    private function serializeAsEvent(Event $event): string
+    {
+        $result = [
+            'event_id' => (string) $event->getId(),
+            'timestamp' => $event->getTimestamp(),
+            'platform' => 'php',
+            'sdk' => [
+                'name' => $event->getSdkIdentifier(),
+                'version' => $event->getSdkVersion(),
+            ],
+        ];
+
+        if (null !== $event->getStartTimestamp()) {
+            $result['start_timestamp'] = $event->getStartTimestamp();
+        }
+
+        if (null !== $event->getLevel()) {
+            $result['level'] = (string) $event->getLevel();
+        }
+
+        if (null !== $event->getLogger()) {
+            $result['logger'] = $event->getLogger();
+        }
+
+        if (null !== $event->getTransaction()) {
+            $result['transaction'] = $event->getTransaction();
+        }
+
+        if (null !== $event->getServerName()) {
+            $result['server_name'] = $event->getServerName();
+        }
+
+        if (null !== $event->getRelease()) {
+            $result['release'] = $event->getRelease();
+        }
+
+        if (null !== $event->getEnvironment()) {
+            $result['environment'] = $event->getEnvironment();
+        }
+
+        if (!empty($event->getFingerprint())) {
+            $result['fingerprint'] = $event->getFingerprint();
+        }
+
+        if (!empty($event->getModules())) {
+            $result['modules'] = $event->getModules();
+        }
+
+        if (!empty($event->getExtra())) {
+            $result['extra'] = $event->getExtra();
+        }
+
+        if (!empty($event->getTags())) {
+            $result['tags'] = $event->getTags();
+        }
+
+        $user = $event->getUser();
+
+        if (null !== $user) {
+            $result['user'] = array_merge($user->getMetadata(), [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+                'ip_address' => $user->getIpAddress(),
+            ]);
+        }
+
+        $osContext = $event->getOsContext();
+        $runtimeContext = $event->getRuntimeContext();
+
+        if (null !== $osContext) {
+            $result['contexts']['os'] = [
+                'name' => $osContext->getName(),
+                'version' => $osContext->getVersion(),
+                'build' => $osContext->getBuild(),
+                'kernel_version' => $osContext->getKernelVersion(),
+            ];
+        }
+
+        if (null !== $runtimeContext) {
+            $result['contexts']['runtime'] = [
+                'name' => $runtimeContext->getName(),
+                'version' => $runtimeContext->getVersion(),
+            ];
+        }
+
+        if (!empty($event->getContexts())) {
+            $result['contexts'] = array_merge($result['contexts'] ?? [], $event->getContexts());
+        }
+
+        if (!empty($event->getBreadcrumbs())) {
+            $result['breadcrumbs']['values'] = array_map([$this, 'serializeBreadcrumb'], $event->getBreadcrumbs());
+        }
+
+        if (!empty($event->getRequest())) {
+            $result['request'] = $event->getRequest();
+        }
+
+        if (null !== $event->getMessage()) {
+            if (empty($event->getMessageParams())) {
+                $result['message'] = $event->getMessage();
+            } else {
+                $result['message'] = [
+                    'message' => $event->getMessage(),
+                    'params' => $event->getMessageParams(),
+                    'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
+                ];
+            }
+        }
+
+        $exceptions = $event->getExceptions();
+
+        for ($i = \count($exceptions) - 1; $i >= 0; --$i) {
+            $result['exception']['values'][] = $this->serializeException($exceptions[$i]);
+        }
+
+        if (EventType::transaction() === $event->getType()) {
+            $result['spans'] = array_map([$this, 'serializeSpan'], $event->getSpans());
+        }
+
+        return JSON::encode($result);
+    }
+
+    private function serializeAsEnvelope(Event $event): string
+    {
+        $envelopeHeader = JSON::encode([
+            'event_id' => (string) $event->getId(),
+            'sent_at' => gmdate('Y-m-d\TH:i:s\Z'),
+        ]);
+
+        $itemHeader = JSON::encode([
+            'type' => (string) $event->getType(),
+            'content_type' => 'application/json',
+        ]);
+
+        return sprintf("%s\n%s\n%s", $envelopeHeader, $itemHeader, $this->serializeAsEvent($event));
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     type: string,
+     *     category: string,
+     *     level: string,
+     *     timestamp: float,
+     *     message?: string,
+     *     data?: array<string, mixed>
+     * }
+     */
+    private function serializeBreadcrumb(Breadcrumb $breadcrumb): array
+    {
+        $result = [
+            'type' => $breadcrumb->getType(),
+            'category' => $breadcrumb->getCategory(),
+            'level' => $breadcrumb->getLevel(),
+            'timestamp' => $breadcrumb->getTimestamp(),
+        ];
+
+        if (null !== $breadcrumb->getMessage()) {
+            $result['message'] = $breadcrumb->getMessage();
+        }
+
+        if (!empty($breadcrumb->getMetadata())) {
+            $result['data'] = $breadcrumb->getMetadata();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     type: string,
+     *     value: string,
+     *     stacktrace?: array{
+     *         frames: array<array<string, mixed>>
+     *     },
+     *     mechanism?: array{
+     *         type: string,
+     *         handled: boolean
+     *     }
+     * }
+     */
+    private function serializeException(ExceptionDataBag $exception): array
+    {
+        $exceptionMechanism = $exception->getMechanism();
+        $exceptionStacktrace = $exception->getStacktrace();
+        $result = [
+            'type' => $exception->getType(),
+            'value' => $exception->getValue(),
+        ];
+
+        if (null !== $exceptionStacktrace) {
+            $result['stacktrace'] = [
+                'frames' => array_map([$this, 'serializeStacktraceFrame'], $exceptionStacktrace->getFrames()),
+            ];
+        }
+
+        if (null !== $exceptionMechanism) {
+            $result['mechanism'] = [
+                'type' => $exceptionMechanism->getType(),
+                'handled' => $exceptionMechanism->isHandled(),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     filename: string,
+     *     lineno: int,
+     *     in_app: bool,
+     *     abs_path?: string,
+     *     function?: string,
+     *     raw_function?: string,
+     *     pre_context?: string[],
+     *     context_line?: string,
+     *     post_context?: string[],
+     *     vars?: array<string, mixed>
+     * }
+     */
+    private function serializeStacktraceFrame(Frame $frame): array
+    {
+        $result = [
+            'filename' => $frame->getFile(),
+            'lineno' => $frame->getLine(),
+            'in_app' => $frame->isInApp(),
+        ];
+
+        if (null !== $frame->getAbsoluteFilePath()) {
+            $result['abs_path'] = $frame->getAbsoluteFilePath();
+        }
+
+        if (null !== $frame->getFunctionName()) {
+            $result['function'] = $frame->getFunctionName();
+        }
+
+        if (null !== $frame->getRawFunctionName()) {
+            $result['raw_function'] = $frame->getRawFunctionName();
+        }
+
+        if (!empty($frame->getPreContext())) {
+            $result['pre_context'] = $frame->getPreContext();
+        }
+
+        if (null !== $frame->getContextLine()) {
+            $result['context_line'] = $frame->getContextLine();
+        }
+
+        if (!empty($frame->getPostContext())) {
+            $result['post_context'] = $frame->getPostContext();
+        }
+
+        if (!empty($frame->getVars())) {
+            $result['vars'] = $frame->getVars();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     span_id: string,
+     *     trace_id: string,
+     *     parent_span_id?: string,
+     *     start_timestamp: float,
+     *     timestamp?: float,
+     *     status?: string,
+     *     description?: string,
+     *     op?: string,
+     *     data?: array<string, mixed>,
+     *     tags?: array<string, string>
+     * }
+     */
+    private function serializeSpan(Span $span): array
+    {
+        $result = [
+            'span_id' => (string) $span->getSpanId(),
+            'trace_id' => (string) $span->getTraceId(),
+            'start_timestamp' => $span->getStartTimestamp(),
+        ];
+
+        if (null !== $span->getParentSpanId()) {
+            $result['parent_span_id'] = (string) $span->getParentSpanId();
+        }
+
+        if (null !== $span->getEndTimestamp()) {
+            $result['timestamp'] = $span->getEndTimestamp();
+        }
+
+        if (null !== $span->getStatus()) {
+            $result['status'] = $span->getStatus();
+        }
+
+        if (null !== $span->getDescription()) {
+            $result['description'] = $span->getDescription();
+        }
+
+        if (null !== $span->getOp()) {
+            $result['op'] = $span->getOp();
+        }
+
+        if (!empty($span->getData())) {
+            $result['data'] = $span->getData();
+        }
+
+        if (!empty($span->getTags())) {
+            $result['tags'] = $span->getTags();
+        }
+
+        return $result;
+    }
+}

--- a/src/Serializer/EventSerializerInterface.php
+++ b/src/Serializer/EventSerializerInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer;
+
+use Sentry\Event;
+
+/**
+ * This interface defines the contract for the classes willing to serialize an
+ * event object to a format suitable for sending over the wire to Sentry.
+ */
+interface EventSerializerInterface
+{
+    /**
+     * Serializes the given event object into a string.
+     *
+     * @param Event $event The event object
+     */
+    public function serialize(Event $event): string;
+}

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -15,8 +15,10 @@ use Sentry\Util\JSON;
 /**
  * This is a simple implementation of a serializer that takes in input an event
  * object and returns a serialized string ready to be sent off to Sentry.
+ *
+ * @internal
  */
-final class EventSerializer implements EventSerializerInterface
+final class PayloadSerializer implements PayloadSerializerInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Serializer/PayloadSerializerInterface.php
+++ b/src/Serializer/PayloadSerializerInterface.php
@@ -9,8 +9,10 @@ use Sentry\Event;
 /**
  * This interface defines the contract for the classes willing to serialize an
  * event object to a format suitable for sending over the wire to Sentry.
+ *
+ * @internal
  */
-interface EventSerializerInterface
+interface PayloadSerializerInterface
 {
     /**
      * Serializes the given event object into a string.

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -9,7 +9,7 @@ namespace Sentry;
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
-final class Stacktrace implements \JsonSerializable
+final class Stacktrace
 {
     /**
      * @var Frame[] The frames that compose the stacktrace
@@ -92,28 +92,5 @@ final class Stacktrace implements \JsonSerializable
         }
 
         array_splice($this->frames, $index, 1);
-    }
-
-    /**
-     * Gets the stacktrace frames (this is the same as calling the getFrames
-     * method).
-     *
-     * @return array<int, array>
-     */
-    public function toArray(): array
-    {
-        return array_map(static function (Frame $frame): array {
-            return $frame->toArray();
-        }, $this->frames);
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return array<int, array>
-     */
-    public function jsonSerialize()
-    {
-        return $this->toArray();
     }
 }

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -56,6 +56,8 @@ final class Scope
 
     /**
      * @var callable[] List of event processors
+     *
+     * @psalm-var array<callable(Event, Event|array): ?Event>
      */
     private $eventProcessors = [];
 
@@ -66,6 +68,8 @@ final class Scope
 
     /**
      * @var callable[] List of event processors
+     *
+     * @psalm-var array<callable(Event, Event|array): ?Event>
      */
     private static $globalEventProcessors = [];
 

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -311,6 +311,56 @@ class Span
     }
 
     /**
+     * Gets the data in a format suitable for storage in the "trace" context.
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     data?: array<string, mixed>,
+     *     description?: string,
+     *     op?: string,
+     *     parent_span_id?: string,
+     *     span_id: string,
+     *     status?: string,
+     *     tags?: array<string, string>,
+     *     trace_id: string
+     * }
+     */
+    public function getTraceContext(): array
+    {
+        $result = [
+            'span_id' => (string) $this->spanId,
+            'trace_id' => (string) $this->traceId,
+        ];
+
+        if (null !== $this->parentSpanId) {
+            $result['parent_span_id'] = (string) $this->parentSpanId;
+        }
+
+        if (null !== $this->description) {
+            $result['description'] = $this->description;
+        }
+
+        if (null !== $this->op) {
+            $result['op'] = $this->op;
+        }
+
+        if (null !== $this->status) {
+            $result['status'] = $this->status;
+        }
+
+        if (!empty($this->data)) {
+            $result['data'] = $this->data;
+        }
+
+        if (!empty($this->tags)) {
+            $result['tags'] = $this->tags;
+        }
+
+        return $result;
+    }
+
+    /**
      * Sets the finish timestamp on the current span.
      *
      * @param float|null $endTimestamp Takes an endTimestamp if the end should not be the time when you call this function

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -9,7 +9,7 @@ use Sentry\EventId;
 /**
  * This class stores all the information about a Span.
  */
-class Span implements \JsonSerializable
+class Span
 {
     /**
      * @var SpanId Span ID
@@ -103,13 +103,221 @@ class Span implements \JsonSerializable
     }
 
     /**
+     * Sets the ID of the span.
+     *
+     * @param SpanId $spanId The ID
+     */
+    public function setSpanId(SpanId $spanId): void
+    {
+        $this->spanId = $spanId;
+    }
+
+    /**
+     * Gets the ID that determines which trace the span belongs to.
+     */
+    public function getTraceId(): TraceId
+    {
+        return $this->traceId;
+    }
+
+    /**
+     * Sets the ID that determines which trace the span belongs to.
+     *
+     * @param TraceId $traceId The ID
+     */
+    public function setTraceId(TraceId $traceId): void
+    {
+        $this->traceId = $traceId;
+    }
+
+    /**
+     * Gets the ID that determines which span is the parent of the current one.
+     */
+    public function getParentSpanId(): ?SpanId
+    {
+        return $this->parentSpanId;
+    }
+
+    /**
+     * Sets the ID that determines which span is the parent of the current one.
+     *
+     * @param SpanId|null $parentSpanId The ID
+     */
+    public function setParentSpanId(?SpanId $parentSpanId): void
+    {
+        $this->parentSpanId = $parentSpanId;
+    }
+
+    /**
+     * Gets the timestamp representing when the measuring started.
+     */
+    public function getStartTimestamp(): float
+    {
+        return $this->startTimestamp;
+    }
+
+    /**
+     * Sets the timestamp representing when the measuring started.
+     *
+     * @param float $startTimestamp The timestamp
+     */
+    public function setStartTimestamp(float $startTimestamp): void
+    {
+        $this->startTimestamp = $startTimestamp;
+    }
+
+    /**
+     * Gets the timestamp representing when the measuring finished.
+     */
+    public function getEndTimestamp(): ?float
+    {
+        return $this->endTimestamp;
+    }
+
+    /**
+     * Returns `sentry-trace` header content.
+     */
+    public function toTraceparent(): string
+    {
+        $sampled = '';
+        if (null !== $this->sampled) {
+            $sampled = $this->sampled ? '-1' : '-0';
+        }
+
+        return $this->traceId . '-' . $this->spanId . $sampled;
+    }
+
+    /**
+     * Gets a description of the span's operation, which uniquely identifies
+     * the span but is consistent across instances of the span.
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Sets a description of the span's operation, which uniquely identifies
+     * the span but is consistent across instances of the span.
+     *
+     * @param string|null $description The description
+     */
+    public function setDescription(?string $description): void
+    {
+        $this->description = $description;
+    }
+
+    /**
+     * Gets a short code identifying the type of operation the span is measuring.
+     */
+    public function getOp(): ?string
+    {
+        return $this->op;
+    }
+
+    /**
+     * Sets a short code identifying the type of operation the span is measuring.
+     *
+     * @param string|null $op The short code
+     */
+    public function setOp(?string $op): void
+    {
+        $this->op = $op;
+    }
+
+    /**
+     * Gets the status of the span/transaction.
+     */
+    public function getStatus(): ?string
+    {
+        return $this->status;
+    }
+
+    /**
+     * Sets the status of the span/transaction.
+     *
+     * @param string|null $status The status
+     */
+    public function setStatus(?string $status): void
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * Gets a map of tags for this event.
+     *
+     * @return array<string, string>
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * Sets a map of tags for this event.
+     *
+     * @param array<string, string> $tags The tags
+     */
+    public function setTags(array $tags): void
+    {
+        $this->tags = array_merge($this->tags, $tags);
+    }
+
+    /**
+     * Gets the ID of the span.
+     */
+    public function getSpanId(): SpanId
+    {
+        return $this->spanId;
+    }
+
+    /**
+     * Gets the flag determining whether this span should be sampled or not.
+     */
+    public function getSampled(): ?bool
+    {
+        return $this->sampled;
+    }
+
+    /**
+     * Sets the flag determining whether this span should be sampled or not.
+     *
+     * @param bool $sampled Whether to sample or not this span
+     */
+    public function setSampled(?bool $sampled): void
+    {
+        $this->sampled = $sampled;
+    }
+
+    /**
+     * Gets a map of arbitrary data.
+     *
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * Sets a map of arbitrary data. This method will merge the given data with
+     * the existing one.
+     *
+     * @param array<string, mixed> $data The data
+     */
+    public function setData(array $data): void
+    {
+        $this->data = array_merge($this->data, $data);
+    }
+
+    /**
      * Sets the finish timestamp on the current span.
      *
      * @param float|null $endTimestamp Takes an endTimestamp if the end should not be the time when you call this function
      *
      * @return EventId|null Finish for a span always returns null
      */
-    public function finish($endTimestamp = null): ?EventId
+    public function finish(?float $endTimestamp = null): ?EventId
     {
         $this->endTimestamp = $endTimestamp ?? microtime(true);
 
@@ -138,198 +346,5 @@ class Span implements \JsonSerializable
         }
 
         return $span;
-    }
-
-    public function getStartTimestamp(): float
-    {
-        return $this->startTimestamp;
-    }
-
-    /**
-     * Returns `sentry-trace` header content.
-     */
-    public function toTraceparent(): string
-    {
-        $sampled = '';
-        if (null !== $this->sampled) {
-            $sampled = $this->sampled ? '-1' : '-0';
-        }
-
-        return $this->traceId . '-' . $this->spanId . $sampled;
-    }
-
-    /**
-     * Gets the event as an array.
-     *
-     * @return array<string, mixed>
-     */
-    public function toArray(): array
-    {
-        $data = [
-            'span_id' => (string) $this->spanId,
-            'trace_id' => (string) $this->traceId,
-            'start_timestamp' => $this->startTimestamp,
-        ];
-
-        if (null !== $this->parentSpanId) {
-            $data['parent_span_id'] = (string) $this->parentSpanId;
-        }
-
-        if (null !== $this->endTimestamp) {
-            $data['timestamp'] = $this->endTimestamp;
-        }
-
-        if (null !== $this->status) {
-            $data['status'] = $this->status;
-        }
-
-        if (null !== $this->description) {
-            $data['description'] = $this->description;
-        }
-
-        if (null !== $this->op) {
-            $data['op'] = $this->op;
-        }
-
-        if (!empty($this->data)) {
-            $data['data'] = $this->data;
-        }
-
-        if (!empty($this->tags)) {
-            $data['tags'] = $this->tags;
-        }
-
-        return $data;
-    }
-
-    /**
-     * @return array<string, mixed> Returns the trace context
-     */
-    public function getTraceContext(): array
-    {
-        $data = $this->toArray();
-
-        unset($data['start_timestamp']);
-        unset($data['timestamp']);
-
-        return $data;
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->toArray();
-    }
-
-    public function getDescription(): ?string
-    {
-        return $this->description;
-    }
-
-    public function setDescription(?string $description): void
-    {
-        $this->description = $description;
-    }
-
-    public function getOp(): ?string
-    {
-        return $this->op;
-    }
-
-    public function setOp(?string $op): void
-    {
-        $this->op = $op;
-    }
-
-    public function getStatus(): ?string
-    {
-        return $this->status;
-    }
-
-    public function setStatus(?string $status): void
-    {
-        $this->status = $status;
-    }
-
-    /**
-     * Gets a map of tags for this event.
-     *
-     * @return array<string, string>
-     */
-    public function getTags(): array
-    {
-        return $this->tags;
-    }
-
-    /**
-     * Sets a map of tags for this event.
-     *
-     * @param array<string, string> $tags The tags
-     */
-    public function setTags(array $tags): void
-    {
-        $this->tags = array_merge($this->tags, $tags);
-    }
-
-    public function getSpanId(): SpanId
-    {
-        return $this->spanId;
-    }
-
-    public function setSpanId(SpanId $spanId): void
-    {
-        $this->spanId = $spanId;
-    }
-
-    public function getTraceId(): TraceId
-    {
-        return $this->traceId;
-    }
-
-    public function setTraceId(TraceId $traceId): void
-    {
-        $this->traceId = $traceId;
-    }
-
-    public function getParentSpanId(): ?SpanId
-    {
-        return $this->parentSpanId;
-    }
-
-    public function setParentSpanId(?SpanId $parentSpanId): void
-    {
-        $this->parentSpanId = $parentSpanId;
-    }
-
-    public function getSampled(): ?bool
-    {
-        return $this->sampled;
-    }
-
-    public function setSampled(?bool $sampled): void
-    {
-        $this->sampled = $sampled;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     */
-    public function setData(array $data): void
-    {
-        $this->data = array_merge($this->data, $data);
-    }
-
-    public function setStartTimestamp(float $startTimestamp): void
-    {
-        $this->startTimestamp = $startTimestamp;
-    }
-
-    public function getEndTimestamp(): ?float
-    {
-        return $this->endTimestamp;
     }
 }

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -50,54 +50,6 @@ final class Transaction extends Span
     }
 
     /**
-     * @return array<string, mixed> Returns the trace context
-     *
-     * @psalm-return array{
-     *     data?: array<string, mixed>,
-     *     description?: string,
-     *     op?: string,
-     *     parent_span_id?: string,
-     *     span_id: string,
-     *     status?: string,
-     *     tags?: array<string, string>,
-     *     trace_id: string
-     * }
-     */
-    public function getTraceContext(): array
-    {
-        $result = [
-            'span_id' => (string) $this->spanId,
-            'trace_id' => (string) $this->traceId,
-        ];
-
-        if (null !== $this->parentSpanId) {
-            $result['parent_span_id'] = (string) $this->parentSpanId;
-        }
-
-        if (null !== $this->description) {
-            $result['description'] = $this->description;
-        }
-
-        if (null !== $this->op) {
-            $result['op'] = $this->op;
-        }
-
-        if (null !== $this->status) {
-            $result['status'] = $this->status;
-        }
-
-        if (!empty($this->data)) {
-            $result['data'] = $this->data;
-        }
-
-        if (!empty($this->tags)) {
-            $result['tags'] = $this->tags;
-        }
-
-        return $result;
-    }
-
-    /**
      * Attaches SpanRecorder to the transaction itself.
      */
     public function initSpanRecorder(): void

--- a/src/Transport/DefaultTransportFactory.php
+++ b/src/Transport/DefaultTransportFactory.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\Options;
-use Sentry\Serializer\EventSerializer;
+use Sentry\Serializer\PayloadSerializer;
 
 /**
  * This class is the default implementation of the {@see TransportFactoryInterface}
@@ -67,7 +67,7 @@ final class DefaultTransportFactory implements TransportFactoryInterface
             $this->httpClientFactory->create($options),
             $this->streamFactory,
             $this->requestFactory,
-            new EventSerializer(),
+            new PayloadSerializer(),
             $this->logger
         );
     }

--- a/src/Transport/DefaultTransportFactory.php
+++ b/src/Transport/DefaultTransportFactory.php
@@ -9,6 +9,7 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\Options;
+use Sentry\Serializer\EventSerializer;
 
 /**
  * This class is the default implementation of the {@see TransportFactoryInterface}
@@ -66,6 +67,7 @@ final class DefaultTransportFactory implements TransportFactoryInterface
             $this->httpClientFactory->create($options),
             $this->streamFactory,
             $this->requestFactory,
+            new EventSerializer(),
             $this->logger
         );
     }

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -14,10 +14,11 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sentry\Event;
+use Sentry\EventType;
 use Sentry\Options;
 use Sentry\Response;
 use Sentry\ResponseStatus;
-use Sentry\Util\JSON;
+use Sentry\Serializer\EventSerializerInterface;
 
 /**
  * This transport sends the events using a syncronous HTTP client that will
@@ -48,6 +49,11 @@ final class HttpTransport implements TransportInterface
     private $requestFactory;
 
     /**
+     * @var EventSerializerInterface The event serializer
+     */
+    private $eventSerializer;
+
+    /**
      * @var LoggerInterface A PSR-3 logger
      */
     private $logger;
@@ -55,23 +61,26 @@ final class HttpTransport implements TransportInterface
     /**
      * Constructor.
      *
-     * @param Options                  $options        The Sentry client configuration
-     * @param HttpAsyncClientInterface $httpClient     The HTTP client
-     * @param StreamFactoryInterface   $streamFactory  The PSR-7 stream factory
-     * @param RequestFactoryInterface  $requestFactory The PSR-7 request factory
-     * @param LoggerInterface|null     $logger         An instance of a PSR-3 logger
+     * @param Options                  $options         The Sentry client configuration
+     * @param HttpAsyncClientInterface $httpClient      The HTTP client
+     * @param StreamFactoryInterface   $streamFactory   The PSR-7 stream factory
+     * @param RequestFactoryInterface  $requestFactory  The PSR-7 request factory
+     * @param EventSerializerInterface $eventSerializer The event serializer
+     * @param LoggerInterface|null     $logger          An instance of a PSR-3 logger
      */
     public function __construct(
         Options $options,
         HttpAsyncClientInterface $httpClient,
         StreamFactoryInterface $streamFactory,
         RequestFactoryInterface $requestFactory,
+        EventSerializerInterface $eventSerializer,
         ?LoggerInterface $logger = null
     ) {
         $this->options = $options;
         $this->httpClient = $httpClient;
         $this->streamFactory = $streamFactory;
         $this->requestFactory = $requestFactory;
+        $this->eventSerializer = $eventSerializer;
         $this->logger = $logger ?? new NullLogger();
     }
 
@@ -86,14 +95,14 @@ final class HttpTransport implements TransportInterface
             throw new \RuntimeException(sprintf('The DSN option must be set to use the "%s" transport.', self::class));
         }
 
-        if ('transaction' === $event->getType()) {
+        if (EventType::transaction() === $event->getType()) {
             $request = $this->requestFactory->createRequest('POST', $dsn->getEnvelopeApiEndpointUrl())
                 ->withHeader('Content-Type', 'application/x-sentry-envelope')
-                ->withBody($this->streamFactory->createStream($event->toEnvelope()));
+                ->withBody($this->streamFactory->createStream($this->eventSerializer->serialize($event)));
         } else {
             $request = $this->requestFactory->createRequest('POST', $dsn->getStoreApiEndpointUrl())
                 ->withHeader('Content-Type', 'application/json')
-                ->withBody($this->streamFactory->createStream(JSON::encode($event->toArray())));
+                ->withBody($this->streamFactory->createStream($this->eventSerializer->serialize($event)));
         }
 
         try {

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,8 +22,8 @@ function init(array $options = []): void
 /**
  * Captures a message event and sends it to Sentry.
  *
- * @param string   $message The message
- * @param Severity $level   The severity level of the message
+ * @param string        $message The message
+ * @param Severity|null $level   The severity level of the message
  */
 function captureMessage(string $message, ?Severity $level = null): ?EventId
 {

--- a/tests/BreadcrumbTest.php
+++ b/tests/BreadcrumbTest.php
@@ -35,57 +35,55 @@ final class BreadcrumbTest extends TestCase
     {
         $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::TYPE_USER, 'foo', 'foo bar', ['baz']);
 
-        $this->assertEquals('foo', $breadcrumb->getCategory());
-        $this->assertEquals(Breadcrumb::LEVEL_INFO, $breadcrumb->getLevel());
-        $this->assertEquals('foo bar', $breadcrumb->getMessage());
-        $this->assertEquals(Breadcrumb::TYPE_USER, $breadcrumb->getType());
-        $this->assertEquals(['baz'], $breadcrumb->getMetadata());
-        $this->assertEquals(microtime(true), $breadcrumb->getTimestamp());
+        $this->assertSame('foo', $breadcrumb->getCategory());
+        $this->assertSame(Breadcrumb::LEVEL_INFO, $breadcrumb->getLevel());
+        $this->assertSame('foo bar', $breadcrumb->getMessage());
+        $this->assertSame(Breadcrumb::TYPE_USER, $breadcrumb->getType());
+        $this->assertSame(['baz'], $breadcrumb->getMetadata());
+        $this->assertSame(microtime(true), $breadcrumb->getTimestamp());
     }
 
     /**
      * @dataProvider fromArrayDataProvider
      */
-    public function testFromArray(array $requestData, array $expectedResult): void
+    public function testFromArray(array $requestData, string $expectedLevel, string $expectedType, string $expectedCategory, ?string $expectedMessage, array $expectedMetadata): void
     {
-        $expectedResult['timestamp'] = microtime(true);
         $breadcrumb = Breadcrumb::fromArray($requestData);
 
-        $this->assertEquals($expectedResult, $breadcrumb->toArray());
+        $this->assertSame($expectedLevel, $breadcrumb->getLevel());
+        $this->assertSame($expectedType, $breadcrumb->getType());
+        $this->assertSame($expectedCategory, $breadcrumb->getCategory());
+        $this->assertSame($expectedMessage, $breadcrumb->getMessage());
+        $this->assertSame($expectedMetadata, $breadcrumb->getMetadata());
     }
 
-    public function fromArrayDataProvider(): array
+    public function fromArrayDataProvider(): iterable
     {
-        return [
+        yield [
             [
-                [
-                    'level' => Breadcrumb::LEVEL_INFO,
-                    'type' => Breadcrumb::TYPE_USER,
-                    'category' => 'foo',
-                    'message' => 'foo bar',
-                    'data' => ['baz'],
-                ],
-                [
-                    'level' => Breadcrumb::LEVEL_INFO,
-                    'type' => Breadcrumb::TYPE_USER,
-                    'category' => 'foo',
-                    'message' => 'foo bar',
-                    'data' => ['baz'],
-                ],
+                'level' => Breadcrumb::LEVEL_INFO,
+                'type' => Breadcrumb::TYPE_USER,
+                'category' => 'foo',
+                'message' => 'foo bar',
+                'data' => ['baz'],
             ],
+            Breadcrumb::LEVEL_INFO,
+            Breadcrumb::TYPE_USER,
+            'foo',
+            'foo bar',
+            ['baz'],
+        ];
+
+        yield [
             [
-                [
-                    'level' => Breadcrumb::LEVEL_INFO,
-                    'category' => 'foo',
-                ],
-                [
-                    'level' => Breadcrumb::LEVEL_INFO,
-                    'type' => Breadcrumb::TYPE_DEFAULT,
-                    'category' => 'foo',
-                    'message' => null,
-                    'data' => [],
-                ],
+                'level' => Breadcrumb::LEVEL_INFO,
+                'category' => 'foo',
             ],
+            Breadcrumb::LEVEL_INFO,
+            Breadcrumb::TYPE_DEFAULT,
+            'foo',
+            null,
+            [],
         ];
     }
 
@@ -95,7 +93,7 @@ final class BreadcrumbTest extends TestCase
         $newBreadcrumb = $breadcrumb->withCategory('bar');
 
         $this->assertNotSame($breadcrumb, $newBreadcrumb);
-        $this->assertEquals('bar', $newBreadcrumb->getCategory());
+        $this->assertSame('bar', $newBreadcrumb->getCategory());
         $this->assertSame($newBreadcrumb, $newBreadcrumb->withCategory('bar'));
     }
 
@@ -105,7 +103,7 @@ final class BreadcrumbTest extends TestCase
         $newBreadcrumb = $breadcrumb->withLevel(Breadcrumb::LEVEL_WARNING);
 
         $this->assertNotSame($breadcrumb, $newBreadcrumb);
-        $this->assertEquals(Breadcrumb::LEVEL_WARNING, $newBreadcrumb->getLevel());
+        $this->assertSame(Breadcrumb::LEVEL_WARNING, $newBreadcrumb->getLevel());
         $this->assertSame($newBreadcrumb, $newBreadcrumb->withLevel(Breadcrumb::LEVEL_WARNING));
     }
 
@@ -115,7 +113,7 @@ final class BreadcrumbTest extends TestCase
         $newBreadcrumb = $breadcrumb->withType(Breadcrumb::TYPE_ERROR);
 
         $this->assertNotSame($breadcrumb, $newBreadcrumb);
-        $this->assertEquals(Breadcrumb::TYPE_ERROR, $newBreadcrumb->getType());
+        $this->assertSame(Breadcrumb::TYPE_ERROR, $newBreadcrumb->getType());
         $this->assertSame($newBreadcrumb, $newBreadcrumb->withType(Breadcrumb::TYPE_ERROR));
     }
 
@@ -125,7 +123,7 @@ final class BreadcrumbTest extends TestCase
         $newBreadcrumb = $breadcrumb->withMessage('foo bar');
 
         $this->assertNotSame($breadcrumb, $newBreadcrumb);
-        $this->assertEquals('foo bar', $newBreadcrumb->getMessage());
+        $this->assertSame('foo bar', $newBreadcrumb->getMessage());
         $this->assertSame($newBreadcrumb, $newBreadcrumb->withMessage('foo bar'));
     }
 
@@ -147,26 +145,5 @@ final class BreadcrumbTest extends TestCase
         $this->assertNotSame($breadcrumb, $newBreadcrumb);
         $this->assertSame(['foo' => 'bar'], $breadcrumb->getMetadata());
         $this->assertArrayNotHasKey('foo', $newBreadcrumb->getMetadata());
-    }
-
-    public function testJsonSerialize(): void
-    {
-        $type = Breadcrumb::TYPE_USER;
-        $level = Breadcrumb::LEVEL_INFO;
-        $category = 'foo';
-        $data = ['baz' => 'bar'];
-        $message = 'message';
-        $breadcrumb = new Breadcrumb($level, $type, $category, $message, $data);
-
-        $expected = [
-            'type' => $type,
-            'category' => $category,
-            'message' => $message,
-            'level' => $level,
-            'timestamp' => microtime(true),
-            'data' => $data,
-        ];
-
-        $this->assertEquals($expected, $breadcrumb->jsonSerialize());
     }
 }

--- a/tests/EventFactoryTest.php
+++ b/tests/EventFactoryTest.php
@@ -50,7 +50,7 @@ class EventFactoryTest extends TestCase
     /**
      * @dataProvider createWithPayloadDataProvider
      */
-    public function testCreateWithPayload(array $payload, array $expectedSubset): void
+    public function testCreateWithPayload(array $payload, ?string $expectedLogger, ?string $expectedMessage, array $expectedMessageParams, ?string $expectedFormattedMessage): void
     {
         $eventFactory = new EventFactory(
             $this->createMock(SerializerInterface::class),
@@ -62,47 +62,40 @@ class EventFactoryTest extends TestCase
 
         $event = $eventFactory->create($payload);
 
-        $this->assertArraySubset($expectedSubset, $event->toArray());
+        $this->assertSame($expectedLogger, $event->getLogger());
+        $this->assertSame($expectedMessage, $event->getMessage());
+        $this->assertSame($expectedMessageParams, $event->getMessageParams());
+        $this->assertSame($expectedFormattedMessage, $event->getMessageFormatted());
     }
 
-    public function createWithPayloadDataProvider()
+    public function createWithPayloadDataProvider(): iterable
     {
-        return [
+        yield [
+            ['logger' => 'app.php'],
+            'app.php',
+            null,
+            [],
+            null,
+        ];
+
+        yield [
+            ['message' => 'My raw message with interpreted strings like this'],
+            null,
+            'My raw message with interpreted strings like this',
+            [],
+            null,
+        ];
+
+        yield [
             [
-                ['logger' => 'testLogger'],
-                ['logger' => 'testLogger'],
+                'message' => 'My raw message with interpreted strings like that',
+                'message_params' => ['this'],
+                'message_formatted' => 'My raw message with interpreted strings like %s',
             ],
-            [
-                ['message' => 'testMessage'],
-                ['message' => 'testMessage'],
-            ],
-            [
-                [
-                    'message' => 'testMessage %s',
-                    'message_params' => ['param'],
-                ],
-                [
-                    'message' => [
-                        'message' => 'testMessage %s',
-                        'params' => ['param'],
-                        'formatted' => 'testMessage param',
-                    ],
-                ],
-            ],
-            [
-                [
-                    'message' => 'testMessage %foo',
-                    'message_params' => ['%foo' => 'param'],
-                    'message_formatted' => 'testMessage param',
-                ],
-                [
-                    'message' => [
-                        'message' => 'testMessage %foo',
-                        'params' => ['%foo' => 'param'],
-                        'formatted' => 'testMessage param',
-                    ],
-                ],
-            ],
+            null,
+            'My raw message with interpreted strings like that',
+            ['this'],
+            'My raw message with interpreted strings like %s',
         ];
     }
 

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -133,7 +133,7 @@ final class FrameBuilderTest extends TestCase
                 'file' => 'path/not/of/app/path/to/file',
                 'line' => 10,
             ],
-            new Frame(null, 'path/not/of/app/path/to/file', 10, null, 'path/not/of/app/path/to/file'),
+            new Frame(null, 'path/not/of/app/path/to/file', 10, null),
         ];
 
         yield [
@@ -147,7 +147,7 @@ final class FrameBuilderTest extends TestCase
                 'file' => 'path/not/of/app/to/file',
                 'line' => 10,
             ],
-            new Frame(null, 'path/not/of/app/to/file', 10, null, 'path/not/of/app/to/file'),
+            new Frame(null, 'path/not/of/app/to/file', 10, null),
         ];
     }
 

--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -39,34 +39,4 @@ final class FrameTest extends TestCase
             ['getVars', 'setVars', ['foo' => 'bar']],
         ];
     }
-
-    /**
-     * @dataProvider toArrayAndJsonSerializeDataProvider
-     */
-    public function testToArrayAndJsonSerialize(string $setterMethod, string $expectedDataKey, $expectedData): void
-    {
-        $frame = new Frame('foo', 'bar', 10);
-        $frame->$setterMethod($expectedData);
-
-        $expectedResult = [
-            'function' => 'foo',
-            'filename' => 'bar',
-            'lineno' => 10,
-            $expectedDataKey => $expectedData,
-        ];
-
-        $this->assertArraySubset($expectedResult, $frame->toArray());
-        $this->assertArraySubset($expectedResult, $frame->jsonSerialize());
-    }
-
-    public function toArrayAndJsonSerializeDataProvider(): array
-    {
-        return [
-            ['setPreContext', 'pre_context', ['foo' => 'bar']],
-            ['setContextLine', 'context_line', 'foo bar'],
-            ['setPostContext', 'post_context', ['bar' => 'foo']],
-            ['setIsInApp', 'in_app', true],
-            ['setVars', 'vars', ['baz' => 'bar']],
-        ];
-    }
 }

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -8,7 +8,6 @@ use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Mock\Client as HttpMockClient;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\RequestInterface;
 use Sentry\HttpClient\HttpClientFactory;
 use Sentry\Options;
 
@@ -43,9 +42,9 @@ final class HttpClientFactoryTest extends TestCase
             ->withBody($streamFactory->createStream('foo bar'));
 
         $httpClient->sendAsyncRequest($request);
+
         $httpRequest = $mockHttpClient->getLastRequest();
 
-        $this->assertInstanceOf(RequestInterface::class, $httpRequest);
         $this->assertSame('http://example.com/sentry/foo', (string) $httpRequest->getUri());
         $this->assertSame('sentry.php.test/1.2.3', $httpRequest->getHeaderLine('User-Agent'));
         $this->assertSame('Sentry sentry_version=7, sentry_client=sentry.php.test/1.2.3, sentry_key=public', $httpRequest->getHeaderLine('X-Sentry-Auth'));

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -60,7 +60,7 @@ final class FrameContextifierIntegrationTest extends TestCase
         SentrySdk::getCurrentHub()->bindClient($client);
 
         $stacktrace = new Stacktrace([
-            new Frame('[unknown]', $fixtureFilePath, $lineNumber),
+            new Frame('[unknown]', $fixtureFilePath, $lineNumber, null, $fixtureFilePath),
         ]);
 
         $event = new Event();
@@ -154,7 +154,7 @@ final class FrameContextifierIntegrationTest extends TestCase
 
         $stacktrace = new Stacktrace([
             new Frame(null, '[internal]', 0),
-            new Frame(null, 'file.ext', 10),
+            new Frame(null, 'file.ext', 10, null, 'file.ext'),
         ]);
 
         $event = new Event();

--- a/tests/Serializer/EventSerializerTest.php
+++ b/tests/Serializer/EventSerializerTest.php
@@ -1,0 +1,427 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Serializer;
+
+use Jean85\PrettyVersions;
+use PHPUnit\Framework\TestCase;
+use Sentry\Breadcrumb;
+use Sentry\Context\OsContext;
+use Sentry\Context\RuntimeContext;
+use Sentry\Event;
+use Sentry\EventId;
+use Sentry\EventType;
+use Sentry\ExceptionDataBag;
+use Sentry\ExceptionMechanism;
+use Sentry\Frame;
+use Sentry\Serializer\EventSerializer;
+use Sentry\Severity;
+use Sentry\Stacktrace;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanId;
+use Sentry\Tracing\TraceId;
+use Sentry\UserDataBag;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @group time-sensitive
+ */
+final class EventSerializerTest extends TestCase
+{
+    /**
+     * @var EventSerializer
+     */
+    private $serializer;
+
+    protected function setUp(): void
+    {
+        $this->serializer = new EventSerializer();
+    }
+
+    /**
+     * @dataProvider serializeDataProvider
+     */
+    public function testSerialize(Event $event, string $expectedResult, bool $isOutputJson): void
+    {
+        ClockMock::withClockMock(1597790835);
+
+        $result = $this->serializer->serialize($event);
+
+        if ($isOutputJson) {
+            $this->assertJsonStringEqualsJsonString($expectedResult, $result);
+        } else {
+            $this->assertSame($expectedResult, $result);
+        }
+    }
+
+    public function serializeDataProvider(): iterable
+    {
+        ClockMock::withClockMock(1597790835);
+
+        $sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
+
+        yield [
+            new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd')),
+            <<<JSON
+{
+    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
+    "timestamp": "2020-08-18T22:47:15Z",
+    "platform": "php",
+    "sdk": {
+        "name": "sentry.php",
+        "version": "$sdkVersion"
+    }
+}
+JSON
+            ,
+            true,
+        ];
+
+        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setLevel(Severity::error());
+        $event->setLogger('app.php');
+        $event->setTransaction('/users/<username>/');
+        $event->setServerName('foo.example.com');
+        $event->setRelease('721e41770371db95eee98ca2707686226b993eda');
+        $event->setEnvironment('production');
+        $event->setFingerprint(['myrpc', 'POST', '/foo.bar']);
+        $event->setModules(['my.module.name' => '1.0']);
+        $event->setStartTimestamp(1597790835);
+        $event->setBreadcrumb([
+            new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::TYPE_USER, 'log'),
+            new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::TYPE_NAVIGATION, 'log', null, ['from' => '/login', 'to' => '/dashboard']),
+        ]);
+
+        $event->setUser(UserDataBag::createFromArray([
+            'id' => 'unique_id',
+            'username' => 'my_user',
+            'email' => 'foo@example.com',
+            'ip_address' => '127.0.0.1',
+        ]));
+
+        $event->setTags([
+            'ios_version' => '4.0',
+            'context' => 'production',
+        ]);
+
+        $event->setExtra([
+            'my_key' => 1,
+            'some_other_value' => 'foo bar',
+        ]);
+
+        $event->setRequest([
+            'method' => 'POST',
+            'url' => 'http://absolute.uri/foo',
+            'query_string' => 'query=foobar&page=2',
+            'data' => [
+                'foo' => 'bar',
+            ],
+            'cookies' => [
+                'PHPSESSID' => '298zf09hf012fh2',
+            ],
+            'headers' => [
+                'content-type' => 'text/html',
+            ],
+            'env' => [
+                'REMOTE_ADDR' => '127.0.0.1',
+            ],
+        ]);
+
+        $event->setOsContext(new OsContext(
+            'Linux',
+            '4.19.104-microsoft-standard',
+            '#1 SMP Wed Feb 19 06:37:35 UTC 2020',
+            'Linux 7944782cd697 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64'
+        ));
+
+        $event->setRuntimeContext(new RuntimeContext(
+            'php',
+            '7.4.3'
+        ));
+
+        $event->setContext('electron', [
+            'type' => 'runtime',
+            'name' => 'Electron',
+            'version' => '4.0',
+        ]);
+
+        $frame1 = new Frame(null, 'file/name.py', 3);
+        $frame2 = new Frame('myfunction', 'file/name.py', 3, 'raw_function_name', 'absolute/file/name.py', ['my_var' => 'value'], false);
+        $frame2->setContextLine('  raise ValueError()');
+        $frame2->setPreContext([
+            'def foo():',
+            '  my_var = \'foo\'',
+        ]);
+
+        $frame2->setPostContext([
+            '',
+            'def main():',
+        ]);
+
+        $event->setExceptions([
+            new ExceptionDataBag(new \Exception('initial exception')),
+            new ExceptionDataBag(
+                new \Exception('chained exception'),
+                new Stacktrace([
+                    $frame1,
+                    $frame2,
+                ]),
+                new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true)
+            ),
+        ]);
+
+        yield [
+            $event,
+            <<<JSON
+{
+    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
+    "timestamp": "2020-08-18T22:47:15Z",
+    "platform": "php",
+    "sdk": {
+        "name": "sentry.php",
+        "version": "$sdkVersion"
+    },
+    "start_timestamp": 1597790835,
+    "level": "error",
+    "logger": "app.php",
+    "transaction": "/users/<username>/",
+    "server_name": "foo.example.com",
+    "release": "721e41770371db95eee98ca2707686226b993eda",
+    "environment": "production",
+    "fingerprint": [
+        "myrpc",
+        "POST",
+        "/foo.bar"
+    ],
+    "modules": {
+        "my.module.name": "1.0"
+    },
+    "extra": {
+        "my_key": 1,
+        "some_other_value": "foo bar"
+    },
+    "tags": {
+        "ios_version": "4.0",
+        "context": "production"
+    },
+    "user": {
+        "id": "unique_id",
+        "username": "my_user",
+        "email": "foo@example.com",
+        "ip_address": "127.0.0.1"
+    },
+    "contexts": {
+        "os": {
+            "name": "Linux",
+            "version": "4.19.104-microsoft-standard",
+            "build": "#1 SMP Wed Feb 19 06:37:35 UTC 2020",
+            "kernel_version": "Linux 7944782cd697 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64"
+        },
+        "runtime": {
+            "name": "php",
+            "version": "7.4.3"
+        },
+        "electron": {
+            "type": "runtime",
+            "name": "Electron",
+            "version": "4.0"
+        }
+    },
+    "breadcrumbs": {
+        "values": [
+            {
+                "type": "user",
+                "category": "log",
+                "level": "info",
+                "timestamp": 1597790835
+            },
+            {
+                "type": "navigation",
+                "category": "log",
+                "level": "info",
+                "timestamp": 1597790835,
+                "data": {
+                    "from": "/login",
+                    "to": "/dashboard"
+                }
+            }
+        ]
+    },
+    "request": {
+        "method": "POST",
+        "url": "http://absolute.uri/foo",
+        "query_string": "query=foobar&page=2",
+        "data": {
+            "foo": "bar"
+        },
+        "cookies": {
+            "PHPSESSID": "298zf09hf012fh2"
+        },
+        "headers": {
+            "content-type": "text/html"
+        },
+        "env": {
+            "REMOTE_ADDR": "127.0.0.1"
+        }
+    },
+    "exception": {
+        "values": [
+            {
+                "type": "Exception",
+                "value": "chained exception",
+                "stacktrace": {
+                    "frames": [
+                        {
+                            "filename": "file/name.py",
+                            "lineno": 3,
+                            "in_app": true
+                        },
+                        {
+                            "filename": "file/name.py",
+                            "lineno": 3,
+                            "in_app": false,
+                            "abs_path": "absolute/file/name.py",
+                            "function": "myfunction",
+                            "raw_function": "raw_function_name",
+                            "pre_context": [
+                                "def foo():",
+                                "  my_var = 'foo'"
+                            ],
+                            "context_line": "  raise ValueError()",
+                            "post_context": [
+                                "",
+                                "def main():"
+                            ],
+                            "vars": {
+                                "my_var": "value"
+                            }
+                        }
+                    ]
+                },
+                "mechanism": {
+                    "type": "generic",
+                    "handled": true
+                }
+            },
+            {
+                "type": "Exception",
+                "value": "initial exception"
+            }
+        ]
+    }
+}
+JSON
+            ,
+            true,
+        ];
+
+        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setMessage('My raw message with interpreted strings like this', []);
+
+        yield [
+            $event,
+            <<<JSON
+{
+    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
+    "timestamp": "2020-08-18T22:47:15Z",
+    "platform": "php",
+    "sdk": {
+        "name": "sentry.php",
+        "version": "$sdkVersion"
+    },
+    "message": "My raw message with interpreted strings like this"
+}
+JSON
+            ,
+            true,
+        ];
+
+        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setMessage('My raw message with interpreted strings like %s', ['this']);
+
+        yield [
+            $event,
+            <<<JSON
+{
+    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
+    "timestamp": "2020-08-18T22:47:15Z",
+    "platform": "php",
+    "sdk": {
+        "name": "sentry.php",
+        "version": "$sdkVersion"
+    },
+    "message": {
+        "message": "My raw message with interpreted strings like %s",
+        "params": ["this"],
+        "formatted": "My raw message with interpreted strings like this"
+    }
+}
+JSON
+            ,
+            true,
+        ];
+
+        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setMessage('My raw message with interpreted strings like %s', ['this'], 'My raw message with interpreted strings like that');
+
+        yield [
+            $event,
+            <<<JSON
+{
+    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
+    "timestamp": "2020-08-18T22:47:15Z",
+    "platform": "php",
+    "sdk": {
+        "name": "sentry.php",
+        "version": "$sdkVersion"
+    },
+    "message": {
+        "message": "My raw message with interpreted strings like %s",
+        "params": ["this"],
+        "formatted": "My raw message with interpreted strings like that"
+    }
+}
+JSON
+            ,
+            true,
+        ];
+
+        $span1 = new Span();
+        $span1->setSpanId(new SpanId('5dd538dc297544cc'));
+        $span1->setTraceId(new TraceId('21160e9b836d479f81611368b2aa3d2c'));
+
+        $span2 = new Span();
+        $span2->setSpanId(new SpanId('b01b9f6349558cd1'));
+        $span2->setParentSpanId(new SpanId('b0e6f15b45c36b12'));
+        $span2->setTraceId(new TraceId('1e57b752bc6e4544bbaa246cd1d05dee'));
+        $span2->setOp('http');
+        $span2->setDescription('GET /sockjs-node/info');
+        $span2->setStatus('ok');
+        $span2->setStartTimestamp(1597790835);
+        $span2->setTags(['http.status_code' => '200']);
+        $span2->setData([
+            'url' => 'http://localhost:8080/sockjs-node/info?t=1588601703755',
+            'status_code' => 200,
+            'type' => 'xhr',
+            'method' => 'GET',
+        ]);
+
+        $span2->finish(1598659060);
+
+        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setType(EventType::transaction());
+        $event->setSpans([$span1, $span2]);
+
+        yield [
+            $event,
+            <<<TEXT
+{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z"}
+{"type":"transaction","content_type":"application\/json"}
+{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":"2020-08-18T22:47:15Z","platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"spans":[{"span_id":"5dd538dc297544cc","trace_id":"21160e9b836d479f81611368b2aa3d2c","start_timestamp":1597790835},{"span_id":"b01b9f6349558cd1","trace_id":"1e57b752bc6e4544bbaa246cd1d05dee","start_timestamp":1597790835,"parent_span_id":"b0e6f15b45c36b12","timestamp":1598659060,"status":"ok","description":"GET \/sockjs-node\/info","op":"http","data":{"url":"http:\/\/localhost:8080\/sockjs-node\/info?t=1588601703755","status_code":200,"type":"xhr","method":"GET"},"tags":{"http.status_code":"200"}}]}
+TEXT
+            ,
+            false,
+        ];
+    }
+}

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -15,7 +15,7 @@ use Sentry\EventType;
 use Sentry\ExceptionDataBag;
 use Sentry\ExceptionMechanism;
 use Sentry\Frame;
-use Sentry\Serializer\EventSerializer;
+use Sentry\Serializer\PayloadSerializer;
 use Sentry\Severity;
 use Sentry\Stacktrace;
 use Sentry\Tracing\Span;
@@ -27,16 +27,16 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 /**
  * @group time-sensitive
  */
-final class EventSerializerTest extends TestCase
+final class PayloadSerializerTest extends TestCase
 {
     /**
-     * @var EventSerializer
+     * @var PayloadSerializer
      */
     private $serializer;
 
     protected function setUp(): void
     {
-        $this->serializer = new EventSerializer();
+        $this->serializer = new PayloadSerializer();
     }
 
     /**

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -54,22 +54,6 @@ final class StacktraceTest extends TestCase
         ];
     }
 
-    public function testStacktraceJsonSerialization(): void
-    {
-        $stacktrace = new Stacktrace([
-            new Frame('test_function', 'path/to/file', 1),
-            new Frame('TestClass::test_function', 'path/to/file', 2),
-            new Frame(null, 'path/to/file', 3),
-        ]);
-
-        $frames = json_encode($stacktrace->getFrames());
-        $serializedStacktrace = json_encode($stacktrace);
-
-        $this->assertNotFalse($frames);
-        $this->assertNotFalse($serializedStacktrace);
-        $this->assertJsonStringEqualsJsonString($frames, $serializedStacktrace);
-    }
-
     public function testAddFrame(): void
     {
         $stacktrace = new Stacktrace([

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -180,7 +180,7 @@ final class ScopeTest extends TestCase
         $event = $scope->applyToEvent(new Event(), []);
 
         $this->assertNotNull($event);
-        $this->assertEquals(Severity::error(), $event->getLevel());
+        $this->assertNull($event->getLevel());
 
         $scope->setLevel(Severity::debug());
 
@@ -295,7 +295,7 @@ final class ScopeTest extends TestCase
         $event = $scope->applyToEvent(new Event(), []);
 
         $this->assertNotNull($event);
-        $this->assertEquals(Severity::error(), $event->getLevel());
+        $this->assertNull($event->getLevel());
         $this->assertEmpty($event->getBreadcrumbs());
         $this->assertEmpty($event->getFingerprint());
         $this->assertEmpty($event->getExtra());

--- a/tests/Transport/DefaultTransportFactoryTest.php
+++ b/tests/Transport/DefaultTransportFactoryTest.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Sentry\Tests\Transport;
 
 use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
-use Http\Discovery\Psr17FactoryDiscovery;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\Options;
 use Sentry\Transport\DefaultTransportFactory;
@@ -19,8 +20,8 @@ final class DefaultTransportFactoryTest extends TestCase
     public function testCreateReturnsNullTransportWhenDsnOptionIsNotConfigured(): void
     {
         $factory = new DefaultTransportFactory(
-            Psr17FactoryDiscovery::findStreamFactory(),
-            Psr17FactoryDiscovery::findRequestFactory(),
+            $this->createMock(StreamFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $this->createMock(HttpClientFactoryInterface::class)
         );
 
@@ -39,8 +40,8 @@ final class DefaultTransportFactoryTest extends TestCase
             ->willReturn($this->createMock(HttpAsyncClientInterface::class));
 
         $factory = new DefaultTransportFactory(
-            Psr17FactoryDiscovery::findStreamFactory(),
-            Psr17FactoryDiscovery::findRequestFactory(),
+            $this->createMock(StreamFactoryInterface::class),
+            $this->createMock(RequestFactoryInterface::class),
             $httpClientFactory
         );
 

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -6,32 +6,64 @@ namespace Sentry\Tests\Transport;
 
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Promise\RejectionException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
-use Http\Discovery\Psr17FactoryDiscovery;
-use Http\Mock\Client as HttpMockClient;
 use Http\Promise\FulfilledPromise as HttpFullfilledPromise;
-use Http\Promise\RejectedPromise;
+use Http\Promise\RejectedPromise as HttpRejectedPromise;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestFactoryInterface;
-use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use Sentry\Dsn;
 use Sentry\Event;
-use Sentry\HttpClient\HttpClientFactory;
+use Sentry\EventType;
 use Sentry\Options;
 use Sentry\ResponseStatus;
+use Sentry\Serializer\EventSerializerInterface;
 use Sentry\Transport\HttpTransport;
+use function GuzzleHttp\Psr7\stream_for;
 
 final class HttpTransportTest extends TestCase
 {
+    /**
+     * @var MockObject&HttpAsyncClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var MockObject&StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    /**
+     * @var MockObject&RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    /**
+     * @var MockObject&EventSerializerInterface
+     */
+    private $eventSerializer;
+
+    protected function setUp(): void
+    {
+        $this->httpClient = $this->createMock(HttpAsyncClientInterface::class);
+        $this->streamFactory = $this->createMock(StreamFactoryInterface::class);
+        $this->requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $this->eventSerializer = $this->createMock(EventSerializerInterface::class);
+    }
+
     public function testSendThrowsIfDsnOptionIsNotSet(): void
     {
         $transport = new HttpTransport(
             new Options(),
-            $this->createMock(HttpAsyncClientInterface::class),
-            Psr17FactoryDiscovery::findStreamFactory(),
-            Psr17FactoryDiscovery::findRequestFactory()
+            $this->httpClient,
+            $this->streamFactory,
+            $this->requestFactory,
+            $this->eventSerializer
         );
 
         $this->expectException(\RuntimeException::class);
@@ -42,36 +74,51 @@ final class HttpTransportTest extends TestCase
 
     public function testSendTransactionAsEnvelope(): void
     {
-        $mockHttpClient = new HttpMockClient();
-        $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
-            Psr17FactoryDiscovery::findStreamFactory(),
-            $mockHttpClient,
-            'sentry.php.test',
-            '1.2.3'
-        );
+        $dsn = Dsn::createFromString('http://public@example.com/sentry/1');
+        $event = new Event();
+        $event->setType(EventType::transaction());
 
-        $httpClient = $httpClientFactory->create(new Options([
-            'dsn' => 'http://public@example.com/sentry/1',
-            'default_integrations' => false,
-        ]));
+        $this->eventSerializer->expects($this->once())
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
+
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('POST', $dsn->getEnvelopeApiEndpointUrl())
+            ->willReturn(new Request('POST', 'http://www.example.com'));
+
+        $this->streamFactory->expects($this->once())
+            ->method('createStream')
+            ->with('{"foo":"bar"}')
+            ->willReturnCallback(static function (string $content): StreamInterface {
+                return stream_for($content);
+            });
+
+        $this->httpClient->expects($this->once())
+            ->method('sendAsyncRequest')
+            ->with($this->callback(function (Request $requestArg): bool {
+                if ('application/x-sentry-envelope' !== $requestArg->getHeaderLine('Content-Type')) {
+                    return false;
+                }
+
+                if ('{"foo":"bar"}' !== $requestArg->getBody()->getContents()) {
+                    return false;
+                }
+
+                return true;
+            }))
+            ->willReturn(new HttpFullfilledPromise(new Response()));
 
         $transport = new HttpTransport(
-            new Options(['dsn' => 'http://public@example.com/sentry/1']),
-            $httpClient,
-            Psr17FactoryDiscovery::findStreamFactory(),
-            Psr17FactoryDiscovery::findRequestFactory()
+            new Options(['dsn' => $dsn]),
+            $this->httpClient,
+            $this->streamFactory,
+            $this->requestFactory,
+            $this->eventSerializer
         );
 
-        $event = new Event();
-        $event->setType('transaction');
-
         $transport->send($event);
-
-        $httpRequest = $mockHttpClient->getLastRequest();
-
-        $this->assertSame('application/x-sentry-envelope', $httpRequest->getHeaderLine('Content-Type'));
     }
 
     /**
@@ -79,24 +126,47 @@ final class HttpTransportTest extends TestCase
      */
     public function testSend(int $httpStatusCode, string $expectedPromiseStatus, ResponseStatus $expectedResponseStatus): void
     {
-        $response = $this->createMock(ResponseInterface::class);
-        $response->expects($this->once())
-            ->method('getStatusCode')
-            ->willReturn($httpStatusCode);
-
+        $dsn = Dsn::createFromString('http://public@example.com/sentry/1');
         $event = new Event();
 
-        /** @var HttpAsyncClientInterface&MockObject $httpClient */
-        $httpClient = $this->createMock(HttpAsyncClientInterface::class);
-        $httpClient->expects($this->once())
+        $this->eventSerializer->expects($this->once())
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
+
+        $this->streamFactory->expects($this->once())
+            ->method('createStream')
+            ->with('{"foo":"bar"}')
+            ->willReturnCallback(static function (string $content): StreamInterface {
+                return stream_for($content);
+            });
+
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('POST', $dsn->getStoreApiEndpointUrl())
+            ->willReturn(new Request('POST', 'http://www.example.com'));
+
+        $this->httpClient->expects($this->once())
             ->method('sendAsyncRequest')
-            ->willReturn(new HttpFullfilledPromise($response));
+            ->with($this->callback(function (Request $requestArg): bool {
+                if ('application/json' !== $requestArg->getHeaderLine('Content-Type')) {
+                    return false;
+                }
+
+                if ('{"foo":"bar"}' !== $requestArg->getBody()->getContents()) {
+                    return false;
+                }
+
+                return true;
+            }))
+            ->willReturn(new HttpFullfilledPromise(new Response($httpStatusCode)));
 
         $transport = new HttpTransport(
             new Options(['dsn' => 'http://public@example.com/sentry/1']),
-            $httpClient,
-            Psr17FactoryDiscovery::findStreamFactory(),
-            Psr17FactoryDiscovery::findRequestFactory()
+            $this->httpClient,
+            $this->streamFactory,
+            $this->requestFactory,
+            $this->eventSerializer
         );
 
         $promise = $transport->send($event);
@@ -129,6 +199,7 @@ final class HttpTransportTest extends TestCase
 
     public function testSendReturnsRejectedPromiseIfSendingFailedDueToHttpClientException(): void
     {
+        $dsn = Dsn::createFromString('http://public@example.com/sentry/1');
         $exception = new \Exception('foo');
         $event = new Event();
 
@@ -138,17 +209,33 @@ final class HttpTransportTest extends TestCase
             ->method('error')
             ->with('Failed to send the event to Sentry. Reason: "foo".', ['exception' => $exception, 'event' => $event]);
 
-        /** @var HttpAsyncClientInterface&MockObject $httpClient */
-        $httpClient = $this->createMock(HttpAsyncClientInterface::class);
-        $httpClient->expects($this->once())
+        $this->eventSerializer->expects($this->once())
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
+
+        $this->requestFactory->expects($this->once())
+            ->method('createRequest')
+            ->with('POST', $dsn->getStoreApiEndpointUrl())
+            ->willReturn(new Request('POST', 'http://www.example.com'));
+
+        $this->streamFactory->expects($this->once())
+            ->method('createStream')
+            ->with('{"foo":"bar"}')
+            ->willReturnCallback(static function (string $content): StreamInterface {
+                return stream_for($content);
+            });
+
+        $this->httpClient->expects($this->once())
             ->method('sendAsyncRequest')
-            ->willReturn(new RejectedPromise($exception));
+            ->willReturn(new HttpRejectedPromise($exception));
 
         $transport = new HttpTransport(
-            new Options(['dsn' => 'http://public@example.com/sentry/1']),
-            $httpClient,
-            Psr17FactoryDiscovery::findStreamFactory(),
-            Psr17FactoryDiscovery::findRequestFactory(),
+            new Options(['dsn' => $dsn]),
+            $this->httpClient,
+            $this->streamFactory,
+            $this->requestFactory,
+            $this->eventSerializer,
             $logger
         );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,26 @@ declare(strict_types=1);
 
 use Http\Discovery\ClassDiscovery;
 use Http\Discovery\Strategy\MockClientStrategy;
+use Sentry\Breadcrumb;
+use Sentry\Event;
+use Sentry\Tracing\Span;
+use Symfony\Bridge\PhpUnit\ClockMock;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 ClassDiscovery::appendStrategy(MockClientStrategy::class);
+
+// According to the Symfony documentation the proper way to register the mocked
+// functions for a certain class would be to configure the listener in the
+// phpunit.xml file, however in our case it doesn't work because PHPUnit loads
+// the data providers of the tests long before instantiating the listeners. In
+// turn, PHP caches the functions to call to avoid looking up in the function
+// table again and again, therefore if for any reason the method that should use
+// a mocked function gets called before the mock itself gets created it will not
+// use the mocked methods.
+//
+// See https://symfony.com/doc/current/components/phpunit_bridge.html#troubleshooting
+// See https://bugs.php.net/bug.php?id=64346
+ClockMock::register(Event::class);
+ClockMock::register(Breadcrumb::class);
+ClockMock::register(Span::class);


### PR DESCRIPTION
One more piece of refactoring: I've extracted the logic to serialize the event into its own class, therefore creating an event serializer service. I have some doubts whether making it a dependency of the HTTP transport rather than just instantiating it in the constructor. The pros of having it passed as an argument is of course testability, the cons is that I don't think there will ever be another implementation and so it may be useless to be able to set the instance from outside the transport. Any opinion is more than welcome!