### PR TITLE
Dont overwrite Event properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)
 - Fix the `logger` option not being applied to the event object (#1165)
+- Fix Event properties being overwritten when saving Event (#1148)
 
 ## 3.1.1 (2020-12-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)
 - Fix the `logger` option not being applied to the event object (#1165)
-- Fix Event properties being overwritten when saving Event (#1148)
+- Fix a bug that made some event attributes being overwritten by option config values when calling `captureEvent()` (#1148)
 
 ## 3.1.1 (2020-12-07)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -225,12 +225,25 @@ final class Client implements ClientInterface
 
         $this->addMissingStacktraceToEvent($event);
 
+        // Do not overwrite event data if it's already set
+        if (null !== $event->getSdkIdentifier()) {
         $event->setSdkIdentifier($this->sdkIdentifier);
+        }
+        if (null !== $event->getSdkVersion()) {
         $event->setSdkVersion($this->sdkVersion);
+        }
+        if (null !== $event->getServerName()) {
         $event->setServerName($this->options->getServerName());
+        }
+        if (null !== $event->getRelease()) {
         $event->setRelease($this->options->getRelease());
-        $event->setTags($this->options->getTags());
+        }
+        if (null !== $event->getEnvironment()) {
         $event->setEnvironment($this->options->getEnvironment());
+        }
+        
+        // Merge tags from the event and from the main options
+        $event->setTags(array_merge($event->getTags(), $this->options->getTags()));
 
         if (null === $event->getLogger()) {
             $event->setLogger($this->options->getLogger());

--- a/src/Client.php
+++ b/src/Client.php
@@ -128,6 +128,8 @@ final class Client implements ClientInterface
         $event = Event::createEvent();
         $event->setMessage($message);
         $event->setLevel($level);
+        $event->setSdkIdentifier($this->sdkIdentifier);
+        $event->setSdkVersion($this->sdkVersion);
 
         return $this->captureEvent($event, null, $scope);
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -225,24 +225,26 @@ final class Client implements ClientInterface
 
         $this->addMissingStacktraceToEvent($event);
 
-        // Do not overwrite event data if it's already set
-        if (null !== $event->getSdkIdentifier()) {
+        if (null === $event->getSdkIdentifier()) {
         $event->setSdkIdentifier($this->sdkIdentifier);
         }
-        if (null !== $event->getSdkVersion()) {
+        
+        if (null === $event->getSdkVersion()) {
         $event->setSdkVersion($this->sdkVersion);
         }
-        if (null !== $event->getServerName()) {
+        
+        if (null === $event->getServerName()) {
         $event->setServerName($this->options->getServerName());
         }
-        if (null !== $event->getRelease()) {
+        
+        if (null === $event->getRelease()) {
         $event->setRelease($this->options->getRelease());
         }
-        if (null !== $event->getEnvironment()) {
+        
+        if (null === $event->getEnvironment()) {
         $event->setEnvironment($this->options->getEnvironment());
         }
         
-        // Merge tags from the event and from the main options
         $event->setTags(array_merge($event->getTags(), $this->options->getTags()));
 
         if (null === $event->getLogger()) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -128,8 +128,6 @@ final class Client implements ClientInterface
         $event = Event::createEvent();
         $event->setMessage($message);
         $event->setLevel($level);
-        $event->setSdkIdentifier($this->sdkIdentifier);
-        $event->setSdkVersion($this->sdkVersion);
 
         return $this->captureEvent($event, null, $scope);
     }
@@ -227,27 +225,21 @@ final class Client implements ClientInterface
 
         $this->addMissingStacktraceToEvent($event);
 
-        if ('' === $event->getSdkIdentifier()) {
         $event->setSdkIdentifier($this->sdkIdentifier);
-        }
-        
-        if ('' === $event->getSdkVersion()) {
         $event->setSdkVersion($this->sdkVersion);
-        }
-        
+        $event->setTags(array_merge($this->options->getTags(), $event->getTags()));
+
         if (null === $event->getServerName()) {
-        $event->setServerName($this->options->getServerName());
+            $event->setServerName($this->options->getServerName());
         }
-        
+
         if (null === $event->getRelease()) {
-        $event->setRelease($this->options->getRelease());
+            $event->setRelease($this->options->getRelease());
         }
-        
+
         if (null === $event->getEnvironment()) {
-        $event->setEnvironment($this->options->getEnvironment());
+            $event->setEnvironment($this->options->getEnvironment());
         }
-        
-        $event->setTags(array_merge($event->getTags(), $this->options->getTags()));
 
         if (null === $event->getLogger()) {
             $event->setLogger($this->options->getLogger());

--- a/src/Client.php
+++ b/src/Client.php
@@ -225,11 +225,11 @@ final class Client implements ClientInterface
 
         $this->addMissingStacktraceToEvent($event);
 
-        if (null === $event->getSdkIdentifier()) {
+        if ('' === $event->getSdkIdentifier()) {
         $event->setSdkIdentifier($this->sdkIdentifier);
         }
         
-        if (null === $event->getSdkVersion()) {
+        if ('' === $event->getSdkVersion()) {
         $event->setSdkVersion($this->sdkVersion);
         }
         

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -468,7 +468,7 @@ final class ClientTest extends TestCase
         $transport->expects($this->once())
             ->method('send')
             ->with($this->callback(function (Event $event) use ($options): bool {
-                $this->assertSame('sentry.php', $event->getSdkIdentifier());
+                $this->assertSame('sentry.sdk.identifier', $event->getSdkIdentifier());
                 $this->assertSame('1.2.3', $event->getSdkVersion());
                 $this->assertSame($options->getServerName(), $event->getServerName());
                 $this->assertSame($options->getRelease(), $event->getRelease());

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -468,7 +468,7 @@ final class ClientTest extends TestCase
         $transport->expects($this->once())
             ->method('send')
             ->with($this->callback(function (Event $event) use ($options): bool {
-                $this->assertSame('sentry.sdk.identifier', $event->getSdkIdentifier());
+                $this->assertSame('sentry.php', $event->getSdkIdentifier());
                 $this->assertSame('1.2.3', $event->getSdkVersion());
                 $this->assertSame($options->getServerName(), $event->getServerName());
                 $this->assertSame($options->getRelease(), $event->getRelease());

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -468,8 +468,6 @@ final class ClientTest extends TestCase
         $transport->expects($this->once())
             ->method('send')
             ->with($this->callback(function (Event $event) use ($options): bool {
-                $this->assertSame('sentry.sdk.identifier', $event->getSdkIdentifier());
-                $this->assertSame('1.2.3', $event->getSdkVersion());
                 $this->assertSame($options->getServerName(), $event->getServerName());
                 $this->assertSame($options->getRelease(), $event->getRelease());
                 $this->assertSame($options->getTags(), $event->getTags());


### PR DESCRIPTION
Do not overwrite Event properties if they are already configured. Merge tags from options and event.

See bug #1146 the bug was only for tags, but also SdkIdentifier, sdkversion, serverName, release, and Environment are always overwritten. 