### PR TITLE
Only accept Event on captureEvent methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add `traces_sampler` option to set custom sample rate callback (#1083)
 - [BC BREAK] Add named constructors to the `Event` class (#1085)
 - Raise the minimum version of PHP to `7.2` and the minimum version of some dependencies (#1088)
+- [BC BREAK] Change the `captureEvent` to only accept an instance of the `Event` class rather than also a plain array (#1094)
 - Add Guzzle middleware to trace performance of HTTP requests (#1096)
 
 ## 3.0.0-beta1 (2020-09-03)

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -113,3 +113,5 @@
 - The signature of `ClientInterface::captureEvent` changed to `ClientInterface::captureEvent(Event $event, ?EventHint $hint = null, ?Scope $scope = null)`
 - The signature of `HubInterface::captureEvent` changed to `HubInterface::captureEvent(Event $event, ?EventHint $hint = null)`
 - The signature of `captureEvent` changed to `captureEvent(Event $event, ?EventHint $hint = null)`
+- The signature of `Scope::applyToEvent` changed to `Scope::applyToEvent(Event $event)`
+- Global and scope event processors will no longer receive a second argument, callable should now have the signature `callable(Event $event)`

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -110,8 +110,8 @@
 - Removed the `Stacktrace::toArray()` and `Stacktrace::jsonSerialize()` methods
 - Removed the `SpoolTransport` class and the `SpoolInterface` interface with related implementation
 - Made the `Event::__construct()` method `private`, use the named constructors instead
-- The signature of `ClientInterface::captureEvent` changed to `ClientInterface::captureEvent(Event $event, ?EventHint $hint = null, ?Scope $scope = null)`
-- The signature of `HubInterface::captureEvent` changed to `HubInterface::captureEvent(Event $event, ?EventHint $hint = null)`
-- The signature of `captureEvent` changed to `captureEvent(Event $event, ?EventHint $hint = null)`
-- The signature of `Scope::applyToEvent` changed to `Scope::applyToEvent(Event $event)`
-- Global and scope event processors will no longer receive a second argument, callable should now have the signature `callable(Event $event)`
+- The signature of `ClientInterface::captureEvent()` changed to `ClientInterface::captureEvent(Event $event, ?EventHint $hint = null, ?Scope $scope = null)`
+- The signature of `HubInterface::captureEvent()` changed to `HubInterface::captureEvent(Event $event, ?EventHint $hint = null)`
+- The signature of `captureEvent()` changed to `captureEvent(Event $event, ?EventHint $hint = null)`
+- The signature of `Scope::applyToEvent()` changed to `Scope::applyToEvent(Event $event, ?EventHint $hint = null)`
+- Global and scope event processors will now receive a `EventHint` as the second parameter, callable should now have the signature `callable(Event $event, EventHint $hint)`

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -102,7 +102,7 @@
 - Removed the `Event::getTagsContext()` method, use `Event::getTags()` instead
 - Removed the `Event::getUserContext()` method, use `Event::getUser()` instead
 - Renamed the `Event::getServerOsContext()` method to `Event::getOsContext()`
-- The signature of the `Scope::setUser()` method changed ot accept a plain array
+- The signature of the `Scope::setUser()` method changed to accept a plain array
 - Removed the `FlushableClientInterface` and `ClosableTransportInterface` interfaces. Their methods have been moved to the corresponding `ClientInterface` and `TransportInterface` interfaces
 - Removed the `Event::toArray()` and `Event::jsonSerialize()` methods
 - Removed the `Breadcrumb::toArray()` and `Breadcrumb::jsonSerialize()` methods
@@ -110,3 +110,6 @@
 - Removed the `Stacktrace::toArray()` and `Stacktrace::jsonSerialize()` methods
 - Removed the `SpoolTransport` class and the `SpoolInterface` interface with related implementation
 - Made the `Event::__construct()` method `private`, use the named constructors instead
+- The signature of `ClientInterface::captureEvent` changed to `ClientInterface::captureEvent(Event $event, ?EventHint $hint = null, ?Scope $scope = null)`
+- The signature of `HubInterface::captureEvent` changed to `HubInterface::captureEvent(Event $event, ?EventHint $hint = null)`
+- The signature of `captureEvent` changed to `captureEvent(Event $event, ?EventHint $hint = null)`

--- a/src/Client.php
+++ b/src/Client.php
@@ -215,7 +215,7 @@ final class Client implements ClientInterface
     {
         $event = $this->buildEvent($payload, $hint);
 
-        $this->addMissingStacktraceToEvent($payload, $hint);
+        $this->addMissingStacktraceToEvent($event, $hint);
 
         $sampleRate = $this->options->getSampleRate();
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -223,14 +223,14 @@ final class Client implements ClientInterface
             }
         }
 
+        $this->addMissingStacktraceToEvent($event);
+
         $event->setSdkIdentifier($this->sdkIdentifier);
         $event->setSdkVersion($this->sdkVersion);
         $event->setServerName($this->options->getServerName());
         $event->setRelease($this->options->getRelease());
         $event->setTags($this->options->getTags());
         $event->setEnvironment($this->options->getEnvironment());
-
-        $this->addMissingStacktraceToEvent($event, $hint);
 
         $sampleRate = $this->options->getSampleRate();
 
@@ -264,17 +264,11 @@ final class Client implements ClientInterface
     /**
      * Optionally adds a missing stacktrace to the Event if the client is configured to do so.
      *
-     * @param Event          $event The Event to add the missing stacktrace to
-     * @param EventHint|null $hint  May contain additional information about the event
+     * @param Event $event The Event to add the missing stacktrace to
      */
-    private function addMissingStacktraceToEvent(Event $event, ?EventHint $hint): void
+    private function addMissingStacktraceToEvent(Event $event): void
     {
         if (!$this->options->shouldAttachStacktrace()) {
-            return;
-        }
-
-        // If the hint contains an exception the stacktrace will be generated for that exception
-        if (null !== $hint && null !== $hint->exception) {
             return;
         }
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -47,10 +47,11 @@ interface ClientInterface
     /**
      * Captures a new event using the provided data.
      *
-     * @param array<string, mixed>|Event $payload The data of the event being captured
-     * @param Scope|null                 $scope   An optional scope keeping the state
+     * @param Event          $event The event being captured
+     * @param EventHint|null $hint  May contain additional information about the original exception
+     * @param Scope|null     $scope An optional scope keeping the state
      */
-    public function captureEvent($payload, ?Scope $scope = null): ?EventId;
+    public function captureEvent(Event $event, ?EventHint $hint = null, ?Scope $scope = null): ?EventId;
 
     /**
      * Returns the integration instance if it is installed on the client.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -48,7 +48,7 @@ interface ClientInterface
      * Captures a new event using the provided data.
      *
      * @param Event          $event The event being captured
-     * @param EventHint|null $hint  May contain additional information about the original exception
+     * @param EventHint|null $hint  May contain additional information about the event
      * @param Scope|null     $scope An optional scope keeping the state
      */
     public function captureEvent(Event $event, ?EventHint $hint = null, ?Scope $scope = null): ?EventId;

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+/**
+ * This class represents hints on how to process an event.
+ */
+final class EventHint
+{
+    /**
+     * The original exception to add to the event.
+     *
+     * @var \Throwable|null
+     */
+    public $exception;
+
+    /**
+     * The stacktrace to set on the event.
+     *
+     * @var Stacktrace|null
+     */
+    public $stacktrace;
+
+    /**
+     * Create a EventHint instance from an array of values.
+     *
+     * @return static
+     */
+    public static function fromArray(array $hintData): self
+    {
+        $hint = new self();
+
+        foreach ($hintData as $hintKey => $hintValue) {
+            if (property_exists($hint, $hintKey)) {
+                $hint->{$hintKey} = $hintValue;
+            }
+        }
+
+        return $hint;
+    }
+}

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Sentry\Exception\InvalidArgumentException;
-
 /**
  * This class represents hints on how to process an event.
  */
@@ -39,7 +37,7 @@ final class EventHint
 
         foreach ($hintData as $hintKey => $hintValue) {
             if (!property_exists($hint, $hintKey)) {
-                throw new InvalidArgumentException(sprintf('There is no EventHint attribute called "%s".', $hintKey));
+                throw new \InvalidArgumentException(sprintf('There is no EventHint attribute called "%s".', $hintKey));
             }
 
             $hint->{$hintKey} = $hintValue;

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -29,6 +29,11 @@ final class EventHint
      * Create a EventHint instance from an array of values.
      *
      * @param array $hintData
+     *
+     * @psalm-param array{
+     *     exception?: \Throwable,
+     *     stacktrace?: Event
+     * } $hintData
      */
     public static function fromArray(array $hintData): self
     {

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Sentry\Exception\InvalidArgumentException;
+
 /**
  * This class represents hints on how to process an event.
  */
@@ -26,16 +28,18 @@ final class EventHint
     /**
      * Create a EventHint instance from an array of values.
      *
-     * @return static
+     * @param array $hintData
      */
     public static function fromArray(array $hintData): self
     {
         $hint = new self();
 
         foreach ($hintData as $hintKey => $hintValue) {
-            if (property_exists($hint, $hintKey)) {
-                $hint->{$hintKey} = $hintValue;
+            if (!property_exists($hint, $hintKey)) {
+                throw new InvalidArgumentException(sprintf('There is no EventHint attribute called "%s".', $hintKey));
             }
+
+            $hint->{$hintKey} = $hintValue;
         }
 
         return $hint;

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -24,11 +24,19 @@ final class EventHint
     public $stacktrace;
 
     /**
+     * Any extra data that might be needed to process the event.
+     *
+     * @var array<string, mixed>
+     */
+    public $extra = [];
+
+    /**
      * Create a EventHint instance from an array of values.
      *
      * @psalm-param array{
      *     exception?: \Throwable,
-     *     stacktrace?: Event
+     *     stacktrace?: Event,
+     *     extra?: array<string, mixed>
      * } $hintData
      */
     public static function fromArray(array $hintData): self

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -28,8 +28,6 @@ final class EventHint
     /**
      * Create a EventHint instance from an array of values.
      *
-     * @param array $hintData
-     *
      * @psalm-param array{
      *     exception?: \Throwable,
      *     stacktrace?: Event

--- a/src/Integration/TransactionIntegration.php
+++ b/src/Integration/TransactionIntegration.php
@@ -22,7 +22,7 @@ final class TransactionIntegration implements IntegrationInterface
      */
     public function setupOnce(): void
     {
-        Scope::addGlobalEventProcessor(static function (Event $event, $payload): Event {
+        Scope::addGlobalEventProcessor(static function (Event $event): Event {
             $integration = SentrySdk::getCurrentHub()->getIntegration(self::class);
 
             // The client bound to the current hub, if any, could not have this
@@ -35,11 +35,7 @@ final class TransactionIntegration implements IntegrationInterface
                 return $event;
             }
 
-            if ($payload instanceof Event && $payload->getTransaction()) {
-                $event->setTransaction($payload->getTransaction());
-            } elseif (isset($payload['transaction'])) {
-                $event->setTransaction($payload['transaction']);
-            } elseif (isset($_SERVER['PATH_INFO'])) {
+            if (isset($_SERVER['PATH_INFO'])) {
                 $event->setTransaction($_SERVER['PATH_INFO']);
             }
 

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -47,7 +47,6 @@ final class Handler extends AbstractProcessingHandler
     protected function write(array $record): void
     {
         $event = Event::createEvent();
-
         $event->setLevel(self::getSeverityFromLevel($record['level']));
         $event->setMessage($record['message']);
         $event->setLogger(sprintf('monolog.%s', $record['channel']));

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -6,6 +6,8 @@ namespace Sentry\Monolog;
 
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
+use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\Severity;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
@@ -44,21 +46,23 @@ final class Handler extends AbstractProcessingHandler
      */
     protected function write(array $record): void
     {
-        $payload = [
-            'level' => self::getSeverityFromLevel($record['level']),
-            'message' => $record['message'],
-            'logger' => 'monolog.' . $record['channel'],
-        ];
+        $event = Event::createEvent();
+
+        $event->setLevel(self::getSeverityFromLevel($record['level']));
+        $event->setMessage($record['message']);
+        $event->setLogger(sprintf('monolog.%s', $record['channel']));
+
+        $hint = new EventHint();
 
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Throwable) {
-            $payload['exception'] = $record['context']['exception'];
+            $hint->exception = $record['context']['exception'];
         }
 
-        $this->hub->withScope(function (Scope $scope) use ($record, $payload): void {
+        $this->hub->withScope(function (Scope $scope) use ($record, $event, $hint): void {
             $scope->setExtra('monolog.channel', $record['channel']);
             $scope->setExtra('monolog.level', $record['level_name']);
 
-            $this->hub->captureEvent($payload);
+            $this->hub->captureEvent($event, $hint);
         });
     }
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -6,6 +6,8 @@ namespace Sentry\State;
 
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
@@ -142,12 +144,12 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureEvent($payload): ?EventId
+    public function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
     {
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureEvent($payload, $this->getScope());
+            return $this->lastEventId = $client->captureEvent($event, $hint, $this->getScope());
         }
 
         return null;

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -6,6 +6,8 @@ namespace Sentry\State;
 
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\SentrySdk;
@@ -120,9 +122,9 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureEvent($payload): ?EventId
+    public function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
     {
-        return SentrySdk::getCurrentHub()->captureEvent($payload);
+        return SentrySdk::getCurrentHub()->captureEvent($event, $hint);
     }
 
     /**

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -90,7 +90,7 @@ interface HubInterface
      * Captures a new event using the provided data.
      *
      * @param Event          $event The event being captured
-     * @param EventHint|null $hint  May contain additional information about the original exception
+     * @param EventHint|null $hint  May contain additional information about the event
      */
     public function captureEvent(Event $event, ?EventHint $hint = null): ?EventId;
 

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -7,6 +7,7 @@ namespace Sentry\State;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Severity;
@@ -88,9 +89,10 @@ interface HubInterface
     /**
      * Captures a new event using the provided data.
      *
-     * @param Event|array<string, mixed> $payload The data of the event being captured
+     * @param Event          $event The event being captured
+     * @param EventHint|null $hint  May contain additional information about the original exception
      */
-    public function captureEvent($payload): ?EventId;
+    public function captureEvent(Event $event, ?EventHint $hint = null): ?EventId;
 
     /**
      * Captures an event that logs the last occurred error.

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -57,7 +57,7 @@ final class Scope
     /**
      * @var callable[] List of event processors
      *
-     * @psalm-var array<callable(Event, Event|array): ?Event>
+     * @psalm-var array<callable(Event): ?Event>
      */
     private $eventProcessors = [];
 
@@ -69,7 +69,7 @@ final class Scope
     /**
      * @var callable[] List of event processors
      *
-     * @psalm-var array<callable(Event, Event|array): ?Event>
+     * @psalm-var array<callable(Event): ?Event>
      */
     private static $globalEventProcessors = [];
 
@@ -303,10 +303,9 @@ final class Scope
      * Applies the current context and fingerprint to the event. If the event has
      * already some breadcrumbs on it, the ones from this scope won't get merged.
      *
-     * @param Event                      $event   The event object that will be enriched with scope data
-     * @param array<string, mixed>|Event $payload The raw payload of the event that will be propagated to the event processors
+     * @param Event $event The event object that will be enriched with scope data
      */
-    public function applyToEvent(Event $event, $payload): ?Event
+    public function applyToEvent(Event $event): ?Event
     {
         $event->setFingerprint(array_merge($event->getFingerprint(), $this->fingerprint));
 
@@ -348,7 +347,7 @@ final class Scope
         }
 
         foreach (array_merge(self::$globalEventProcessors, $this->eventProcessors) as $processor) {
-            $event = $processor($event, $payload);
+            $event = $processor($event);
 
             if (null === $event) {
                 return null;

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -347,7 +347,7 @@ final class Scope
             $event->setContext($name, $data);
         }
 
-        // We create a empty `EventHint` instance to allow processors to always recieve a `EventHint` instance even if there wasn't one
+        // We create a empty `EventHint` instance to allow processors to always receive a `EventHint` instance even if there wasn't one
         if (null === $hint) {
             $hint = new EventHint();
         }

--- a/src/functions.php
+++ b/src/functions.php
@@ -43,11 +43,12 @@ function captureException(\Throwable $exception): ?EventId
 /**
  * Captures a new event using the provided data.
  *
- * @param array<string, mixed> $payload The data of the event being captured
+ * @param Event                  $event The event being captured
+ * @param \Sentry\EventHint|null $hint  May contain additional information about the original exception
  */
-function captureEvent(array $payload): ?EventId
+function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureEvent($payload);
+    return SentrySdk::getCurrentHub()->captureEvent($event, $hint);
 }
 
 /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -43,8 +43,8 @@ function captureException(\Throwable $exception): ?EventId
 /**
  * Captures a new event using the provided data.
  *
- * @param Event                  $event The event being captured
- * @param \Sentry\EventHint|null $hint  May contain additional information about the original exception
+ * @param Event          $event The event being captured
+ * @param EventHint|null $hint  May contain additional information about the event
  */
 function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
 {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -147,7 +147,6 @@ final class ClientTest extends TestCase
             ->getClient();
 
         $event = Event::createEvent();
-
         $event->setTransaction('foo bar');
         $event->setLevel(Severity::debug());
         $event->setLogger('foo');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Sentry\Client;
 use Sentry\ClientBuilder;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\ExceptionMechanism;
 use Sentry\Frame;
 use Sentry\Integration\IntegrationInterface;
@@ -27,6 +28,7 @@ use Sentry\Stacktrace;
 use Sentry\State\Scope;
 use Sentry\Transport\TransportFactoryInterface;
 use Sentry\Transport\TransportInterface;
+use Sentry\UserDataBag;
 
 final class ClientTest extends TestCase
 {
@@ -73,7 +75,7 @@ final class ClientTest extends TestCase
             $logger
         );
 
-        $client->captureEvent([], new Scope());
+        $client->captureEvent(Event::createEvent(), null, new Scope());
 
         $this->assertTrue($integrationCalled);
     }
@@ -144,22 +146,22 @@ final class ClientTest extends TestCase
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        $inputData = [
-            'transaction' => 'foo bar',
-            'level' => Severity::debug(),
-            'logger' => 'foo',
-            'tags_context' => ['foo', 'bar'],
-            'extra_context' => ['foo' => 'bar'],
-            'user_context' => ['bar' => 'foo'],
-        ];
+        $event = Event::createEvent();
 
-        $this->assertNotNull($client->captureEvent($inputData));
+        $event->setTransaction('foo bar');
+        $event->setLevel(Severity::debug());
+        $event->setLogger('foo');
+        $event->setTags(['foo', 'bar']);
+        $event->setExtra(['foo' => 'bar']);
+        $event->setUser(UserDataBag::createFromUserIdentifier('foo'));
+
+        $this->assertNotNull($client->captureEvent($event));
     }
 
     /**
      * @dataProvider captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider
      */
-    public function testCaptureEventAttachesStacktraceAccordingToAttachStacktraceOption(bool $attachStacktraceOption, array $payload, bool $shouldAttachStacktrace): void
+    public function testCaptureEventAttachesStacktraceAccordingToAttachStacktraceOption(bool $attachStacktraceOption, ?EventHint $hint, bool $shouldAttachStacktrace): void
     {
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
@@ -184,36 +186,36 @@ final class ClientTest extends TestCase
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        $this->assertNotNull($client->captureEvent($payload));
+        $this->assertNotNull($client->captureEvent(Event::createEvent(), $hint));
     }
 
     public function captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider(): \Generator
     {
         yield 'Stacktrace attached when attach_stacktrace = true and both payload.exception and payload.stacktrace are unset' => [
             true,
-            [],
+            null,
             true,
         ];
 
         yield 'No stacktrace attached when attach_stacktrace = false' => [
             false,
-            [],
+            null,
             false,
         ];
 
         yield 'No stacktrace attached when attach_stacktrace = true and payload.exception is set' => [
             true,
-            [
+            EventHint::fromArray([
                 'exception' => new \Exception(),
-            ],
+            ]),
             false,
         ];
 
         yield 'No stacktrace attached when attach_stacktrace = false and payload.exception is set' => [
             true,
-            [
+            EventHint::fromArray([
                 'exception' => new \Exception(),
-            ],
+            ]),
             false,
         ];
     }
@@ -239,7 +241,9 @@ final class ClientTest extends TestCase
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        $this->assertNotNull($client->captureEvent(['stacktrace' => $stacktrace]));
+        $this->assertNotNull($client->captureEvent(Event::createEvent(), EventHint::fromArray([
+            'stacktrace' => $stacktrace,
+        ])));
     }
 
     public function testCaptureLastError(): void
@@ -309,7 +313,7 @@ final class ClientTest extends TestCase
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        $client->captureEvent([]);
+        $client->captureEvent(Event::createEvent());
 
         $this->assertTrue($beforeSendCalled);
     }
@@ -515,68 +519,7 @@ final class ClientTest extends TestCase
             $this->createMock(RepresentationSerializerInterface::class)
         );
 
-        $client->captureEvent([]);
-    }
-
-    /**
-     * @dataProvider buildWithPayloadDataProvider
-     */
-    public function testBuildWithPayload(array $payload, ?string $expectedLogger, ?string $expectedMessage, array $expectedMessageParams, ?string $expectedFormattedMessage): void
-    {
-        /** @var TransportInterface&MockObject $transport */
-        $transport = $this->createMock(TransportInterface::class);
-        $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event) use ($expectedLogger, $expectedMessage, $expectedFormattedMessage, $expectedMessageParams): bool {
-                $this->assertSame($expectedLogger, $event->getLogger());
-                $this->assertSame($expectedMessage, $event->getMessage());
-                $this->assertSame($expectedMessageParams, $event->getMessageParams());
-                $this->assertSame($expectedFormattedMessage, $event->getMessageFormatted());
-
-                return true;
-            }));
-
-        $client = new Client(
-            new Options(),
-            $transport,
-            'sentry.sdk.identifier',
-            '1.2.3',
-            $this->createMock(SerializerInterface::class),
-            $this->createMock(RepresentationSerializerInterface::class)
-        );
-
-        $client->captureEvent($payload);
-    }
-
-    public function buildWithPayloadDataProvider(): iterable
-    {
-        yield [
-            ['logger' => 'app.php'],
-            'app.php',
-            null,
-            [],
-            null,
-        ];
-
-        yield [
-            ['message' => 'My raw message with interpreted strings like this'],
-            null,
-            'My raw message with interpreted strings like this',
-            [],
-            null,
-        ];
-
-        yield [
-            [
-                'message' => 'My raw message with interpreted strings like that',
-                'message_params' => ['this'],
-                'message_formatted' => 'My raw message with interpreted strings like %s',
-            ],
-            null,
-            'My raw message with interpreted strings like that',
-            ['this'],
-            'My raw message with interpreted strings like %s',
-        ];
+        $client->captureEvent(Event::createEvent());
     }
 
     public function testBuildEventInCLIDoesntSetTransaction(): void
@@ -600,7 +543,7 @@ final class ClientTest extends TestCase
             $this->createMock(RepresentationSerializerInterface::class)
         );
 
-        $client->captureEvent([]);
+        $client->captureEvent(Event::createEvent());
     }
 
     public function testBuildEventWithException(): void
@@ -639,7 +582,9 @@ final class ClientTest extends TestCase
             $this->createMock(RepresentationSerializerInterface::class)
         );
 
-        $client->captureEvent(['exception' => $exception]);
+        $client->captureEvent(Event::createEvent(), EventHint::fromArray([
+            'exception' => $exception,
+        ]));
     }
 
     public function testBuildWithErrorException(): void
@@ -665,7 +610,9 @@ final class ClientTest extends TestCase
             $this->createMock(RepresentationSerializerInterface::class)
         );
 
-        $client->captureEvent(['exception' => $exception]);
+        $client->captureEvent(Event::createEvent(), EventHint::fromArray([
+            'exception' => $exception,
+        ]));
     }
 
     public function testBuildWithStacktrace(): void
@@ -702,6 +649,6 @@ final class ClientTest extends TestCase
             $this->createMock(RepresentationSerializerInterface::class)
         );
 
-        $client->captureEvent([]);
+        $client->captureEvent(Event::createEvent());
     }
 }

