### PR TITLE
Change the dependencies guzzlehttp/promises and symfony/options-resolver in favor of php 8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - PHP 8 support
 - Change the error handling for silenced fatal errors using `@` to use a mask check in order to be php 8 compatible (#1141)
 - Change the dependency of `guzzlehttp/promises` from `^1.3` to `^1.4` since it contains crucial type checks for the `FulfilledPromise` class (#1144)
-- Change the dependency of `symfony/options-resolver` from `^3.4.4|^4.0|^5.0` to `^4.4.11|^5.0` since there were a couple of important php 8 compatibility issues addressed in release `^4.4.11` (#1144)
+- Change the dependency of `symfony/options-resolver` from `^3.4.4|^4.0|^5.0` to `^3.4.43|^4.4.11|^5.0.9` since there were a couple of important php 8 compatibility issues (#1144)
 
 ## 3.0.3 (2020-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 - PHP 8 support
 - Change the error handling for silenced fatal errors using `@` to use a mask check in order to be php 8 compatible (#1141)
+- Change the dependency of `guzzlehttp/promises` from `^1.3` to `^1.4` since it contains crucial type checks for the `FulfilledPromise` class (#1144)
+- Change the dependency of `symfony/options-resolver` from `^3.4.4|^4.0|^5.0` to `^4.4.11|^5.0` since there were a couple of important php 8 compatibility issues addressed in release `^4.4.11` (#1144)
 
 ## 3.0.3 (2020-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - PHP 8 support
 - Change the error handling for silenced fatal errors using `@` to use a mask check in order to be php 8 compatible (#1141)
 - Change the dependency of `guzzlehttp/promises` from `^1.3` to `^1.4` since it contains crucial type checks for the `FulfilledPromise` class (#1144)
-- Change the dependency of `symfony/options-resolver` from `^3.4.4|^4.0|^5.0` to `^3.4.43|^4.4.11|^5.0.9` since there were a couple of important php 8 compatibility issues (#1144)
+- Change the dependency of `symfony/options-resolver` from `^3.4.4|^4.0|^5.0` to `^3.4.43|^4.4.11|^5.0.11` since there were a couple of important php 8 compatibility issues (#1144)
 
 ## 3.0.3 (2020-10-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Unreleased
 - PHP 8 support
 - Change the error handling for silenced fatal errors using `@` to use a mask check in order to be php 8 compatible (#1141)
-- Change the dependency of `guzzlehttp/promises` from `^1.3` to `^1.4` since it contains crucial type checks for the `FulfilledPromise` class (#1144)
-- Change the dependency of `symfony/options-resolver` from `^3.4.4|^4.0|^5.0` to `^3.4.43|^4.4.11|^5.0.11` since there were a couple of important php 8 compatibility issues (#1144)
+- Update the `guzzlehttp/promises` package to the minimum required version compatible with PHP 8 (#1144)
+- Update the `symfony/options-resolver` package to the minimum required version compatible with PHP 8 (#1144)
 
 ## 3.0.3 (2020-10-12)
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0",
-        "symfony/options-resolver": "^3.4.43|^4.4.11|^5.0.9",
+        "symfony/options-resolver": "^3.4.43|^4.4.11|^5.0.11",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-uuid": "^1.13.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.3|^2.0",
         "php-http/mock-client": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -35,12 +35,11 @@
         "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0",
-        "symfony/options-resolver": "^4.4.11|^5.0",
+        "symfony/options-resolver": "^3.4.43|^4.4.11|^5.0.9",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.3|^2.0",
         "php-http/mock-client": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/promises": "^1.3",
+        "guzzlehttp/promises": "^1.4",
         "guzzlehttp/psr7": "^1.6",
         "jean85/pretty-package-versions": "^1.5",
         "ocramius/package-versions": "^1.8",
@@ -35,7 +35,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0",
-        "symfony/options-resolver": "^3.4.4|^4.0|^5.0",
+        "symfony/options-resolver": "^4.4.11|^5.0",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-uuid": "^1.13.1"
     },


### PR DESCRIPTION
I'm still trying to help regarding php 8 support, so I checked the remaining CI issues and found two dependency issues when installing under lowest compatibility that this PR will address.

**guzzlehttp/promises: `^1.3` => `^1.4`**

In https://github.com/getsentry/sentry-php/pull/1079 the promise `new FulfilledPromise(true);` has been added to several Transport classes, which is theoretically valid, but due to a lax check of data types, this causes an error under `guzzlehttp/promises` `1.3.*`, since it will be assumed that the parameter is an object or string without checking. in `1.4.0` there is an additional `is_object` check which prevents that from happening
(https://github.com/guzzle/promises/commit/3976c7d3b3585373348ffc3921eddda714dad475).

**symfony/options-resolver: `^3.4.4|^4.0|^5.0` => `^3.4.43|^4.4.11|^5.0.11`**

Several reflection methods have been deprecated or changed in php 8 and therefor the Symfony Team adjusted the package accordingly to make `options-resolver` compatible to php 8. The latest changes are available in version constraint `^3.4.43|^4.4.11|^5.0.11`:
https://github.com/symfony/options-resolver/releases/tag/v3.4.43
https://github.com/symfony/options-resolver/releases/tag/v4.4.11
https://github.com/symfony/options-resolver/releases/tag/v5.0.11

These two changes have no impact on the lowest php version support of this package. After this PR, it seems only the Segmentation faults are still blocking the support for php 8.

EDIT: I had to change the symfony version constraint again. In the first version I assumed no php 8 compatibility for Symfony 3.