### PR TITLE
Update .travis.yml to php 8.0snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
     - 7.2
     - 7.3
     - 7.4
-    - 8.0
+    - 8.0snapshot
 
 env:
     - dependencies=highest


### PR DESCRIPTION
There is no php 8.0 in travis, the correct one is 8.0snapshot.