--- a/tests/EventHintTest.php
+++ b/tests/EventHintTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\EventHint;
+use Sentry\Exception\InvalidArgumentException;
+use Sentry\Frame;
+use Sentry\Stacktrace;
+
+final class EventHintTest extends TestCase
+{
+    public function testCreateFromArray(): void
+    {
+        $exception = new \Exception();
+        $stacktrace = new Stacktrace([
+            new Frame('function_1', 'path/to/file_1', 10),
+        ]);
+
+        $hint = EventHint::fromArray([
+            'exception' => $exception,
+            'stacktrace' => $stacktrace,
+        ]);
+
+        $this->assertEquals($exception, $hint->exception);
+        $this->assertEquals($stacktrace, $hint->stacktrace);
+    }
+
+    public function testThrowsExceptionOnInvalidKeyInArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no EventHint attribute called "missing_property".');
+
+        EventHint::fromArray([
+            'missing_property' => 'some value',
+        ]);
+    }
+
+    public function testThrowsExceptionOnInvalidKeyInArrayWhenValidKeyIsPresent(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no EventHint attribute called "missing_property".');
+
+        EventHint::fromArray([
+            'exception' => new \Exception(),
+            'missing_property' => 'some value',
+        ]);
+    }
+}

--- a/tests/EventHintTest.php
+++ b/tests/EventHintTest.php
@@ -6,7 +6,6 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\EventHint;
-use Sentry\Exception\InvalidArgumentException;
 use Sentry\Frame;
 use Sentry\Stacktrace;
 
