### PR TITLE
Update some deps and require at least PHP 7.2

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,12 +7,6 @@ image: Visual Studio 2019
 
 environment:
     matrix:
-        - PHP_VERSION: 7.1
-          XDEBUG_VERSION: 2.9.2-7.1-vc14-nts
-          DEPENDENCIES: lowest
-        - PHP_VERSION: 7.1
-          XDEBUG_VERSION: 2.9.2-7.1-vc14-nts
-          DEPENDENCIES: highest
         - PHP_VERSION: 7.2
           XDEBUG_VERSION: 2.9.2-7.2-vc15-nts
           DEPENDENCIES: lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 7.1
     - 7.2
     - 7.3
     - 7.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add `traces_sampler` option to set custom sample rate callback (#1083)
 - [BC BREAK] Add named constructors to the `Event` class (#1085)
+- Raise the minimum version of PHP to `7.2` and the minimum version of some dependencies (#1088)
 
 ## 3.0.0-beta1 (2020-09-03)
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.3",
@@ -35,7 +35,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0",
-        "symfony/options-resolver": "^2.7|^3.0|^4.0|^5.0",
+        "symfony/options-resolver": "^3.4|^4.0|^5.0",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-uuid": "^1.13.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0",
-        "symfony/options-resolver": "^3.4|^4.0|^5.0",
+        "symfony/options-resolver": "^3.4.4|^4.0|^5.0",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-uuid": "^1.13.1"
     },

--- a/src/Options.php
+++ b/src/Options.php
@@ -729,7 +729,7 @@ final class Options
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
-        $resolver->setAllowedTypes('prefixes', 'array');
+        $resolver->setAllowedTypes('prefixes', 'string[]');
         $resolver->setAllowedTypes('sample_rate', ['int', 'float']);
         $resolver->setAllowedTypes('traces_sample_rate', ['int', 'float']);
         $resolver->setAllowedTypes('traces_sampler', ['null', 'callable']);
@@ -737,18 +737,18 @@ final class Options
         $resolver->setAllowedTypes('context_lines', ['null', 'int']);
         $resolver->setAllowedTypes('enable_compression', 'bool');
         $resolver->setAllowedTypes('environment', ['null', 'string']);
-        $resolver->setAllowedTypes('in_app_exclude', 'array');
-        $resolver->setAllowedTypes('in_app_include', 'array');
+        $resolver->setAllowedTypes('in_app_exclude', 'string[]');
+        $resolver->setAllowedTypes('in_app_include', 'string[]');
         $resolver->setAllowedTypes('logger', 'string');
         $resolver->setAllowedTypes('release', ['null', 'string']);
         $resolver->setAllowedTypes('dsn', ['null', 'string', 'bool', Dsn::class]);
         $resolver->setAllowedTypes('server_name', 'string');
         $resolver->setAllowedTypes('before_send', ['callable']);
-        $resolver->setAllowedTypes('tags', 'array');
+        $resolver->setAllowedTypes('tags', 'string[]');
         $resolver->setAllowedTypes('error_types', ['int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');
         $resolver->setAllowedTypes('before_breadcrumb', ['callable']);
-        $resolver->setAllowedTypes('integrations', ['array', 'callable']);
+        $resolver->setAllowedTypes('integrations', ['Sentry\\Integration\\IntegrationInterface[]', 'callable']);
         $resolver->setAllowedTypes('send_default_pii', 'bool');
         $resolver->setAllowedTypes('default_integrations', 'bool');
         $resolver->setAllowedTypes('max_value_length', 'int');
@@ -759,10 +759,8 @@ final class Options
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
-        $resolver->setAllowedValues('integrations', \Closure::fromCallable([$this, 'validateIntegrationsOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));
         $resolver->setAllowedValues('class_serializers', \Closure::fromCallable([$this, 'validateClassSerializersOption']));
-        $resolver->setAllowedValues('tags', \Closure::fromCallable([$this, 'validateTagsOption']));
         $resolver->setAllowedValues('context_lines', \Closure::fromCallable([$this, 'validateContextLinesOption']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
@@ -864,27 +862,6 @@ final class Options
     }
 
     /**
-     * Validates that the elements of this option are all class instances that
-     * implements the {@see IntegrationInterface} interface.
-     *
-     * @param IntegrationInterface[]|callable $integrations The value to validate
-     */
-    private function validateIntegrationsOption($integrations): bool
-    {
-        if (\is_callable($integrations)) {
-            return true;
-        }
-
-        foreach ($integrations as $integration) {
-            if (!$integration instanceof IntegrationInterface) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
      * Validates if the value of the max_breadcrumbs option is in range.
      *
      * @param int $value The value to validate
@@ -903,22 +880,6 @@ final class Options
     {
         foreach ($serializers as $class => $serializer) {
             if (!\is_string($class) || !\is_callable($serializer)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Validates that the values passed to the `tags` option are valid.
-     *
-     * @param mixed[] $tags The value to validate
-     */
-    private function validateTagsOption(array $tags): bool
-    {
-        foreach ($tags as $tagName => $tagValue) {
-            if (!\is_string($tagValue)) {
                 return false;
             }
         }


### PR DESCRIPTION
Not much to say, minimum supported PHP version for `3.x` will be `7.2`. I also decided to update the required version of the `symfony/options-resolver` paclkage so that we are able to use the standard `value[]` syntax to validate that an option of type `array` contains only values of that type rather than writing our own validator function