### PR TITLE
Allow passing the event hint to the captureException method and pass it down to the before_send callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Deprecate the `logger` option (#1167)
+- Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
 
 ## 3.1.2 (2021-01-08)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
+			count: 3
+			path: src/ClientInterface.php
+
+		-
 			message: "#^Offset 'scheme' does not exist on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\.$#"
 			count: 1
 			path: src/Dsn.php
@@ -61,14 +66,54 @@ parameters:
 			path: src/Serializer/AbstractSerializer.php
 
 		-
+			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureMessage\\(\\) invoked with 4 parameters, 1\\-3 required\\.$#"
+			count: 1
+			path: src/State/Hub.php
+
+		-
+			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureException\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/State/Hub.php
+
+		-
+			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureLastError\\(\\) invoked with 2 parameters, 0\\-1 required\\.$#"
+			count: 1
+			path: src/State/Hub.php
+
+		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:startTransaction\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
 			path: src/State/HubAdapter.php
 
 		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
+			count: 3
+			path: src/State/HubInterface.php
+
+		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$customSamplingContext$#"
 			count: 1
 			path: src/State/HubInterface.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
+			count: 3
+			path: src/functions.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureMessage\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/functions.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureException\\(\\) invoked with 2 parameters, 1 required\\.$#"
+			count: 1
+			path: src/functions.php
+
+		-
+			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureLastError\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: src/functions.php
 
 		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:startTransaction\\(\\) invoked with 2 parameters, 1 required\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -96,11 +96,6 @@ parameters:
 			path: src/State/HubInterface.php
 
 		-
-			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
-			count: 3
-			path: src/functions.php
-
-		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureMessage\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
 			count: 1
 			path: src/functions.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -123,23 +123,39 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?EventId
+    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId
     {
+        $hint = \func_num_args() > 3 ? func_get_arg(3) : null;
+
+        if (null !== $hint && !$hint instanceof EventHint) {
+            throw new \InvalidArgumentException(sprintf('The $hint argument must be an instance of the "%s" class. Got: "%s".', EventHint::class, get_debug_type($hint)));
+        }
+
         $event = Event::createEvent();
         $event->setMessage($message);
         $event->setLevel($level);
 
-        return $this->captureEvent($event, null, $scope);
+        return $this->captureEvent($event, $hint, $scope);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception, ?Scope $scope = null): ?EventId
+    public function captureException(\Throwable $exception, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId
     {
-        return $this->captureEvent(Event::createEvent(), EventHint::fromArray([
-            'exception' => $exception,
-        ]), $scope);
+        $hint = \func_num_args() > 2 ? func_get_arg(2) : null;
+
+        if (null !== $hint && !$hint instanceof EventHint) {
+            throw new \InvalidArgumentException(sprintf('The $hint argument must be an instance of the "%s" class. Got: "%s".', EventHint::class, get_debug_type($hint)));
+        }
+
+        $hint = $hint ?? new EventHint();
+
+        if (null === $hint->exception) {
+            $hint->exception = $exception;
+        }
+
+        return $this->captureEvent(Event::createEvent(), $hint, $scope);
     }
 
     /**
@@ -170,8 +186,9 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(?Scope $scope = null): ?EventId
+    public function captureLastError(?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId
     {
+        $hint = \func_num_args() > 1 ? func_get_arg(1) : null;
         $error = error_get_last();
 
         if (null === $error || !isset($error['message'][0])) {
@@ -180,7 +197,7 @@ final class Client implements ClientInterface
 
         $exception = new \ErrorException(@$error['message'], 0, @$error['type'], @$error['file'], @$error['line']);
 
-        return $this->captureException($exception, $scope);
+        return $this->captureException($exception, $scope, $hint);
     }
 
     /**
@@ -267,7 +284,7 @@ final class Client implements ClientInterface
 
         if (!$isTransaction) {
             $previousEvent = $event;
-            $event = ($this->options->getBeforeSendCallback())($event);
+            $event = ($this->options->getBeforeSendCallback())($event, $hint);
 
             if (null === $event) {
                 $this->logger->info('The event will be discarded because the "before_send" callback returned "null".', ['event' => $previousEvent]);

--- a/src/Client.php
+++ b/src/Client.php
@@ -123,14 +123,8 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId
+    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null, ?EventHint $hint = null): ?EventId
     {
-        $hint = \func_num_args() > 3 ? func_get_arg(3) : null;
-
-        if (null !== $hint && !$hint instanceof EventHint) {
-            throw new \InvalidArgumentException(sprintf('The $hint argument must be an instance of the "%s" class. Got: "%s".', EventHint::class, get_debug_type($hint)));
-        }
-
         $event = Event::createEvent();
         $event->setMessage($message);
         $event->setLevel($level);
@@ -141,14 +135,8 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId
+    public function captureException(\Throwable $exception, ?Scope $scope = null, ?EventHint $hint = null): ?EventId
     {
-        $hint = \func_num_args() > 2 ? func_get_arg(2) : null;
-
-        if (null !== $hint && !$hint instanceof EventHint) {
-            throw new \InvalidArgumentException(sprintf('The $hint argument must be an instance of the "%s" class. Got: "%s".', EventHint::class, get_debug_type($hint)));
-        }
-
         $hint = $hint ?? new EventHint();
 
         if (null === $hint->exception) {
@@ -186,9 +174,8 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId
+    public function captureLastError(?Scope $scope = null, ?EventHint $hint = null): ?EventId
     {
-        $hint = \func_num_args() > 1 ? func_get_arg(1) : null;
         $error = error_get_last();
 
         if (null === $error || !isset($error['message'][0])) {

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -23,26 +23,29 @@ interface ClientInterface
     /**
      * Logs a message.
      *
-     * @param string     $message The message (primary description) for the event
-     * @param Severity   $level   The level of the message to be sent
-     * @param Scope|null $scope   An optional scope keeping the state
+     * @param string         $message The message (primary description) for the event
+     * @param Severity|null  $level   The level of the message to be sent
+     * @param Scope|null     $scope   An optional scope keeping the state
+     * @param EventHint|null $hint    Object that can contain additional information about the event
      */
-    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null): ?EventId;
+    public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Logs an exception.
      *
-     * @param \Throwable $exception The exception object
-     * @param Scope|null $scope     An optional scope keeping the state
+     * @param \Throwable     $exception The exception object
+     * @param Scope|null     $scope     An optional scope keeping the state
+     * @param EventHint|null $hint      Object that can contain additional information about the event
      */
-    public function captureException(\Throwable $exception, ?Scope $scope = null): ?EventId;
+    public function captureException(\Throwable $exception, ?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Logs the most recent error (obtained with {@link error_get_last}).
      *
-     * @param Scope|null $scope An optional scope keeping the state
+     * @param Scope|null     $scope An optional scope keeping the state
+     * @param EventHint|null $hint  Object that can contain additional information about the event
      */
-    public function captureLastError(?Scope $scope = null): ?EventId;
+    public function captureLastError(?Scope $scope = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Captures a new event using the provided data.

--- a/src/Options.php
+++ b/src/Options.php
@@ -352,7 +352,7 @@ final class Options
      * Gets a callback that will be invoked before an event is sent to the server.
      * If `null` is returned it won't be sent.
      *
-     * @psalm-return callable(Event): ?Event
+     * @psalm-return callable(Event, ?EventHint): ?Event
      */
     public function getBeforeSendCallback(): callable
     {
@@ -365,7 +365,7 @@ final class Options
      *
      * @param callable $callback The callable
      *
-     * @psalm-param callable(Event): ?Event $callback
+     * @psalm-param callable(Event, ?EventHint): ?Event $callback
      */
     public function setBeforeSendCallback(callable $callback): void
     {

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -116,12 +116,14 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?EventId
+    public function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $hint = null*/): ?EventId
     {
+        $hint = \func_num_args() > 2 ? func_get_arg(2) : null;
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureMessage($message, $level, $this->getScope());
+            /** @psalm-suppress TooManyArguments */
+            return $this->lastEventId = $client->captureMessage($message, $level, $this->getScope(), $hint);
         }
 
         return null;
@@ -130,12 +132,14 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception): ?EventId
+    public function captureException(\Throwable $exception/*, ?EventHint $hint = null*/): ?EventId
     {
+        $hint = \func_num_args() > 1 ? func_get_arg(1) : null;
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureException($exception, $this->getScope());
+            /** @psalm-suppress TooManyArguments */
+            return $this->lastEventId = $client->captureException($exception, $this->getScope(), $hint);
         }
 
         return null;
@@ -158,12 +162,14 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(): ?EventId
+    public function captureLastError(/*?EventHint $hint = null*/): ?EventId
     {
+        $hint = \func_num_args() > 0 ? func_get_arg(0) : null;
         $client = $this->getClient();
 
         if (null !== $client) {
-            return $this->lastEventId = $client->captureLastError($this->getScope());
+            /** @psalm-suppress TooManyArguments */
+            return $this->lastEventId = $client->captureLastError($this->getScope(), $hint);
         }
 
         return null;
@@ -214,7 +220,7 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function startTransaction(TransactionContext $context): Transaction
+    public function startTransaction(TransactionContext $context/*, array $customSamplingContext = []*/): Transaction
     {
         $customSamplingContext = null;
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -116,9 +116,8 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $hint = null*/): ?EventId
+    public function captureMessage(string $message, ?Severity $level = null, ?EventHint $hint = null): ?EventId
     {
-        $hint = \func_num_args() > 2 ? func_get_arg(2) : null;
         $client = $this->getClient();
 
         if (null !== $client) {
@@ -132,9 +131,8 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureException(\Throwable $exception/*, ?EventHint $hint = null*/): ?EventId
+    public function captureException(\Throwable $exception, ?EventHint $hint = null): ?EventId
     {
-        $hint = \func_num_args() > 1 ? func_get_arg(1) : null;
         $client = $this->getClient();
 
         if (null !== $client) {
@@ -162,9 +160,8 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function captureLastError(/*?EventHint $hint = null*/): ?EventId
+    public function captureLastError(?EventHint $hint = null): ?EventId
     {
-        $hint = \func_num_args() > 0 ? func_get_arg(0) : null;
         $client = $this->getClient();
 
         if (null !== $client) {
@@ -219,15 +216,11 @@ final class Hub implements HubInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param array<string, mixed> $customSamplingContext Additional context that will be passed to the {@see SamplingContext}
      */
-    public function startTransaction(TransactionContext $context/*, array $customSamplingContext = []*/): Transaction
+    public function startTransaction(TransactionContext $context, array $customSamplingContext = []): Transaction
     {
-        $customSamplingContext = null;
-
-        if (\func_num_args() > 1) {
-            $customSamplingContext = func_get_arg(1);
-        }
-
         $transaction = new Transaction($context, $this);
         $client = $this->getClient();
         $options = null !== $client ? $client->getOptions() : null;

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -75,17 +75,19 @@ interface HubInterface
     /**
      * Captures a message event and sends it to Sentry.
      *
-     * @param string   $message The message
-     * @param Severity $level   The severity level of the message
+     * @param string         $message The message
+     * @param Severity|null  $level   The severity level of the message
+     * @param EventHint|null $hint    Object that can contain additional information about the event
      */
-    public function captureMessage(string $message, ?Severity $level = null): ?EventId;
+    public function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Captures an exception event and sends it to Sentry.
      *
-     * @param \Throwable $exception The exception
+     * @param \Throwable     $exception The exception
+     * @param EventHint|null $hint      Object that can contain additional information about the event
      */
-    public function captureException(\Throwable $exception): ?EventId;
+    public function captureException(\Throwable $exception/*, ?EventHint $hint = null*/): ?EventId;
 
     /**
      * Captures a new event using the provided data.
@@ -97,8 +99,10 @@ interface HubInterface
 
     /**
      * Captures an event that logs the last occurred error.
+     *
+     * @param EventHint|null $hint Object that can contain additional information about the event
      */
-    public function captureLastError(): ?EventId;
+    public function captureLastError(/*?EventHint $hint = null*/): ?EventId;
 
     /**
      * Records a new breadcrumb which will be attached to future events. They
@@ -142,7 +146,7 @@ interface HubInterface
      * @param TransactionContext   $context               Properties of the new transaction
      * @param array<string, mixed> $customSamplingContext Additional context that will be passed to the {@see SamplingContext}
      */
-    public function startTransaction(TransactionContext $context): Transaction;
+    public function startTransaction(TransactionContext $context/*, array $customSamplingContext = []*/): Transaction;
 
     /**
      * Returns the transaction that is on the Hub.

--- a/src/functions.php
+++ b/src/functions.php
@@ -26,10 +26,8 @@ function init(array $options = []): void
  * @param Severity|null  $level   The severity level of the message
  * @param EventHint|null $hint    Object that can contain additional information about the event
  */
-function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $hint = null*/): ?EventId
+function captureMessage(string $message, ?Severity $level = null, ?EventHint $hint = null): ?EventId
 {
-    $hint = \func_num_args() > 2 ? func_get_arg(2) : null;
-
     /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->captureMessage($message, $level, $hint);
 }
@@ -40,10 +38,8 @@ function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $
  * @param \Throwable     $exception The exception
  * @param EventHint|null $hint      Object that can contain additional information about the event
  */
-function captureException(\Throwable $exception/*, ?EventHint $hint = null*/): ?EventId
+function captureException(\Throwable $exception, ?EventHint $hint = null): ?EventId
 {
-    $hint = \func_num_args() > 1 ? func_get_arg(1) : null;
-
     /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->captureException($exception, $hint);
 }
@@ -64,10 +60,8 @@ function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
  *
  * @param EventHint|null $hint Object that can contain additional information about the event
  */
-function captureLastError(/*?EventHint $hint = null*/): ?EventId
+function captureLastError(?EventHint $hint = null): ?EventId
 {
-    $hint = \func_num_args() > 0 ? func_get_arg(0) : null;
-
     /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->captureLastError($hint);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -22,22 +22,30 @@ function init(array $options = []): void
 /**
  * Captures a message event and sends it to Sentry.
  *
- * @param string        $message The message
- * @param Severity|null $level   The severity level of the message
+ * @param string         $message The message
+ * @param Severity|null  $level   The severity level of the message
+ * @param EventHint|null $hint    Object that can contain additional information about the event
  */
-function captureMessage(string $message, ?Severity $level = null): ?EventId
+function captureMessage(string $message, ?Severity $level = null/*, ?EventHint $hint = null*/): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureMessage($message, $level);
+    $hint = \func_num_args() > 2 ? func_get_arg(2) : null;
+
+    /** @psalm-suppress TooManyArguments */
+    return SentrySdk::getCurrentHub()->captureMessage($message, $level, $hint);
 }
 
 /**
  * Captures an exception event and sends it to Sentry.
  *
- * @param \Throwable $exception The exception
+ * @param \Throwable     $exception The exception
+ * @param EventHint|null $hint      Object that can contain additional information about the event
  */
-function captureException(\Throwable $exception): ?EventId
+function captureException(\Throwable $exception/*, ?EventHint $hint = null*/): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureException($exception);
+    $hint = \func_num_args() > 1 ? func_get_arg(1) : null;
+
+    /** @psalm-suppress TooManyArguments */
+    return SentrySdk::getCurrentHub()->captureException($exception, $hint);
 }
 
 /**
@@ -52,11 +60,16 @@ function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
 }
 
 /**
- * Logs the most recent error (obtained with {@link error_get_last}).
+ * Logs the most recent error (obtained with {@see error_get_last()}).
+ *
+ * @param EventHint|null $hint Object that can contain additional information about the event
  */
-function captureLastError(): ?EventId
+function captureLastError(/*?EventHint $hint = null*/): ?EventId
 {
-    return SentrySdk::getCurrentHub()->captureLastError();
+    $hint = \func_num_args() > 0 ? func_get_arg(0) : null;
+
+    /** @psalm-suppress TooManyArguments */
+    return SentrySdk::getCurrentHub()->captureLastError($hint);
 }
 
 /**

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -128,18 +128,6 @@ final class ClientTest extends TestCase
         $this->assertTrue($beforeSendCallbackCalled);
     }
 
-    /**
-     * @dataProvider invalidEventHintArgumentDataProvider
-     */
-    public function testCaptureMessageThrowsIfHintArgumentIsInvalid($hint, string $expectedExceptionMessage): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-
-        $client = new Client(new Options(), $this->createMock(TransportInterface::class));
-        $client->captureMessage('foo', null, null, $hint);
-    }
-
     public function testCaptureException(): void
     {
         $exception = new \Exception('Some foo error');
@@ -207,18 +195,6 @@ final class ClientTest extends TestCase
                 'exception' => new \Exception('foo'),
             ]),
         ];
-    }
-
-    /**
-     * @dataProvider invalidEventHintArgumentDataProvider
-     */
-    public function testCaptureExceptionThrowsIfHintArgumentIsInvalid($hint, string $expectedExceptionMessage): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-
-        $client = new Client(new Options(), $this->createMock(TransportInterface::class));
-        $client->captureException(new \Exception(), null, $hint);
     }
 
     /**
@@ -440,35 +416,6 @@ final class ClientTest extends TestCase
         error_clear_last();
 
         $this->assertTrue($beforeSendCallbackCalled);
-    }
-
-    /**
-     * @dataProvider invalidEventHintArgumentDataProvider
-     */
-    public function testCaptureLastErrorThrowsIfHintArgumentIsInvalid($hint, string $expectedExceptionMessage): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-
-        @trigger_error('foo', E_USER_NOTICE);
-
-        $client = new Client(new Options(), $this->createMock(TransportInterface::class));
-        $client->captureLastError(null, $hint);
-
-        error_clear_last();
-    }
-
-    public function invalidEventHintArgumentDataProvider(): \Generator
-    {
-        yield [
-            'foo',
-            'The $hint argument must be an instance of the "Sentry\EventHint" class. Got: "string".',
-        ];
-
-        yield [
-            new \stdClass(),
-            'The $hint argument must be an instance of the "Sentry\EventHint" class. Got: "stdClass".',
-        ];
     }
 
     public function testCaptureLastErrorDoesNothingWhenThereIsNoError(): void

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -9,12 +9,14 @@ use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\EventHint;
 use Sentry\EventId;
 use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\Severity;
+use Sentry\State\HubInterface;
 use Sentry\State\Scope;
-use Sentry\Tracing\SamplingContext;
+use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use function Sentry\addBreadcrumb;
 use function Sentry\captureEvent;
@@ -35,70 +37,141 @@ final class FunctionsTest extends TestCase
         $this->assertNotNull(SentrySdk::getCurrentHub()->getClient());
     }
 
-    public function testCaptureMessage(): void
+    /**
+     * @dataProvider captureMessageDataProvider
+     */
+    public function testCaptureMessage(array $functionCallArgs, array $expectedFunctionCallArgs): void
     {
         $eventId = EventId::generate();
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureMessage')
-            ->with('foo', Severity::debug())
+            ->with(...$expectedFunctionCallArgs)
             ->willReturn($eventId);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame($eventId, captureMessage('foo', Severity::debug()));
+        $this->assertSame($eventId, captureMessage(...$functionCallArgs));
     }
 
-    public function testCaptureException(): void
+    public function captureMessageDataProvider(): \Generator
+    {
+        yield [
+            [
+                'foo',
+                Severity::debug(),
+            ],
+            [
+                'foo',
+                Severity::debug(),
+                null,
+            ],
+        ];
+
+        yield [
+            [
+                'foo',
+                Severity::debug(),
+                new EventHint(),
+            ],
+            [
+                'foo',
+                Severity::debug(),
+                new EventHint(),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider captureExceptionDataProvider
+     */
+    public function testCaptureException(array $functionCallArgs, array $expectedFunctionCallArgs): void
     {
         $eventId = EventId::generate();
-        $exception = new \RuntimeException('foo');
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureException')
-            ->with($exception)
+            ->with(...$expectedFunctionCallArgs)
             ->willReturn($eventId);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame($eventId, captureException($exception));
+        $this->assertSame($eventId, captureException(...$functionCallArgs));
+    }
+
+    public function captureExceptionDataProvider(): \Generator
+    {
+        yield [
+            [
+                new \Exception('foo'),
+            ],
+            [
+                new \Exception('foo'),
+                null,
+            ],
+        ];
+
+        yield [
+            [
+                new \Exception('foo'),
+                new EventHint(),
+            ],
+            [
+                new \Exception('foo'),
+                new EventHint(),
+            ],
+        ];
     }
 
     public function testCaptureEvent(): void
     {
         $event = Event::createEvent();
+        $hint = new EventHint();
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureEvent')
-            ->with($event)
+            ->with($event, $hint)
             ->willReturn($event->getId());
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
-        $this->assertSame($event->getId(), captureEvent($event));
+        $this->assertSame($event->getId(), captureEvent($event, $hint));
     }
 
-    public function testCaptureLastError()
+    /**
+     * @dataProvider captureLastErrorDataProvider
+     */
+    public function testCaptureLastError(array $functionCallArgs, array $expectedFunctionCallArgs): void
     {
         $eventId = EventId::generate();
 
-        /** @var ClientInterface|MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
             ->method('captureLastError')
+            ->with(...$expectedFunctionCallArgs)
             ->willReturn($eventId);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
+        SentrySdk::setCurrentHub($hub);
 
         @trigger_error('foo', E_USER_NOTICE);
 
-        $this->assertSame($eventId, captureLastError());
+        $this->assertSame($eventId, captureLastError(...$functionCallArgs));
+    }
+
+    public function captureLastErrorDataProvider(): \Generator
+    {
+        yield [
+            [],
+            [null],
+        ];
+
+        yield [
+            [new EventHint()],
+            [new EventHint()],
+        ];
     }
 
     public function testAddBreadcrumb(): void
@@ -147,23 +220,17 @@ final class FunctionsTest extends TestCase
     public function testStartTransaction(): void
     {
         $transactionContext = new TransactionContext('foo');
+        $transaction = new Transaction($transactionContext);
         $customSamplingContext = ['foo' => 'bar'];
 
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('getOptions')
-            ->willReturn(new Options([
-                'traces_sampler' => function (SamplingContext $samplingContext) use ($customSamplingContext): float {
-                    $this->assertSame($customSamplingContext, $samplingContext->getAdditionalContext());
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
+            ->method('startTransaction')
+            ->with($transactionContext, $customSamplingContext)
+            ->willReturn($transaction);
 
-                    return 0.0;
-                },
-            ]));
+        SentrySdk::setCurrentHub($hub);
 
-        SentrySdk::getCurrentHub()->bindClient($client);
-
-        $transaction = startTransaction($transactionContext, $customSamplingContext);
-
-        $this->assertSame($transactionContext->getName(), $transaction->getName());
+        $this->assertSame($transaction, startTransaction($transactionContext, $customSamplingContext));
     }
 }


### PR DESCRIPTION
I have a use case where we have extended Exception to have some extra data. Ex:

```php
class ExtraDataException {
   private $extraData = [];
   public function addExtraData($data) {
      $extraData[] = $data;
   }
   public function getExtraData(): array {
      return $this->extraData;
   }
}
```

This is ideologically different from how sentry works. Namely, the behaviour is to wrap with a scope to be able to `$scope->setExtra('data', $data)`.

I am not opposed to this at all. In fact, I like it better than our current approach.

However, I have issues being able to shim in the functionality I need at a global level, as I lose context of the exception right here.

With this change I can do something like:

```php
'before_send' => function (Event $event): Event {
   $data = array_map(function(ExceptionDataBag $e) {
      return $e->getThrowable()->getExtraData();
   }, $event->getExceptions());
   $event->setExtra($data);
   return $event;
}
```

The main reason for this pull is to allow us to shim our existing code.