@@ -30,7 +29,7 @@ final class EventHintTest extends TestCase
 
     public function testThrowsExceptionOnInvalidKeyInArray(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('There is no EventHint attribute called "missing_property".');
 
         EventHint::fromArray([
@@ -40,7 +39,7 @@ final class EventHintTest extends TestCase
 
     public function testThrowsExceptionOnInvalidKeyInArrayWhenValidKeyIsPresent(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('There is no EventHint attribute called "missing_property".');
 
         EventHint::fromArray([

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -69,14 +69,12 @@ final class FunctionsTest extends TestCase
     {
         $event = Event::createEvent($eventId = EventId::generate());
 
-        $event->setMessage('foo');
-
         /** @var ClientInterface|MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
-               ->method('captureEvent')
-               ->with($event)
-               ->willReturn($eventId);
+            ->method('captureEvent')
+            ->with($event)
+            ->willReturn($eventId);
 
         SentrySdk::getCurrentHub()->bindClient($client);
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -67,18 +67,20 @@ final class FunctionsTest extends TestCase
 
     public function testCaptureEvent(): void
     {
-        $eventId = EventId::generate();
+        $event = Event::createEvent($eventId = EventId::generate());
+
+        $event->setMessage('foo');
 
         /** @var ClientInterface|MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
-            ->method('captureEvent')
-            ->with(['message' => 'foo'])
-            ->willReturn($eventId);
+               ->method('captureEvent')
+               ->with($event)
+               ->willReturn($eventId);
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $this->assertSame($eventId, captureEvent(['message' => 'foo']));
+        $this->assertSame($eventId, captureEvent($event));
     }
 
     public function testCaptureLastError()

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -67,18 +67,18 @@ final class FunctionsTest extends TestCase
 
     public function testCaptureEvent(): void
     {
-        $event = Event::createEvent($eventId = EventId::generate());
+        $event = Event::createEvent();
 
         /** @var ClientInterface|MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureEvent')
             ->with($event)
-            ->willReturn($eventId);
+            ->willReturn($event->getId());
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        $this->assertSame($eventId, captureEvent($event));
+        $this->assertSame($event->getId(), captureEvent($event));
     }
 
     public function testCaptureLastError()

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -114,7 +114,7 @@ final class FunctionsTest extends TestCase
 
         addBreadcrumb($breadcrumb);
         configureScope(function (Scope $scope) use ($breadcrumb): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb], $event->getBreadcrumbs());

--- a/tests/Integration/EnvironmentIntegrationTest.php
+++ b/tests/Integration/EnvironmentIntegrationTest.php
@@ -39,7 +39,7 @@ final class EnvironmentIntegrationTest extends TestCase
             $event->setRuntimeContext($initialRuntimeContext);
             $event->setOsContext($initialOsContext);
 
-            $event = $scope->applyToEvent($event, []);
+            $event = $scope->applyToEvent($event);
 
             $this->assertNotNull($event);
 

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -67,7 +67,7 @@ final class FrameContextifierIntegrationTest extends TestCase
         $event->setStacktrace($stacktrace);
 
         withScope(static function (Scope $scope) use (&$event): void {
-            $event = $scope->applyToEvent($event, []);
+            $event = $scope->applyToEvent($event);
         });
 
         $this->assertNotNull($event);
@@ -161,7 +161,7 @@ final class FrameContextifierIntegrationTest extends TestCase
         $event->setStacktrace($stacktrace);
 
         withScope(static function (Scope $scope) use (&$event): void {
-            $event = $scope->applyToEvent($event, []);
+            $event = $scope->applyToEvent($event);
         });
 
         $this->assertNotNull($event);

--- a/tests/Integration/IgnoreErrorsIntegrationTest.php
+++ b/tests/Integration/IgnoreErrorsIntegrationTest.php
@@ -33,7 +33,7 @@ final class IgnoreErrorsIntegrationTest extends TestCase
         SentrySdk::getCurrentHub()->bindClient($client);
 
         withScope(function (Scope $scope) use ($event, $expectedEventToBeDropped): void {
-            $event = $scope->applyToEvent($event, []);
+            $event = $scope->applyToEvent($event);
 
             if ($expectedEventToBeDropped) {
                 $this->assertNull($event);

--- a/tests/Integration/ModulesIntegrationTest.php
+++ b/tests/Integration/ModulesIntegrationTest.php
@@ -32,7 +32,7 @@ final class ModulesIntegrationTest extends TestCase
         SentrySdk::getCurrentHub()->bindClient($client);
 
         withScope(function (Scope $scope) use ($expectedEmptyModules): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -47,7 +47,7 @@ final class RequestIntegrationTest extends TestCase
         SentrySdk::getCurrentHub()->bindClient($client);
 
         withScope(function (Scope $scope) use ($event, $expectedRequestContextData, $initialUser, $expectedUser): void {
-            $event = $scope->applyToEvent($event, []);
+            $event = $scope->applyToEvent($event);
 
             $this->assertNotNull($event);
             $this->assertSame($expectedRequestContextData, $event->getRequest());

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -54,15 +54,12 @@ final class TransactionIntegrationTest extends TestCase
             null,
         ];
 
-        $event = Event::createEvent();
-        $event->setTransaction('/foo/bar');
-
         yield [
-            $event,
-            true,
+            Event::createEvent(),
+            false,
             null,
             [],
-            '/foo/bar',
+            null,
         ];
 
         yield [
@@ -101,7 +98,7 @@ final class TransactionIntegrationTest extends TestCase
 
         yield [
             $event,
-            true,
+            false,
             null,
             [],
             '/foo/bar',
@@ -109,9 +106,25 @@ final class TransactionIntegrationTest extends TestCase
 
         yield [
             Event::createEvent(),
+            true,
+            EventHint::fromArray([
+                'extra' => [
+                    'transaction' => '/some/other',
+                ],
+            ]),
+            ['PATH_INFO' => '/foo/bar'],
+            '/some/other',
+        ];
+
+        yield [
+            Event::createEvent(),
             false,
-            null,
-            [],
+            EventHint::fromArray([
+                'extra' => [
+                    'transaction' => '/some/other',
+                ],
+            ]),
+            ['PATH_INFO' => '/foo/bar'],
             null,
         ];
     }

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\Integration\TransactionIntegration;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
@@ -20,7 +21,7 @@ final class TransactionIntegrationTest extends TestCase
      *
      * @backupGlobals
      */
-    public function testSetupOnce(Event $event, bool $isIntegrationEnabled, array $serverGlobals, ?string $expectedTransaction): void
+    public function testSetupOnce(Event $event, bool $isIntegrationEnabled, ?EventHint $hint, array $serverGlobals, ?string $expectedTransaction): void
     {
         $_SERVER = array_merge($_SERVER, $serverGlobals);
 
@@ -35,8 +36,8 @@ final class TransactionIntegrationTest extends TestCase
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        withScope(function (Scope $scope) use ($event, $expectedTransaction): void {
-            $event = $scope->applyToEvent($event);
+        withScope(function (Scope $scope) use ($event, $hint, $expectedTransaction): void {
+            $event = $scope->applyToEvent($event, $hint);
 
             $this->assertNotNull($event);
             $this->assertSame($event->getTransaction(), $expectedTransaction);
@@ -48,6 +49,7 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             Event::createEvent(),
             true,
+            null,
             [],
             null,
         ];
@@ -58,6 +60,7 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             $event,
             true,
+            null,
             [],
             '/foo/bar',
         ];
@@ -65,16 +68,19 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             Event::createEvent(),
             true,
+            null,
             ['PATH_INFO' => '/foo/bar'],
             '/foo/bar',
         ];
 
-        $event = Event::createEvent();
-        $event->setTransaction('/foo/bar');
-
         yield [
-            $event,
+            Event::createEvent(),
             true,
+            EventHint::fromArray([
+                'extra' => [
+                    'transaction' => '/foo/bar',
+                ],
+            ]),
             [],
             '/foo/bar',
         ];
@@ -85,6 +91,18 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             $event,
             true,
+            null,
+            [],
+            '/foo/bar',
+        ];
+
+        $event = Event::createEvent();
+        $event->setTransaction('/foo/bar');
+
+        yield [
+            $event,
+            true,
+            null,
             [],
             '/foo/bar',
         ];
@@ -92,6 +110,7 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             Event::createEvent(),
             false,
+            null,
             [],
             null,
         ];

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -20,7 +20,7 @@ final class TransactionIntegrationTest extends TestCase
      *
      * @backupGlobals
      */
-    public function testSetupOnce(Event $event, bool $isIntegrationEnabled, array $payload, array $serverGlobals, ?string $expectedTransaction): void
+    public function testSetupOnce(Event $event, bool $isIntegrationEnabled, array $serverGlobals, ?string $expectedTransaction): void
     {
         $_SERVER = array_merge($_SERVER, $serverGlobals);
 
@@ -35,8 +35,8 @@ final class TransactionIntegrationTest extends TestCase
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        withScope(function (Scope $scope) use ($event, $payload, $expectedTransaction): void {
-            $event = $scope->applyToEvent($event, $payload);
+        withScope(function (Scope $scope) use ($event, $expectedTransaction): void {
+            $event = $scope->applyToEvent($event);
 
             $this->assertNotNull($event);
             $this->assertSame($event->getTransaction(), $expectedTransaction);
@@ -49,14 +49,18 @@ final class TransactionIntegrationTest extends TestCase
             Event::createEvent(),
             true,
             [],
-            [],
             null,
         ];
 
         yield [
-            Event::createEvent(),
+            (static function () {
+                $event = Event::createEvent();
+
+                $event->setTransaction('/foo/bar');
+
+                return $event;
+            })(),
             true,
-            ['transaction' => '/foo/bar'],
             [],
             '/foo/bar',
         ];
@@ -64,7 +68,6 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             Event::createEvent(),
             true,
-            [],
             ['PATH_INFO' => '/foo/bar'],
             '/foo/bar',
         ];
@@ -76,7 +79,6 @@ final class TransactionIntegrationTest extends TestCase
             $event,
             true,
             [],
-            [],
             '/foo/bar',
         ];
 
@@ -86,7 +88,6 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             $event,
             true,
-            ['/foo/bar/baz'],
             [],
             '/foo/bar',
         ];
@@ -94,7 +95,6 @@ final class TransactionIntegrationTest extends TestCase
         yield [
             Event::createEvent(),
             false,
-            ['transaction' => '/foo/bar'],
             [],
             null,
         ];

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -52,14 +52,11 @@ final class TransactionIntegrationTest extends TestCase
             null,
         ];
 
+        $event = Event::createEvent();
+        $event->setTransaction('/foo/bar');
+
         yield [
-            (static function () {
-                $event = Event::createEvent();
-
-                $event->setTransaction('/foo/bar');
-
-                return $event;
-            })(),
+            $event,
             true,
             [],
             '/foo/bar',

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -32,11 +32,7 @@ final class HandlerTest extends TestCase
                 $this->assertEquals($expectedEvent->getLogger(), $event->getLogger());
 
                 return true;
-            }), $this->callback(function (EventHint $hint) use ($expectedHint): bool {
-                $this->assertEquals($hint, $expectedHint);
-
-                return true;
-            }), $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
+            }), $expectedHint, $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
                 $event = $scopeArg->applyToEvent(Event::createEvent());
 
                 $this->assertNotNull($event);
@@ -51,6 +47,11 @@ final class HandlerTest extends TestCase
 
     public function handleDataProvider(): iterable
     {
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::debug());
+
         yield [
             [
                 'message' => 'foo bar',
@@ -60,21 +61,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::debug());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::DEBUG),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::info());
 
         yield [
             [
@@ -85,21 +83,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::info());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::INFO),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::info());
 
         yield [
             [
@@ -110,21 +105,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::info());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::NOTICE),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::warning());
 
         yield [
             [
@@ -135,21 +127,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::warning());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::WARNING),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::error());
 
         yield [
             [
@@ -160,21 +149,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::error());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::ERROR),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::fatal());
 
         yield [
             [
@@ -185,21 +171,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::fatal());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::CRITICAL),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::fatal());
 
         yield [
             [
@@ -210,21 +193,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::fatal());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::ALERT),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::fatal());
 
         yield [
             [
@@ -235,21 +215,18 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::fatal());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::EMERGENCY),
             ],
         ];
