### PR TITLE
Symfony HTTP client support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support the `timeout` and `proxy` options for the Symfony HTTP Client (#1084)
+
 ### 2.4.3 (2020-08-13)
 
 - Fix `Options::setEnvironment` method not accepting `null` values (#1057)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -31,9 +31,6 @@ parameters:
             message: '/^Method Sentry\\Monolog\\Handler::write\(\) has parameter \$record with no value type specified in iterable type array\.$/'
             path: src/Monolog/Handler.php
         -
-            message: '/^Cannot cast array\|bool\|float\|int\|string\|null to string\.$/'
-            path: src/Serializer/RepresentationSerializer.php
-        -
             message: '/^Method Sentry\\Client::getIntegration\(\) should return T of Sentry\\Integration\\IntegrationInterface\|null but returns Sentry\\Integration\\IntegrationInterface\|null\.$/'
             path: src/Client.php
         -

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,9 @@ parameters:
             message: '/^Access to constant (?:PROXY|TIMEOUT|CONNECT_TIMEOUT) on an unknown class GuzzleHttp\\RequestOptions\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
+            message: '/^Call to static method create\(\) on an unknown class Symfony\\Component\\HttpClient\\HttpClient\.$/'
+            path: src/HttpClient/HttpClientFactory.php
+        -
             message: '/^Parameter #1 \$c of function ctype_digit expects int\|string, string\|null given\.$/'
             path: src/Dsn.php
         -

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -115,7 +115,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         if (null === $httpClient) {
             if (class_exists(SymfonyHttplugClient::class)) {
                 $symfonyConfig = [
-                    'timeout' => self::DEFAULT_HTTP_TIMEOUT,
+                    'max_duration' => self::DEFAULT_HTTP_TIMEOUT,
                 ];
 
                 if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -21,6 +21,8 @@ use Http\Message\UriFactory as UriFactoryInterface;
 use Sentry\HttpClient\Authentication\SentryAuthentication;
 use Sentry\HttpClient\Plugin\GzipEncoderPlugin;
 use Sentry\Options;
+use Symfony\Component\HttpClient\HttpClient as SymfonyHttpClient;
+use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
 
 /**
  * Default implementation of the {@HttpClientFactoryInterface} interface that uses
@@ -111,7 +113,20 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         }
 
         if (null === $httpClient) {
-            if (class_exists(GuzzleHttpClient::class)) {
+            if (class_exists(SymfonyHttplugClient::class)) {
+                $symfonyConfig = [
+                    'timeout' => self::DEFAULT_HTTP_TIMEOUT,
+                ];
+
+                if (null !== $options->getHttpProxy()) {
+                    $symfonyConfig['proxy'] = $options->getHttpProxy();
+                }
+
+                /** @psalm-suppress UndefinedClass */
+                $httpClient = new SymfonyHttplugClient(
+                    SymfonyHttpClient::create($symfonyConfig)
+                );
+            } elseif (class_exists(GuzzleHttpClient::class)) {
                 /** @psalm-suppress UndefinedClass */
                 $guzzleConfig = [
                     GuzzleHttpClientOptions::TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,


### PR DESCRIPTION
This implements the "missing" HTTP client options needed when we switch our default/preferred HTTP client to it (getsentry/sentry-php-sdk#7).

---

Symfony has only a single timeout option, maybe we want to combine our 2 timeouts into that one?

Full Symfony options docs: https://symfony.com/doc/current/reference/configuration/framework.html#http-client

---

I've opted to not remove any others (we can do that in 3.x) because I want to release this as 2.5.0 or 2.4.x and release the SDK package as 2.5.0 which will require `sentry/sentry-php` at whatever version this is released.