### PR TITLE
Update the README badges and fix the CI config to run on 2.x branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,11 +4,6 @@ clone_depth: 2
 clone_folder: c:\projects\sentry-php
 skip_branch_with_pr: true
 image: Visual Studio 2019
-branches:
-    only:
-        - master
-        - develop
-        - /^release\/.+$/
 
 environment:
     matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: php
 
-branches:
-    only:
-        - master
-        - develop
-        - /^release\/.+$/
-
 php:
     - 7.1
     - 7.2

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@
 
 | Version | Build Status | Code Coverage |
 |:---------:|:-------------:|:-----:|
-| `master`| [![Build Status][Travis Master Build Status Image]][Travis Build Status] [![Build Status][AppVeyor Master Build Status Image]][AppVeyor Build Status] | [![Coverage Status][Master Code Coverage Image]][Master Code Coverage] |
-| `develop` | [![Build Status][Travis Develop Build Status Image]][Travis Build Status] [![Build Status][AppVeyor Develop Build Status Image]][AppVeyor Build Status] | [![Coverage Status][Develop Code Coverage Image]][Develop Code Coverage] |
+| `2.x`| [![Build Status][Travis 2.x Build Status Image]][Travis Build Status] [![Build Status][AppVeyor 2.x Build Status Image]][AppVeyor Build Status] | [![Coverage Status][2.x Code Coverage Image]][2.x Code Coverage] |
 
 The Sentry PHP error reporter tracks errors and exceptions that happen during the
 execution of your application and provides instant notification with detailed
@@ -117,12 +116,8 @@ $ vendor/bin/phpunit
 ```
 
 [Travis Build Status]: http://travis-ci.org/getsentry/sentry-php
-[Travis Master Build Status Image]: https://img.shields.io/travis/getsentry/sentry-php/master?logo=travis
-[Travis Develop Build Status Image]: https://img.shields.io/travis/getsentry/sentry-php/develop?logo=travis
+[Travis 2.x Build Status Image]: https://img.shields.io/travis/getsentry/sentry-php/2.x?logo=travis
 [AppVeyor Build Status]: https://ci.appveyor.com/project/sentry/sentry-php
-[AppVeyor Master Build Status Image]: https://img.shields.io/appveyor/ci/sentry/sentry-php/master?logo=appveyor
-[AppVeyor Develop Build Status Image]: https://img.shields.io/appveyor/ci/sentry/sentry-php/develop?logo=appveyor
-[Master Code Coverage]: https://codecov.io/gh/getsentry/sentry-php/branch/master
-[Master Code Coverage Image]: https://img.shields.io/codecov/c/github/getsentry/sentry-php/master?logo=codecov
-[Develop Code Coverage]: https://codecov.io/gh/getsentry/sentry-php/branch/develop
-[Develop Code Coverage Image]: https://img.shields.io/codecov/c/github/getsentry/sentry-php/develop?logo=codecov
+[AppVeyor 2.x Build Status Image]: https://img.shields.io/appveyor/ci/sentry/sentry-php/2.x?logo=appveyor
+[2.x Code Coverage]: https://codecov.io/gh/getsentry/sentry-php/branch/2.x
+[2.x Code Coverage Image]: https://img.shields.io/codecov/c/github/getsentry/sentry-php/2.x?logo=codecov

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,9 +16,6 @@ parameters:
             message: '/^Call to static method create\(\) on an unknown class Symfony\\Component\\HttpClient\\HttpClient\.$/'
             path: src/HttpClient/HttpClientFactory.php
         -
-            message: '/^Parameter #1 \$c of function ctype_digit expects int\|string, string\|null given\.$/'
-            path: src/Dsn.php
-        -
             message: "/^Offset 'scheme' does not exist on array\\(\\?'scheme' => string, \\?'host' => string, \\?'port' => int, \\?'user' => string, \\?'pass' => string, \\?'path' => string, \\?'query' => string, \\?'fragment' => string\\)\\.$/"
             path: src/Dsn.php
         -


### PR DESCRIPTION
As per title, I noticed that the badges in the README file were not showing the data for the `2.x` version and more importantly the CI was not enabled for the target branch. With this PR I'm aligning the AppVeyor and Travis CI configuration with the one present in `master`