### PR TITLE
Fix FrameContextifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix stacktrace frames were not contextified (#1104)
+
 ## 3.0.2 (2020-10-02)
 
 - fix: Use the traces sample rate for traces instead of the event sample rate (#1106)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix stacktrace frames were not contextified (#1104)
+- Fix missing source code excerpts for stacktrace frames whose absolute file path is equal to the file path (#1104)
 
 ## 3.0.2 (2020-10-02)
 

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -84,7 +84,7 @@ final class FrameBuilder
             $strippedFilePath,
             $line,
             $rawFunctionName,
-            Frame::INTERNAL_FRAME_FILENAME !== $file && $strippedFilePath !== $file ? $file : null,
+            Frame::INTERNAL_FRAME_FILENAME !== $file ? $file : null,
             $this->getFunctionArguments($backtraceFrame),
             $this->isFrameInApp($file, $functionName)
         );

--- a/src/StacktraceBuilder.php
+++ b/src/StacktraceBuilder.php
@@ -70,7 +70,7 @@ final class StacktraceBuilder
         }
 
         // Add a final stackframe for the first method ever of this stacktrace
-        array_unshift($frames, new Frame(null, $file, $line));
+        array_unshift($frames, $this->frameBuilder->buildFromBacktraceFrame($file, $line, []));
 
         return new Stacktrace($frames);
     }

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -36,7 +36,7 @@ final class FrameBuilderTest extends TestCase
                 'line' => 20,
                 'function' => 'test_function',
             ],
-            new Frame('test_function', '/path/to/file', 10),
+            new Frame('test_function', '/path/to/file', 10, null, '/path/to/file'),
         ];
 
         yield [
@@ -46,7 +46,7 @@ final class FrameBuilderTest extends TestCase
                 'line' => 20,
                 'function' => 'test_function',
             ],
-            new Frame('test_function', '/path/to/file', 10),
+            new Frame('test_function', '/path/to/file', 10, null, '/path/to/file'),
         ];
 
         yield [
@@ -57,7 +57,7 @@ final class FrameBuilderTest extends TestCase
                 'function' => 'test_function',
                 'class' => 'TestClass',
             ],
-            new Frame('TestClass::test_function', '/path/to/file', 10, 'TestClass::test_function'),
+            new Frame('TestClass::test_function', '/path/to/file', 10, 'TestClass::test_function', '/path/to/file'),
         ];
 
         yield [
@@ -67,7 +67,7 @@ final class FrameBuilderTest extends TestCase
                 'line' => 10,
                 'function' => 'test_function',
             ],
-            new Frame('test_function', '/path/to/file', 10),
+            new Frame('test_function', '/path/to/file', 10, null, '/path/to/file'),
         ];
 
         yield [
@@ -78,7 +78,7 @@ final class FrameBuilderTest extends TestCase
                 'function' => 'test_function',
                 'class' => "class@anonymous\0/path/to/file",
             ],
-            new Frame("class@anonymous\0/path/to/file::test_function", '/path/to/file', 10, "class@anonymous\0/path/to/file::test_function"),
+            new Frame("class@anonymous\0/path/to/file::test_function", '/path/to/file', 10, "class@anonymous\0/path/to/file::test_function", '/path/to/file'),
         ];
 
         yield [
@@ -133,7 +133,7 @@ final class FrameBuilderTest extends TestCase
                 'file' => 'path/not/of/app/path/to/file',
                 'line' => 10,
             ],
-            new Frame(null, 'path/not/of/app/path/to/file', 10, null),
+            new Frame(null, 'path/not/of/app/path/to/file', 10, null, 'path/not/of/app/path/to/file'),
         ];
 
         yield [
@@ -147,7 +147,7 @@ final class FrameBuilderTest extends TestCase
                 'file' => 'path/not/of/app/to/file',
                 'line' => 10,
             ],
-            new Frame(null, 'path/not/of/app/to/file', 10, null),
+            new Frame(null, 'path/not/of/app/to/file', 10, null, 'path/not/of/app/to/file'),
         ];
     }
 

--- a/tests/StacktraceBuilderTest.php
+++ b/tests/StacktraceBuilderTest.php
@@ -38,10 +38,12 @@ final class StacktraceBuilderTest extends TestCase
 
         $this->assertNull($frames[0]->getFunctionName());
         $this->assertSame('/in/jXVmi', $frames[0]->getFile());
+        $this->assertSame('/in/jXVmi', $frames[0]->getAbsoluteFilePath());
         $this->assertSame(5, $frames[0]->getLine());
 
         $this->assertSame('{closure}', $frames[1]->getFunctionName());
         $this->assertSame('/in/jXVmi', $frames[1]->getFile());
+        $this->assertSame('/in/jXVmi', $frames[1]->getAbsoluteFilePath());
         $this->assertSame(9, $frames[1]->getLine());
 
         $this->assertSame('main', $frames[2]->getFunctionName());


### PR DESCRIPTION
This PR fixes #1103 when `$file` is same as absolute path.