### PR TITLE
Send stacktrace with events, not just exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix stacktrace missing from payload for non-exception events (#1123)
+
 ## 3.0.3 (2020-10-12)
 
 - Fix missing source code excerpts for stacktrace frames whose absolute file path is equal to the file path (#1104)

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -152,6 +152,12 @@ final class PayloadSerializer implements PayloadSerializerInterface
             $result['spans'] = array_values(array_map([$this, 'serializeSpan'], $event->getSpans()));
         }
 
+        if ($stacktrace = $event->getStacktrace()) {
+            $result['stacktrace'] = [
+                'frames' => array_map([$this, 'serializeStacktraceFrame'], $stacktrace->getFrames()),
+            ];
+        }
+
         return JSON::encode($result);
     }
 

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -152,7 +152,9 @@ final class PayloadSerializer implements PayloadSerializerInterface
             $result['spans'] = array_values(array_map([$this, 'serializeSpan'], $event->getSpans()));
         }
 
-        if ($stacktrace = $event->getStacktrace()) {
+        $stacktrace = $event->getStacktrace();
+
+        if (null !== $stacktrace) {
             $result['stacktrace'] = [
                 'frames' => array_map([$this, 'serializeStacktraceFrame'], $stacktrace->getFrames()),
             ];

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -422,5 +422,34 @@ TEXT
             ,
             false,
         ];
+
+        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setStacktrace(new Stacktrace([new Frame(null, '', 0)]));
+
+        yield [
+            $event,
+            <<<JSON
+{
+    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
+    "timestamp": 1597790835,
+    "platform": "php",
+    "sdk": {
+        "name": "sentry.php",
+        "version": "$sdkVersion"
+    },
+    "stacktrace": {
+        "frames": [
+            {
+                "filename": "",
+                "lineno": 0,
+                "in_app": true
+            }
+        ]
+    }
+}
+JSON
+            ,
+            true,
+        ];
     }
 }


### PR DESCRIPTION
I noticed that if I set a stacktrace on an event, it is not sent to Sentry.  This patch should resolve the issue.