+
+        $event = Event::createEvent();
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::warning());
 
         $exampleException = new \Exception('exception message');
 
@@ -264,15 +241,7 @@ final class HandlerTest extends TestCase
                 'channel' => 'channel.foo',
                 'extra' => [],
             ],
-            (static function (): Event {
-                $event = Event::createEvent();
-
-                $event->setLevel(Severity::warning());
-                $event->setMessage('foo bar');
-                $event->setLogger('monolog.channel.foo');
-
-                return $event;
-            })(),
+            $event,
             EventHint::fromArray([
                 'exception' => $exampleException,
             ]),

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -37,7 +37,7 @@ final class HandlerTest extends TestCase
 
                 return true;
             }), $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
-                $event = $scopeArg->applyToEvent(Event::createEvent(), []);
+                $event = $scopeArg->applyToEvent(Event::createEvent());
 
                 $this->assertNotNull($event);
                 $this->assertSame($expectedExtra, $event->getExtra());

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\Monolog\Handler;
 use Sentry\Severity;
 use Sentry\State\Hub;
@@ -19,13 +20,23 @@ final class HandlerTest extends TestCase
     /**
      * @dataProvider handleDataProvider
      */
-    public function testHandle(array $record, array $expectedPayload, array $expectedExtra): void
+    public function testHandle(array $record, Event $expectedEvent, EventHint $expectedHint, array $expectedExtra): void
     {
         /** @var ClientInterface&MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureEvent')
-            ->with($expectedPayload, $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
+            ->with($this->callback(function (Event $event) use ($expectedEvent): bool {
+                $this->assertEquals($expectedEvent->getLevel(), $event->getLevel());
+                $this->assertEquals($expectedEvent->getMessage(), $event->getMessage());
+                $this->assertEquals($expectedEvent->getLogger(), $event->getLogger());
+
+                return true;
+            }), $this->callback(function (EventHint $hint) use ($expectedHint): bool {
+                $this->assertEquals($hint, $expectedHint);
+
+                return true;
+            }), $this->callback(function (Scope $scopeArg) use ($expectedExtra): bool {
                 $event = $scopeArg->applyToEvent(Event::createEvent(), []);
 
                 $this->assertNotNull($event);
@@ -49,11 +60,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::debug(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::debug());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::DEBUG),
@@ -69,11 +85,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::info(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::info());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::INFO),
@@ -89,11 +110,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::info(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::info());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::NOTICE),
@@ -109,11 +135,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::warning(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::warning());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::WARNING),
@@ -129,11 +160,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::error(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::error());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::ERROR),
@@ -149,11 +185,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::fatal(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::fatal());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::CRITICAL),
@@ -169,11 +210,16 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::fatal(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::fatal());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::ALERT),
@@ -189,16 +235,23 @@ final class HandlerTest extends TestCase
                 'context' => [],
                 'extra' => [],
             ],
-            [
-                'level' => Severity::fatal(),
-                'message' => 'foo bar',
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::fatal());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            new EventHint(),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::EMERGENCY),
             ],
         ];
+
+        $exampleException = new \Exception('exception message');
 
         yield [
             [
@@ -206,17 +259,23 @@ final class HandlerTest extends TestCase
                 'level' => Logger::WARNING,
                 'level_name' => Logger::getLevelName(Logger::WARNING),
                 'context' => [
-                    'exception' => new \Exception('exception message'),
+                    'exception' => $exampleException,
                 ],
                 'channel' => 'channel.foo',
                 'extra' => [],
             ],
-            [
-                'level' => Severity::warning(),
-                'message' => 'foo bar',
-                'exception' => new \Exception('exception message'),
-                'logger' => 'monolog.channel.foo',
-            ],
+            (static function (): Event {
+                $event = Event::createEvent();
+
+                $event->setLevel(Severity::warning());
+                $event->setMessage('foo bar');
+                $event->setLogger('monolog.channel.foo');
+
+                return $event;
+            })(),
+            EventHint::fromArray([
+                'exception' => $exampleException,
+            ]),
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::WARNING),

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -292,7 +292,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb($breadcrumb);
         $hub->configureScope(function (Scope $scope): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertEmpty($event->getBreadcrumbs());
@@ -301,7 +301,7 @@ final class HubTest extends TestCase
         $hub->bindClient($client);
         $hub->addBreadcrumb($breadcrumb);
         $hub->configureScope(function (Scope $scope) use (&$callbackInvoked, $breadcrumb): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb], $event->getBreadcrumbs());
@@ -324,7 +324,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $hub->configureScope(function (Scope $scope): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertEmpty($event->getBreadcrumbs());
@@ -348,7 +348,7 @@ final class HubTest extends TestCase
         $hub->addBreadcrumb($breadcrumb2);
 
         $hub->configureScope(function (Scope $scope) use ($breadcrumb1, $breadcrumb2): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb1, $breadcrumb2], $event->getBreadcrumbs());
@@ -357,7 +357,7 @@ final class HubTest extends TestCase
         $hub->addBreadcrumb($breadcrumb3);
 
         $hub->configureScope(function (Scope $scope) use ($breadcrumb2, $breadcrumb3): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb2, $breadcrumb3], $event->getBreadcrumbs());
@@ -380,7 +380,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $hub->configureScope(function (Scope $scope): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertEmpty($event->getBreadcrumbs());
@@ -407,7 +407,7 @@ final class HubTest extends TestCase
 
         $hub->addBreadcrumb($breadcrumb1);
         $hub->configureScope(function (Scope $scope) use (&$callbackInvoked, $breadcrumb2): void {
-            $event = $scope->applyToEvent(Event::createEvent(), []);
+            $event = $scope->applyToEvent(Event::createEvent());
 
             $this->assertNotNull($event);
             $this->assertSame([$breadcrumb2], $event->getBreadcrumbs());

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -271,7 +271,7 @@ final class HubTest extends TestCase
 
         $hub = new Hub();
 
-        $this->assertNull($hub->captureEvent(Event::createEvent()));
+        $this->assertNull($hub->captureEvent($event));
 
         $hub->bindClient($client);
 

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -258,22 +258,24 @@ final class HubTest extends TestCase
 
     public function testCaptureEvent(): void
     {
-        $eventId = EventId::generate();
+        $event = Event::createEvent($eventId = EventId::generate());
+
+        $event->setMessage('test');
 
         /** @var ClientInterface&MockObject $client */
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
             ->method('captureEvent')
-            ->with(['message' => 'test'])
+            ->with($event)
             ->willReturn($eventId);
 
         $hub = new Hub();
 
-        $this->assertNull($hub->captureEvent([]));
+        $this->assertNull($hub->captureEvent(Event::createEvent()));
 
         $hub->bindClient($client);
 
-        $this->assertSame($eventId, $hub->captureEvent(['message' => 'test']));
+        $this->assertSame($eventId, $hub->captureEvent($event));
     }
 
     public function testAddBreadcrumb(): void

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -7,6 +7,7 @@ namespace Sentry\Tests\State;
 use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\Severity;
 use Sentry\State\Scope;
 use Sentry\UserDataBag;
