### PR TITLE
fix: span vs transaction guzzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Use Span on Scope instead of Transaction for GuzzleMiddleware (#1099)
+
 ## 3.0.0 (2020-09-28)
 
 **Tracing API**

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -18,20 +18,20 @@ final class GuzzleTracingMiddleware
         return function (callable $handler) use ($hub): \Closure {
             return function (RequestInterface $request, array $options) use ($hub, $handler) {
                 $hub = $hub ?? SentrySdk::getCurrentHub();
-                $transaction = $hub->getTransaction();
-                $span = null;
+                $span = $hub->getSpan();
+                $childSpan = null;
 
-                if (null !== $transaction) {
+                if (null !== $span) {
                     $spanContext = new SpanContext();
                     $spanContext->setOp('http.guzzle');
                     $spanContext->setDescription($request->getMethod() . ' ' . $request->getUri());
 
-                    $span = $transaction->startChild($spanContext);
+                    $childSpan = $span->startChild($spanContext);
                 }
 
-                $handlerPromiseCallback = static function ($responseOrException) use ($span) {
-                    if (null !== $span) {
-                        $span->finish();
+                $handlerPromiseCallback = static function ($responseOrException) use ($childSpan) {
+                    if (null !== $childSpan) {
+                        $childSpan->finish();
                     }
 
                     if ($responseOrException instanceof \Throwable) {


### PR DESCRIPTION
Counterpart to:

https://github.com/getsentry/sentry-laravel/pull/387#pullrequestreview-498279501

This makes it that the Guzzle Spans will be added to the span on the scope vs. always the transaction.
It makes a nicer tree view.

Before: 
![image](https://user-images.githubusercontent.com/363802/94543296-27976200-024a-11eb-9e5f-c1b4adc743c7.png)

After:
![image](https://user-images.githubusercontent.com/363802/94543318-341bba80-024a-11eb-8514-1129463df473.png)
