### PR TITLE
Fix wrong deprecation message for the MissingPublicKeyCredentialException class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix regression introduced in #1129 (#1143)
 - Fix capturing of the request body in the `RequestIntegration` integration when the stream is empty (#1129)
+- Fix wrong deprecation message when using the `MissingPublicKeyCredentialException` class (#1155)
 
 ### 2.5.0 (2020-09-14)
 

--- a/src/Exception/MissingPublicKeyCredentialException.php
+++ b/src/Exception/MissingPublicKeyCredentialException.php
@@ -6,7 +6,7 @@ namespace Sentry\Exception;
 
 use Throwable;
 
-@trigger_error(sprintf('The %s class is deprecated since version 2.4 and will be removed in 3.0.', MissingProjectIdCredentialException::class), E_USER_DEPRECATED);
+@trigger_error(sprintf('The %s class is deprecated since version 2.4 and will be removed in 3.0.', MissingPublicKeyCredentialException::class), E_USER_DEPRECATED);
 
 /**
  * This exception is thrown during the sending of an event when the public key


### PR DESCRIPTION
While making some changes to the tests in another PR I found out that the `@expectedDeprecationMessage` annotation apparently was not working at all. Once solved the issue, I discovered a bug in a deprecation error that refers to the wrong class name