### PR TITLE
Add Scope::removeTag() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add setter for value on the `ExceptionDataBag` (#1100)
+- Add `Scope::removeTag` method (#1126)
 
 ## 3.0.4 (2020-11-6)
 

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -104,6 +104,20 @@ final class Scope
     }
 
     /**
+     * Removes a given tag from the tags context.
+     *
+     * @param string $key The key that uniquely identifies the tag
+     *
+     * @return $this
+     */
+    public function removeTag(string $key): self
+    {
+        unset($this->tags[$key]);
+
+        return $this;
+    }
+
+    /**
      * Sets context data with the given name.
      *
      * @param string               $name  The name that uniquely identifies the context

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -49,6 +49,27 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTags());
     }
 
+    public function testRemoveTag(): void
+    {
+        $scope = new Scope();
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $scope->setTag('foo', 'bar');
+        $scope->setTag('bar', 'baz');
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getTags());
+
+        $scope->removeTag('foo');
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertSame(['bar' => 'baz'], $event->getTags());
+    }
+
     public function testSetAndRemoveContext(): void
     {
         $scope = new Scope();


### PR DESCRIPTION
This was cheap to put together, so feel free to cheaply kill this. But I can't find other way how to remove tag other than clear the whole `Scope`, which is something I don't believe is desired (I don't want to lose default tags + I don't want to lose tags set by myself in higher level of the code).