@@ -277,6 +278,27 @@ final class ScopeTest extends TestCase
         $this->assertNull($scope->applyToEvent($event));
         $this->assertTrue($callback2Called);
         $this->assertFalse($callback3Called);
+    }
+
+    public function testEventProcessorRecievesTheEventAndEventHint(): void
+    {
+        $event = Event::createEvent();
+        $scope = new Scope();
+        $hint = new EventHint();
+
+        $processorCalled = false;
+        $processorReceivedHint = null;
+
+        $scope->addEventProcessor(function (Event $eventArg, EventHint $hint) use (&$processorCalled, &$processorReceivedHint): ?Event {
+            $processorCalled = true;
+            $processorReceivedHint = $hint;
+
+            return $eventArg;
+        });
+
+        $this->assertSame($event, $scope->applyToEvent($event, $hint));
+        $this->assertSame($hint, $processorReceivedHint);
+        $this->assertTrue($processorCalled);
     }
 
     public function testClear(): void

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -16,7 +16,7 @@ final class ScopeTest extends TestCase
     public function testSetTag(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getTags());
@@ -24,7 +24,7 @@ final class ScopeTest extends TestCase
         $scope->setTag('foo', 'bar');
         $scope->setTag('bar', 'baz');
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTags());
@@ -35,14 +35,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setTags(['foo' => 'bar']);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar'], $event->getTags());
 
         $scope->setTags(['bar' => 'baz']);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTags());
