### PR TITLE
Allow the user ID to be more types

### DIFF
--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -10,7 +10,7 @@ namespace Sentry;
 final class UserDataBag
 {
     /**
-     * @var string|null The unique ID of the user
+     * @var string|int|null The unique ID of the user
      */
     private $id;
 
@@ -41,9 +41,9 @@ final class UserDataBag
     /**
      * Creates an instance of this object from a user ID.
      *
-     * @param string $id The ID of the user
+     * @param string|int $id The ID of the user
      */
-    public static function createFromUserIdentifier(string $id): self
+    public static function createFromUserIdentifier($id): self
     {
         $instance = new self();
         $instance->setId($id);
@@ -102,8 +102,10 @@ final class UserDataBag
 
     /**
      * Gets the ID of the user.
+     *
+     * @return string|int|null
      */
-    public function getId(): ?string
+    public function getId()
     {
         return $this->id;
     }
@@ -111,12 +113,16 @@ final class UserDataBag
     /**
      * Sets the ID of the user.
      *
-     * @param string|null $id The ID
+     * @param string|int|null $id The ID
      */
-    public function setId(?string $id): void
+    public function setId($id): void
     {
         if (null === $id && null === $this->ipAddress) {
             throw new \BadMethodCallException('Either the IP address or the ID must be set.');
+        }
+
+        if (!\is_string($id) && !\is_int($id)) {
+            throw new \UnexpectedValueException(sprintf('Expected an integer or string value for the $id argument. Got: "%s".', get_debug_type($id)));
         }
 
         $this->id = $id;

--- a/tests/UserDataBagTest.php
+++ b/tests/UserDataBagTest.php
@@ -35,7 +35,7 @@ final class UserDataBagTest extends TestCase
     /**
      * @dataProvider createFromArrayDataProvider
      */
-    public function testCreateFromArray(array $data, ?string $expectedId, ?string $expectedIpAddress, ?string $expectedEmail, ?string $expectedUsername, array $expectedMetadata): void
+    public function testCreateFromArray(array $data, $expectedId, ?string $expectedIpAddress, ?string $expectedEmail, ?string $expectedUsername, array $expectedMetadata): void
     {
         $userDataBag = UserDataBag::createFromArray($data);
 
@@ -48,6 +48,15 @@ final class UserDataBagTest extends TestCase
 
     public function createFromArrayDataProvider(): iterable
     {
+        yield [
+            ['id' => 1234],
+            1234,
+            null,
+            null,
+            null,
+            [],
+        ];
+
         yield [
             ['id' => 'unique_id'],
             'unique_id',
@@ -100,6 +109,30 @@ final class UserDataBagTest extends TestCase
             null,
             null,
             ['subscription' => 'basic'],
+        ];
+    }
+
+    /**
+     * @dataProvider setIdThrowsIfValueIsUnexpectedValueDataProvider
+     */
+    public function testSetIdThrowsIfValueIsUnexpectedValue($value, string $expectedExceptionMessage): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        UserDataBag::createFromUserIdentifier($value);
+    }
+
+    public function setIdThrowsIfValueIsUnexpectedValueDataProvider(): iterable
+    {
+        yield [
+            12.34,
+            'Expected an integer or string value for the $id argument. Got: "float".',
+        ];
+
+        yield [
+            new \stdClass(),
+            'Expected an integer or string value for the $id argument. Got: "stdClass".',
         ];
     }
 


### PR DESCRIPTION
User identifiers can be strings but most of the time are integers, only allowing strings is too strict with that in mind.