### PR TITLE
Fix criteria for valid user data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fix missing source code excerpts for stacktrace frames whose absolute file path is equal to the file path (#1104)
-- Fix criteria for valid user data (#1108)
+- Fix requirements to construct a valid object instance of the `UserDataBag` class (#1108)
 
 ## 3.0.2 (2020-10-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix criteria for valid user data (#1108)
+
 ## 3.0.2 (2020-10-02)
 
 - fix: Use the traces sample rate for traces instead of the event sample rate (#1106)

--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -34,8 +34,17 @@ final class UserDataBag
      */
     private $metadata = [];
 
-    private function __construct()
+    /**
+     * UserDataBag constructor.
+     *
+     * @param string|int|null $id
+     */
+    public function __construct($id = null, ?string $email = null, ?string $ipAddress = null, ?string $username = null)
     {
+        $this->setId($id);
+        $this->setEmail($email);
+        $this->setIpAddress($ipAddress);
+        $this->setUsername($username);
     }
 
     /**
@@ -45,10 +54,7 @@ final class UserDataBag
      */
     public static function createFromUserIdentifier($id): self
     {
-        $instance = new self();
-        $instance->setId($id);
-
-        return $instance;
+        return new self($id);
     }
 
     /**
@@ -58,10 +64,7 @@ final class UserDataBag
      */
     public static function createFromUserIpAddress(string $ipAddress): self
     {
-        $instance = new self();
-        $instance->setIpAddress($ipAddress);
-
-        return $instance;
+        return new self(null, null, $ipAddress);
     }
 
     /**
@@ -71,10 +74,6 @@ final class UserDataBag
      */
     public static function createFromArray(array $data): self
     {
-        if (!isset($data['id']) && !isset($data['username']) && !isset($data['email']) && !isset($data['ip_address'])) {
-            throw new \InvalidArgumentException('One of the following fields must be set: "id", "username", "email" or "ip_address".');
-        }
-
         $instance = new self();
 
         foreach ($data as $field => $value) {
@@ -117,11 +116,7 @@ final class UserDataBag
      */
     public function setId($id): void
     {
-        if (null === $id && null === $this->ipAddress) {
-            throw new \BadMethodCallException('Either the IP address or the ID must be set.');
-        }
-
-        if (!\is_string($id) && !\is_int($id)) {
+        if (null !== $id && !\is_string($id) && !\is_int($id)) {
             throw new \UnexpectedValueException(sprintf('Expected an integer or string value for the $id argument. Got: "%s".', get_debug_type($id)));
         }
 
@@ -181,10 +176,6 @@ final class UserDataBag
     {
         if (null !== $ipAddress && false === filter_var($ipAddress, FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value is not a valid IP address.', $ipAddress));
-        }
-
-        if (null === $ipAddress && null === $this->id) {
-            throw new \BadMethodCallException('Either the IP address or the ID must be set.');
         }
 
         $this->ipAddress = $ipAddress;

--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -79,16 +79,16 @@ final class UserDataBag
         foreach ($data as $field => $value) {
             switch ($field) {
                 case 'id':
-                    $instance->setId($data['id']);
+                    $instance->setId($value);
                     break;
                 case 'ip_address':
-                    $instance->setIpAddress($data['ip_address']);
+                    $instance->setIpAddress($value);
                     break;
                 case 'email':
-                    $instance->setEmail($data['email']);
+                    $instance->setEmail($value);
                     break;
                 case 'username':
-                    $instance->setUsername($data['username']);
+                    $instance->setUsername($value);
                     break;
                 default:
                     $instance->setMetadata($field, $value);

--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -71,8 +71,8 @@ final class UserDataBag
      */
     public static function createFromArray(array $data): self
     {
-        if (!isset($data['id']) && !isset($data['ip_address'])) {
-            throw new \InvalidArgumentException('Either the "id" or the "ip_address" field must be set.');
+        if (!isset($data['id']) && !isset($data['username']) && !isset($data['email']) && !isset($data['ip_address'])) {
+            throw new \InvalidArgumentException('One of the following fields must be set: "id", "username", "email" or "ip_address".');
         }
 
         $instance = new self();

--- a/tests/UserDataBagTest.php
+++ b/tests/UserDataBagTest.php
@@ -99,6 +99,17 @@ final class UserDataBagTest extends TestCase
     /**
      * @dataProvider unexpectedValueForIdFieldDataProvider
      */
+    public function testConstructorThrowsIfIdValueIsUnexpectedValue($value, string $expectedExceptionMessage): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        new UserDataBag($value);
+    }
+
+    /**
+     * @dataProvider unexpectedValueForIdFieldDataProvider
+     */
     public function testSetIdThrowsIfValueIsUnexpectedValue($value, string $expectedExceptionMessage): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -130,6 +141,14 @@ final class UserDataBagTest extends TestCase
             new \stdClass(),
             'Expected an integer or string value for the $id argument. Got: "stdClass".',
         ];
+    }
+
+    public function testConstructorThrowsIfIpAddressArgumentIsInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "foo" value is not a valid IP address.');
+
+        new UserDataBag(null, null, 'foo');
     }
 
     public function testSetIpAddressThrowsIfArgumentIsInvalid(): void

--- a/tests/UserDataBagTest.php
+++ b/tests/UserDataBagTest.php
@@ -9,25 +9,10 @@ use Sentry\UserDataBag;
 
 final class UserDataBagTest extends TestCase
 {
-    public function testCreateFromUserIdentifierThrowsIfArgumentIsInvalid(): void
-    {
-        $this->expectException(\UnexpectedValueException::class);
-        $this->expectExceptionMessage('Expected an integer or string value for the $id argument. Got: "float".');
-
-        UserDataBag::createFromUserIdentifier(1.1);
-    }
-
-    public function testCreateFromIpAddressThrowsIfArgumentIsInvalid(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The "foo" value is not a valid IP address.');
-
-        UserDataBag::createFromUserIpAddress('foo');
-    }
-
     public function testGettersAndSetters(): void
     {
-        $userDataBag = UserDataBag::createFromUserIdentifier('unique_id');
+        $userDataBag = new UserDataBag();
+        $userDataBag->setId('unique_id');
         $userDataBag->setIpAddress('127.0.0.1');
         $userDataBag->setEmail('foo@example.com');
         $userDataBag->setUsername('my_user');
@@ -84,11 +69,8 @@ final class UserDataBagTest extends TestCase
         ];
 
         yield [
-            [
-                'id' => 'unique_id',
-                'email' => 'foo@example.com',
-            ],
-            'unique_id',
+            ['email' => 'foo@example.com'],
+            null,
             null,
             'foo@example.com',
             null,
@@ -96,11 +78,8 @@ final class UserDataBagTest extends TestCase
         ];
 
         yield [
-            [
-                'id' => 'unique_id',
-                'username' => 'my_user',
-            ],
-            'unique_id',
+            ['username' => 'my_user'],
+            null,
             null,
             null,
             'my_user',
@@ -108,11 +87,8 @@ final class UserDataBagTest extends TestCase
         ];
 
         yield [
-            [
-                'id' => 'unique_id',
-                'subscription' => 'basic',
-            ],
-            'unique_id',
+            ['subscription' => 'basic'],
+            null,
             null,
             null,
             null,
@@ -121,7 +97,7 @@ final class UserDataBagTest extends TestCase
     }
 
     /**
-     * @dataProvider setIdThrowsIfValueIsUnexpectedValueDataProvider
+     * @dataProvider unexpectedValueForIdFieldDataProvider
      */
     public function testSetIdThrowsIfValueIsUnexpectedValue($value, string $expectedExceptionMessage): void
     {
@@ -132,7 +108,18 @@ final class UserDataBagTest extends TestCase
         $userDataBag->setId($value);
     }
 
-    public function setIdThrowsIfValueIsUnexpectedValueDataProvider(): iterable
+    /**
+     * @dataProvider unexpectedValueForIdFieldDataProvider
+     */
+    public function testCreateFromUserIdentifierThrowsIfArgumentIsInvalid($value, string $expectedExceptionMessage): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
+        UserDataBag::createFromUserIdentifier($value);
+    }
+
+    public function unexpectedValueForIdFieldDataProvider(): iterable
     {
         yield [
             12.34,
@@ -152,6 +139,14 @@ final class UserDataBagTest extends TestCase
 
         $userDataBag = new UserDataBag();
         $userDataBag->setIpAddress('foo');
+    }
+
+    public function testCreateFromIpAddressThrowsIfArgumentIsInvalid(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "foo" value is not a valid IP address.');
+
+        UserDataBag::createFromUserIpAddress('foo');
     }
 
     public function testMerge(): void

--- a/tests/UserDataBagTest.php
+++ b/tests/UserDataBagTest.php
@@ -9,7 +9,15 @@ use Sentry\UserDataBag;
 
 final class UserDataBagTest extends TestCase
 {
-    public function testConstructorThrowsIfArgumentIsInvalid(): void
+    public function testCreateFromUserIdentifierThrowsIfArgumentIsInvalid(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Expected an integer or string value for the $id argument. Got: "float".');
+
+        UserDataBag::createFromUserIdentifier(1.1);
+    }
+
+    public function testCreateFromIpAddressThrowsIfArgumentIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" value is not a valid IP address.');
@@ -120,7 +128,8 @@ final class UserDataBagTest extends TestCase
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionMessage($expectedExceptionMessage);
 
-        UserDataBag::createFromUserIdentifier($value);
+        $userDataBag = new UserDataBag();
+        $userDataBag->setId($value);
     }
 
     public function setIdThrowsIfValueIsUnexpectedValueDataProvider(): iterable
@@ -136,30 +145,12 @@ final class UserDataBagTest extends TestCase
         ];
     }
 
-    public function testSetIdThrowsIfBothArgumentAndIpAddressAreNull(): void
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Either the IP address or the ID must be set.');
-
-        $userDataBag = UserDataBag::createFromUserIdentifier('unique_id');
-        $userDataBag->setId(null);
-    }
-
-    public function testSetIpAddressThrowsIfBothArgumentAndIdAreNull(): void
-    {
-        $this->expectException(\BadMethodCallException::class);
-        $this->expectExceptionMessage('Either the IP address or the ID must be set.');
-
-        $userDataBag = UserDataBag::createFromUserIpAddress('127.0.0.1');
-        $userDataBag->setIpAddress(null);
-    }
-
     public function testSetIpAddressThrowsIfArgumentIsInvalid(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('The "foo" value is not a valid IP address.');
 
-        $userDataBag = UserDataBag::createFromUserIpAddress('127.0.0.1');
+        $userDataBag = new UserDataBag();
         $userDataBag->setIpAddress('foo');
     }
 


### PR DESCRIPTION
Fixes #1107 to allow `username` or `email` to identify a user in addition to `id` or `ip_address`.