@@ -53,14 +53,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setContext('foo', ['foo' => 'bar']);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => ['foo' => 'bar']], $event->getContexts());
 
         $scope->removeContext('foo');
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame([], $event->getContexts());
@@ -69,7 +69,7 @@ final class ScopeTest extends TestCase
     public function testSetExtra(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getExtra());
@@ -77,7 +77,7 @@ final class ScopeTest extends TestCase
         $scope->setExtra('foo', 'bar');
         $scope->setExtra('bar', 'baz');
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtra());
@@ -88,14 +88,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setExtras(['foo' => 'bar']);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar'], $event->getExtra());
 
         $scope->setExtras(['bar' => 'baz']);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtra());
@@ -104,7 +104,7 @@ final class ScopeTest extends TestCase
     public function testSetUser(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertNull($event->getUser());
@@ -114,7 +114,7 @@ final class ScopeTest extends TestCase
 
         $scope->setUser($user);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame($user, $event->getUser());
@@ -125,7 +125,7 @@ final class ScopeTest extends TestCase
 
         $scope->setUser(['ip_address' => '127.0.0.1', 'subscription_expires_at' => '2020-08-26']);
 
-        $event = $scope->applyToEvent($event, []);
+        $event = $scope->applyToEvent($event);
 
         $this->assertNotNull($event);
         $this->assertEquals($user, $event->getUser());
@@ -145,14 +145,14 @@ final class ScopeTest extends TestCase
         $scope = new Scope();
         $scope->setUser(UserDataBag::createFromUserIdentifier('unique_id'));
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertNotNull($event->getUser());
 
         $scope->removeUser();
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertNull($event->getUser());
@@ -161,14 +161,14 @@ final class ScopeTest extends TestCase
     public function testSetFingerprint(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getFingerprint());
 
         $scope->setFingerprint(['foo', 'bar']);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame(['foo', 'bar'], $event->getFingerprint());
@@ -177,14 +177,14 @@ final class ScopeTest extends TestCase
     public function testSetLevel(): void
     {
         $scope = new Scope();
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertNull($event->getLevel());
 
         $scope->setLevel(Severity::debug());
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertEquals(Severity::debug(), $event->getLevel());
@@ -197,7 +197,7 @@ final class ScopeTest extends TestCase
         $breadcrumb2 = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
         $breadcrumb3 = new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting');
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getBreadcrumbs());
@@ -205,14 +205,14 @@ final class ScopeTest extends TestCase
         $scope->addBreadcrumb($breadcrumb1);
         $scope->addBreadcrumb($breadcrumb2);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame([$breadcrumb1, $breadcrumb2], $event->getBreadcrumbs());
 
         $scope->addBreadcrumb($breadcrumb3, 2);
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertSame([$breadcrumb2, $breadcrumb3], $event->getBreadcrumbs());
@@ -225,14 +225,14 @@ final class ScopeTest extends TestCase
         $scope->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
         $scope->addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_ERROR, Breadcrumb::TYPE_ERROR, 'error_reporting'));
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertNotEmpty($event->getBreadcrumbs());
 
         $scope->clearBreadcrumbs();
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertEmpty($event->getBreadcrumbs());
@@ -256,7 +256,7 @@ final class ScopeTest extends TestCase
             return $eventArg;
         });
 
