### PR TITLE
Add setter for value on ExceptionDataBag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: Use Span on Scope instead of Transaction for GuzzleMiddleware (#1099)
+- Add setter for value on the `ExceptionDataBag` (#1100)
 
 ## 3.0.0 (2020-09-28)
 

--- a/src/ExceptionDataBag.php
+++ b/src/ExceptionDataBag.php
@@ -59,6 +59,14 @@ final class ExceptionDataBag
     }
 
     /**
+     * Sets the value of the exception.
+     */
+    public function setValue(string $value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
      * Gets the stack trace object corresponding to the Stack Trace Interface.
      */
     public function getStacktrace(): ?Stacktrace


### PR DESCRIPTION
This allows the user to modify the Exception message at a later stage. This could for example be useful to update an exception message in the `beforeSend` callback (to filter out data or cleanup a message which contains file paths).

No tests because the class in it's whole is not tested and just a DTO it looks like.