### PR TITLE
Fix capturing of the request body in the RequestIntegration integration when the stream is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix capturing of the request body in the `RequestIntegration` integration when the stream is empty (#1129)
+
 ### 2.5.0 (2020-09-14)
 
 - Support the `timeout` and `proxy` options for the Symfony HTTP Client (#1084)

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -188,7 +188,7 @@ final class RequestIntegration implements IntegrationInterface
         $requestBodySize = $requestBody->getSize();
 
         if (
-            null === $requestBodySize ||
+            !$requestBodySize ||
             'none' === $maxRequestBodySize ||
             ('small' === $maxRequestBodySize && $requestBodySize > self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH) ||
             ('medium' === $maxRequestBodySize && $requestBodySize > self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH)

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -318,7 +318,8 @@ final class RequestIntegrationTest extends TestCase
             (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
                 ->withUploadedFiles([
                     'foo' => new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
-                ]),
+                ])
+                ->withBody($this->getStreamMock(123 + 321)),
             [
                 'url' => 'http://www.example.com/foo',
                 'method' => 'POST',
@@ -345,7 +346,8 @@ final class RequestIntegrationTest extends TestCase
                         new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
                         new UploadedFile('bar content', 321, UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
                     ],
-                ]),
+                ])
+                ->withBody($this->getStreamMock(123 + 321)),
             [
                 'url' => 'http://www.example.com/foo',
                 'method' => 'POST',
@@ -381,7 +383,8 @@ final class RequestIntegrationTest extends TestCase
                             new UploadedFile('bar content', 321, UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
                         ],
                     ],
-                ]),
+                ])
+                ->withBody($this->getStreamMock(123 + 321)),
             [
                 'url' => 'http://www.example.com/foo',
                 'method' => 'POST',
@@ -460,6 +463,25 @@ final class RequestIntegrationTest extends TestCase
                     'Content-Type' => ['application/json'],
                 ],
             ],
+        ];
+
+        yield [
+            [
+                'max_request_body_size' => 'always',
+            ],
+            (new ServerRequest('POST', new Uri('http://www.example.com/foo')))
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->getStreamMock(0)),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Content-Type' => ['application/json'],
+                ],
+            ],
+            null,
+            null,
         ];
     }
 


### PR DESCRIPTION
This is a simple backport of the fix made by @Bziks in #1119 that fixes #1118. I tried reusing the PR he prepared for the `2.x` branch, however after an attempt of rebasing it GitHub closed the issue and I cannot open it anymore :angry: