### PR TITLE
Avoid calling the before_send callback with transaction events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+- Fix unwanted call to the `before_send` callback with transaction events (#1158)
+
 ## 3.1.1 (2020-12-07)
 
 - Add support for PHP 8.0 (#1087)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix unwanted call to the `before_send` callback with transaction events (#1158)
+- Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)
 
 ## 3.1.1 (2020-12-07)
 

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -35,7 +35,7 @@ final class EventHint
      *
      * @psalm-param array{
      *     exception?: \Throwable,
-     *     stacktrace?: Event,
+     *     stacktrace?: Stacktrace|null,
      *     extra?: array<string, mixed>
      * } $hintData
      */


### PR DESCRIPTION
Reading the [Tracing documentation](https://develop.sentry.dev/sdk/unified-api/tracing/#interaction-with-beforesend-and-event-processors) I found out that the `before_send` callback shouldn't be called for the transactions. This PR fixes the behaviour, but it kinda of breaks the BC because users that were relying on this behaviour will not be able to do it anymore. Since this is a bug I consider the BC justified and I don't see any other way to avoid it anyway