### PR TITLE
Migrate the error handling for the @ operator to php 8 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - PHP 8 support
+- Change the error handling for silenced fatal errors using `@` to use a mask check in order to be php 8 compatible (#1141)
 
 ## 3.0.3 (2020-10-12)
 

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -265,7 +265,7 @@ final class ErrorHandler
      */
     private function handleError(int $level, string $message, string $file, int $line, ?array $errcontext = []): bool
     {
-        if (!(error_reporting() & $level)) {
+        if (0 === (error_reporting() & $level)) {
             $errorAsException = new SilencedErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);
         } else {
             $errorAsException = new \ErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -265,7 +265,7 @@ final class ErrorHandler
      */
     private function handleError(int $level, string $message, string $file, int $line, ?array $errcontext = []): bool
     {
-        if (0 === error_reporting()) {
+        if (!(error_reporting() & $level)) {
             $errorAsException = new SilencedErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);
         } else {
             $errorAsException = new \ErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);


### PR DESCRIPTION
While trying to execute the unit tests of the latest state of the `php8-support` branch locally, I was able to find the reason why the `error_handler_respects_error_reporting.phpt` test keeps failing. The reason is mentioned in the [official php 8 migration guide](https://www.php.net/manual/de/migration80.incompatible.php):

> The @ operator will no longer silence fatal errors (E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR, E_PARSE). Error handlers that expect error_reporting to be 0 when @ is used, should be adjusted to use a mask check instead:
```php
<?php
// Replace
function my_error_handler($err_no, $err_msg, $filename, $linenum) {
    if (error_reporting() == 0) {
        return; // Silenced
    }
    // ...
}

// With
function my_error_handler($err_no, $err_msg, $filename, $linenum) {
    if (!(error_reporting() & $err_no)) {
        return; // Silenced
    }
    // ...
}
?>
```

You will see that the error_reporting under php 8 no longer returns 0 (none) within a custom error handler: https://3v4l.org/qZ1OG

After this change, my local tests run successful under php 7.2 - 8.0. This does not fix the Segmentation faults or the other remaining CI issues.