### PR TITLE
Add named constructors to the Event class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `traces_sampler` option to set custom sample rate callback (#1083)
+- [BC BREAK] Add named constructors to the `Event` class (#1085)
 
 ## 3.0.0-beta1 (2020-09-03)
 

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -109,3 +109,4 @@
 - Removed the `Frame::toArray()` and `Frame::jsonSerialize()` methods
 - Removed the `Stacktrace::toArray()` and `Stacktrace::jsonSerialize()` methods
 - Removed the `SpoolTransport` class and the `SpoolInterface` interface with related implementation
+- Made the `Event::__construct()` method `private`, use the named constructors instead

--- a/src/Event.php
+++ b/src/Event.php
@@ -158,17 +158,32 @@ final class Event
      */
     private $type;
 
-    /**
-     * Class constructor.
-     *
-     * @param EventId|null $eventId The ID of the event
-     */
-    public function __construct(?EventId $eventId = null)
+    private function __construct(?EventId $eventId, EventType $eventType)
     {
         $this->id = $eventId ?? EventId::generate();
         $this->timestamp = gmdate('Y-m-d\TH:i:s\Z');
         $this->sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
-        $this->type = EventType::default();
+        $this->type = $eventType;
+    }
+
+    /**
+     * Creates a new event.
+     *
+     * @param EventId|null $eventId The ID of the event
+     */
+    public static function createEvent(?EventId $eventId = null): self
+    {
+        return new self($eventId, EventType::default());
+    }
+
+    /**
+     * Creates a new transaction event.
+     *
+     * @param EventId|null $eventId The ID of the event
+     */
+    public static function createTransaction(EventId $eventId = null): self
+    {
+        return new self($eventId, EventType::transaction());
     }
 
     /**
@@ -635,11 +650,6 @@ final class Event
     public function getType(): EventType
     {
         return $this->type;
-    }
-
-    public function setType(EventType $type): void
-    {
-        $this->type = $type;
     }
 
     /**

--- a/src/EventFactory.php
+++ b/src/EventFactory.php
@@ -85,7 +85,7 @@ final class EventFactory implements EventFactoryInterface
             if ($payload instanceof Event) {
                 $event = $payload;
             } else {
-                $event = new Event();
+                $event = Event::createEvent();
 
                 if (isset($payload['logger'])) {
                     $event->setLogger($payload['logger']);

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -6,7 +6,6 @@ namespace Sentry\Tracing;
 
 use Sentry\Event;
 use Sentry\EventId;
-use Sentry\EventType;
 use Sentry\Severity;
 use Sentry\State\HubInterface;
 
@@ -90,8 +89,7 @@ final class Transaction extends Span
      */
     public function toEvent(): Event
     {
-        $event = new Event();
-        $event->setType(EventType::transaction());
+        $event = Event::createTransaction();
         $event->setTags(array_merge($event->getTags(), $this->tags));
         $event->setTransaction($this->name);
         $event->setStartTimestamp($this->startTimestamp);

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -15,8 +15,8 @@ final class EventTest extends TestCase
 {
     public function testEventIsGeneratedWithUniqueIdentifier(): void
     {
-        $event1 = new Event();
-        $event2 = new Event();
+        $event1 = Event::createEvent();
+        $event2 = Event::createEvent();
 
         $this->assertNotEquals($event1->getId(), $event2->getId());
     }
@@ -26,7 +26,7 @@ final class EventTest extends TestCase
      */
     public function testGetMessage(array $setMessageArguments, array $expectedValue): void
     {
-        $event = new Event();
+        $event = Event::createEvent();
 
         \call_user_func_array([$event, 'setMessage'], $setMessageArguments);
 
@@ -80,7 +80,7 @@ final class EventTest extends TestCase
         $getterMethod = 'get' . ucfirst($propertyName);
         $setterMethod = 'set' . ucfirst($propertyName);
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->$setterMethod($propertyValue);
 
         $this->assertEquals($event->$getterMethod(), $propertyValue);

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -112,7 +112,7 @@ final class FunctionsTest extends TestCase
 
         addBreadcrumb($breadcrumb);
         configureScope(function (Scope $scope) use ($breadcrumb): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb], $event->getBreadcrumbs());

--- a/tests/Integration/EnvironmentIntegrationTest.php
+++ b/tests/Integration/EnvironmentIntegrationTest.php
@@ -35,7 +35,7 @@ final class EnvironmentIntegrationTest extends TestCase
         SentrySdk::getCurrentHub()->bindClient($client);
 
         withScope(function (Scope $scope) use ($expectedRuntimeContext, $expectedOsContext, $initialRuntimeContext, $initialOsContext): void {
-            $event = new Event();
+            $event = Event::createEvent();
             $event->setRuntimeContext($initialRuntimeContext);
             $event->setOsContext($initialOsContext);
 

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -63,7 +63,7 @@ final class FrameContextifierIntegrationTest extends TestCase
             new Frame('[unknown]', $fixtureFilePath, $lineNumber, null, $fixtureFilePath),
         ]);
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setStacktrace($stacktrace);
 
         withScope(static function (Scope $scope) use (&$event): void {
@@ -157,7 +157,7 @@ final class FrameContextifierIntegrationTest extends TestCase
             new Frame(null, 'file.ext', 10, null, 'file.ext'),
         ]);
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setStacktrace($stacktrace);
 
         withScope(static function (Scope $scope) use (&$event): void {

--- a/tests/Integration/IgnoreErrorsIntegrationTest.php
+++ b/tests/Integration/IgnoreErrorsIntegrationTest.php
@@ -45,11 +45,11 @@ final class IgnoreErrorsIntegrationTest extends TestCase
 
     public function invokeDataProvider(): \Generator
     {
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setExceptions([new ExceptionDataBag(new \RuntimeException())]);
 
         yield 'Integration disabled' => [
-            new Event(),
+            Event::createEvent(),
             false,
             [
                 'ignore_exceptions' => [],
@@ -57,11 +57,11 @@ final class IgnoreErrorsIntegrationTest extends TestCase
             false,
         ];
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setExceptions([new ExceptionDataBag(new \RuntimeException())]);
 
         yield 'No exceptions to check' => [
-            new Event(),
+            Event::createEvent(),
             true,
             [
                 'ignore_exceptions' => [],
@@ -69,7 +69,7 @@ final class IgnoreErrorsIntegrationTest extends TestCase
             false,
         ];
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setExceptions([new ExceptionDataBag(new \RuntimeException())]);
 
         yield 'The exception is matching exactly the "ignore_exceptions" option' => [
@@ -83,7 +83,7 @@ final class IgnoreErrorsIntegrationTest extends TestCase
             true,
         ];
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setExceptions([new ExceptionDataBag(new \RuntimeException())]);
 
         yield 'The exception is matching the "ignore_exceptions" option' => [

--- a/tests/Integration/ModulesIntegrationTest.php
+++ b/tests/Integration/ModulesIntegrationTest.php
@@ -32,7 +32,7 @@ final class ModulesIntegrationTest extends TestCase
         SentrySdk::getCurrentHub()->bindClient($client);
 
         withScope(function (Scope $scope) use ($expectedEmptyModules): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -28,7 +28,7 @@ final class RequestIntegrationTest extends TestCase
      */
     public function testInvoke(array $options, ServerRequestInterface $request, array $expectedRequestContextData, ?UserDataBag $initialUser, ?UserDataBag $expectedUser): void
     {
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setUser($initialUser);
 
         $integration = new RequestIntegration($this->createRequestFetcher($request));

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -46,7 +46,7 @@ final class TransactionIntegrationTest extends TestCase
     public function setupOnceDataProvider(): \Generator
     {
         yield [
-            new Event(),
+            Event::createEvent(),
             true,
             [],
             [],
@@ -54,7 +54,7 @@ final class TransactionIntegrationTest extends TestCase
         ];
 
         yield [
-            new Event(),
+            Event::createEvent(),
             true,
             ['transaction' => '/foo/bar'],
             [],
@@ -62,14 +62,14 @@ final class TransactionIntegrationTest extends TestCase
         ];
 
         yield [
-            new Event(),
+            Event::createEvent(),
             true,
             [],
             ['PATH_INFO' => '/foo/bar'],
             '/foo/bar',
         ];
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setTransaction('/foo/bar');
 
         yield [
@@ -80,7 +80,7 @@ final class TransactionIntegrationTest extends TestCase
             '/foo/bar',
         ];
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setTransaction('/foo/bar');
 
         yield [
@@ -92,7 +92,7 @@ final class TransactionIntegrationTest extends TestCase
         ];
 
         yield [
-            new Event(),
+            Event::createEvent(),
             false,
             ['transaction' => '/foo/bar'],
             [],

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -26,7 +26,7 @@ final class HandlerTest extends TestCase
         $client->expects($this->once())
             ->method('captureEvent')
             ->with($expectedPayload, $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
-                $event = $scopeArg->applyToEvent(new Event(), []);
+                $event = $scopeArg->applyToEvent(Event::createEvent(), []);
 
                 $this->assertNotNull($event);
                 $this->assertSame($expectedExtra, $event->getExtra());

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -11,7 +11,6 @@ use Sentry\Context\OsContext;
 use Sentry\Context\RuntimeContext;
 use Sentry\Event;
 use Sentry\EventId;
-use Sentry\EventType;
 use Sentry\ExceptionDataBag;
 use Sentry\ExceptionMechanism;
 use Sentry\Frame;
@@ -62,7 +61,7 @@ final class PayloadSerializerTest extends TestCase
         $sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
 
         yield [
-            new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd')),
+            Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd')),
             <<<JSON
 {
     "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
@@ -78,7 +77,7 @@ JSON
             true,
         ];
 
-        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setLevel(Severity::error());
         $event->setLogger('app.php');
         $event->setTransaction('/users/<username>/');
@@ -316,7 +315,7 @@ JSON
             true,
         ];
 
-        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setMessage('My raw message with interpreted strings like this', []);
 
         yield [
@@ -337,7 +336,7 @@ JSON
             true,
         ];
 
-        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setMessage('My raw message with interpreted strings like %s', ['this']);
 
         yield [
@@ -362,7 +361,7 @@ JSON
             true,
         ];
 
-        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setMessage('My raw message with interpreted strings like %s', ['this'], 'My raw message with interpreted strings like that');
 
         yield [
@@ -409,8 +408,7 @@ JSON
 
         $span2->finish(1598659060);
 
-        $event = new Event(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setType(EventType::transaction());
+        $event = Event::createTransaction(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setSpans([$span1, $span2]);
 
         yield [

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -289,7 +289,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb($breadcrumb);
         $hub->configureScope(function (Scope $scope): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertEmpty($event->getBreadcrumbs());
@@ -298,7 +298,7 @@ final class HubTest extends TestCase
         $hub->bindClient($client);
         $hub->addBreadcrumb($breadcrumb);
         $hub->configureScope(function (Scope $scope) use (&$callbackInvoked, $breadcrumb): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb], $event->getBreadcrumbs());
@@ -321,7 +321,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $hub->configureScope(function (Scope $scope): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertEmpty($event->getBreadcrumbs());
@@ -345,7 +345,7 @@ final class HubTest extends TestCase
         $hub->addBreadcrumb($breadcrumb2);
 
         $hub->configureScope(function (Scope $scope) use ($breadcrumb1, $breadcrumb2): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb1, $breadcrumb2], $event->getBreadcrumbs());
@@ -354,7 +354,7 @@ final class HubTest extends TestCase
         $hub->addBreadcrumb($breadcrumb3);
 
         $hub->configureScope(function (Scope $scope) use ($breadcrumb2, $breadcrumb3): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb2, $breadcrumb3], $event->getBreadcrumbs());
@@ -377,7 +377,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $hub->configureScope(function (Scope $scope): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertEmpty($event->getBreadcrumbs());
@@ -404,7 +404,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb($breadcrumb1);
         $hub->configureScope(function (Scope $scope) use (&$callbackInvoked, $breadcrumb2): void {
-            $event = $scope->applyToEvent(new Event(), []);
+            $event = $scope->applyToEvent(Event::createEvent(), []);
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb2], $event->getBreadcrumbs());

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -16,7 +16,7 @@ final class ScopeTest extends TestCase
     public function testSetTag(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getTags());
@@ -24,7 +24,7 @@ final class ScopeTest extends TestCase
         $scope->setTag('foo', 'bar');
         $scope->setTag('bar', 'baz');
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTags());
@@ -35,14 +35,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setTags(['foo' => 'bar']);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar'], $event->getTags());
 
         $scope->setTags(['bar' => 'baz']);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTags());
@@ -53,14 +53,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setContext('foo', ['foo' => 'bar']);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => ['foo' => 'bar']], $event->getContexts());
 
         $scope->removeContext('foo');
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame([], $event->getContexts());
@@ -69,7 +69,7 @@ final class ScopeTest extends TestCase
     public function testSetExtra(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getExtra());
@@ -77,7 +77,7 @@ final class ScopeTest extends TestCase
         $scope->setExtra('foo', 'bar');
         $scope->setExtra('bar', 'baz');
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtra());
@@ -88,14 +88,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setExtras(['foo' => 'bar']);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar'], $event->getExtra());
 
         $scope->setExtras(['bar' => 'baz']);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtra());
@@ -104,7 +104,7 @@ final class ScopeTest extends TestCase
     public function testSetUser(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertNull($event->getUser());
@@ -114,7 +114,7 @@ final class ScopeTest extends TestCase
 
         $scope->setUser($user);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame($user, $event->getUser());
@@ -145,14 +145,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setUser(UserDataBag::createFromUserIdentifier('unique_id'));
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertNotNull($event->getUser());
 
         $scope->removeUser();
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertNull($event->getUser());
@@ -161,14 +161,14 @@ final class ScopeTest extends TestCase
     public function testSetFingerprint(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getFingerprint());
 
         $scope->setFingerprint(['foo', 'bar']);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame(['foo', 'bar'], $event->getFingerprint());
@@ -177,14 +177,14 @@ final class ScopeTest extends TestCase
     public function testSetLevel(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertNull($event->getLevel());
 
         $scope->setLevel(Severity::debug());
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertEquals(Severity::debug(), $event->getLevel());
@@ -197,7 +197,7 @@ final class ScopeTest extends TestCase
         $breadcrumb2 = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
         $breadcrumb3 = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getBreadcrumbs());
@@ -205,14 +205,14 @@ final class ScopeTest extends TestCase
         $scope->addBreadcrumb($breadcrumb1);
         $scope->addBreadcrumb($breadcrumb2);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame([$breadcrumb1, $breadcrumb2], $event->getBreadcrumbs());
 
         $scope->addBreadcrumb($breadcrumb3, 2);
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertSame([$breadcrumb2, $breadcrumb3], $event->getBreadcrumbs());
@@ -225,14 +225,14 @@ final class ScopeTest extends TestCase
         $scope->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $scope->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertNotEmpty($event->getBreadcrumbs());
 
         $scope->clearBreadcrumbs();
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getBreadcrumbs());
@@ -244,7 +244,7 @@ final class ScopeTest extends TestCase
         $callback2Called = false;
         $callback3Called = false;
 
-        $event = new Event();
+        $event = Event::createEvent();
         $scope = new Scope();
 
         $scope->addEventProcessor(function (Event $eventArg) use (&$callback1Called, $callback2Called, $callback3Called): ?Event {
@@ -292,7 +292,7 @@ final class ScopeTest extends TestCase
         $scope->setUser(UserDataBag::createFromUserIdentifier('unique_id'));
         $scope->clear();
 
-        $event = $scope->applyToEvent(new Event(), []);
+        $event = $scope->applyToEvent(Event::createEvent(), []);
 
         $this->assertNotNull($event);
         $this->assertNull($event->getLevel());
@@ -308,7 +308,7 @@ final class ScopeTest extends TestCase
         $breadcrumb = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
         $user = UserDataBag::createFromUserIdentifier('unique_id');
 
-        $event = new Event();
+        $event = Event::createEvent();
         $event->setContext('foocontext', ['foo' => 'foo', 'bar' => 'bar']);
 
         $scope = new Scope();

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -19,7 +19,6 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Sentry\Dsn;
 use Sentry\Event;
-use Sentry\EventType;
 use Sentry\Options;
 use Sentry\ResponseStatus;
 use Sentry\Serializer\PayloadSerializerInterface;
@@ -69,14 +68,13 @@ final class HttpTransportTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The DSN option must be set to use the "Sentry\Transport\HttpTransport" transport.');
 
-        $transport->send(new Event());
+        $transport->send(Event::createEvent());
     }
 
     public function testSendTransactionAsEnvelope(): void
     {
         $dsn = Dsn::createFromString('http://public@example.com/sentry/1');
-        $event = new Event();
-        $event->setType(EventType::transaction());
+        $event = Event::createTransaction();
 
         $this->payloadSerializer->expects($this->once())
             ->method('serialize')
@@ -127,7 +125,7 @@ final class HttpTransportTest extends TestCase
     public function testSend(int $httpStatusCode, string $expectedPromiseStatus, ResponseStatus $expectedResponseStatus): void
     {
         $dsn = Dsn::createFromString('http://public@example.com/sentry/1');
-        $event = new Event();
+        $event = Event::createEvent();
 
         $this->payloadSerializer->expects($this->once())
             ->method('serialize')
@@ -201,7 +199,7 @@ final class HttpTransportTest extends TestCase
     {
         $dsn = Dsn::createFromString('http://public@example.com/sentry/1');
         $exception = new \Exception('foo');
-        $event = new Event();
+        $event = Event::createEvent();
 
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);

--- a/tests/Transport/NullTransportTest.php
+++ b/tests/Transport/NullTransportTest.php
@@ -24,7 +24,7 @@ final class NullTransportTest extends TestCase
 
     public function testSend(): void
     {
-        $event = new Event();
+        $event = Event::createEvent();
 
         $promise = $this->transport->send($event);
         $promiseResult = $promise->wait();


### PR DESCRIPTION
Little (breaking) change in the `Event` class: since we now have two types of events (event and transaction), I decided to add named constructors and make the default constructor `private`. This should make it easier in the future to encapsulate the minimum amount of information required for initializing each type of event and ensure that the newly created object is in a valid and consistent state from the beginning rather than rely on the hope that users will call all the appropriate setters depending on the situation