-        $this->assertSame($event, $scope->applyToEvent($event, []));
+        $this->assertSame($event, $scope->applyToEvent($event));
         $this->assertTrue($callback1Called);
 
         $scope->addEventProcessor(function () use ($callback1Called, &$callback2Called, $callback3Called) {
@@ -274,7 +274,7 @@ final class ScopeTest extends TestCase
             return null;
         });
 
-        $this->assertNull($scope->applyToEvent($event, []));
+        $this->assertNull($scope->applyToEvent($event));
         $this->assertTrue($callback2Called);
         $this->assertFalse($callback3Called);
     }
@@ -292,7 +292,7 @@ final class ScopeTest extends TestCase
         $scope->setUser(UserDataBag::createFromUserIdentifier('unique_id'));
         $scope->clear();
 
-        $event = $scope->applyToEvent(Event::createEvent(), []);
+        $event = $scope->applyToEvent(Event::createEvent());
 
         $this->assertNotNull($event);
         $this->assertNull($event->getLevel());
@@ -321,7 +321,7 @@ final class ScopeTest extends TestCase
         $scope->setContext('foocontext', ['foo' => 'bar']);
         $scope->setContext('barcontext', ['bar' => 'foo']);
 
-        $this->assertSame($event, $scope->applyToEvent($event, []));
+        $this->assertSame($event, $scope->applyToEvent($event));
         $this->assertTrue($event->getLevel()->isEqualTo(Severity::warning()));
         $this->assertSame(['foo'], $event->getFingerprint());
         $this->assertSame([$breadcrumb], $event->getBreadcrumbs());

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -280,7 +280,7 @@ final class ScopeTest extends TestCase
         $this->assertFalse($callback3Called);
     }
 
-    public function testEventProcessorRecievesTheEventAndEventHint(): void
+    public function testEventProcessorReceivesTheEventAndEventHint(): void
     {
         $event = Event::createEvent();
         $scope = new Scope();


### PR DESCRIPTION
The EventHint class was introduced to pass around extra data needed to correctly hydrate an event, this method of "hinting" was copied from the JavaScript SDK.

Chosen for a dedicated class to have type safety built-in instead of having an array and adding type checks and isset everywhere, this looks cleaner internally. To make it easier to use I've added a simple `fromArray` static method to have "the best of both worlds" I think, if users need it they can use the `extra` property on the hint to add arbitrary data.