### PR TITLE
Fix the logger option not being applied to the event object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)
+- Fix the `logger` option not being applied to the event object (#1165)
 
 ## 3.1.1 (2020-12-07)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -232,6 +232,10 @@ final class Client implements ClientInterface
         $event->setTags($this->options->getTags());
         $event->setEnvironment($this->options->getEnvironment());
 
+        if (null === $event->getLogger()) {
+            $event->setLogger($this->options->getLogger());
+        }
+
         $isTransaction = EventType::transaction() === $event->getType();
         $sampleRate = $this->options->getSampleRate();
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -454,29 +454,6 @@ final class ClientTest extends TestCase
         $this->assertTrue($promise->wait());
     }
 
-    private function createTransportFactory(TransportInterface $transport): TransportFactoryInterface
-    {
-        return new class($transport) implements TransportFactoryInterface {
-            /**
-             * @var TransportInterface
-             */
-            private $transport;
-
-            public function __construct(TransportInterface $transport)
-            {
-                $this->transport = $transport;
-            }
-
-            public function create(Options $options): TransportInterface
-            {
-                return $this->transport;
-            }
-        };
-    }
-
-    /**
-     * @backupGlobals
-     */
     public function testBuildEventWithDefaultValues(): void
     {
         $options = new Options();
@@ -484,6 +461,7 @@ final class ClientTest extends TestCase
         $options->setRelease('testRelease');
         $options->setTags(['test' => 'tag']);
         $options->setEnvironment('testEnvironment');
+        $options->setLogger('app.logger');
 
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
@@ -496,6 +474,7 @@ final class ClientTest extends TestCase
                 $this->assertSame($options->getRelease(), $event->getRelease());
                 $this->assertSame($options->getTags(), $event->getTags());
                 $this->assertSame($options->getEnvironment(), $event->getEnvironment());
+                $this->assertSame($options->getLogger(), $event->getLogger());
                 $this->assertNull($event->getStacktrace());
 
                 return true;
@@ -641,5 +620,25 @@ final class ClientTest extends TestCase
         );
 
         $client->captureEvent(Event::createEvent());
+    }
+
+    private function createTransportFactory(TransportInterface $transport): TransportFactoryInterface
+    {
+        return new class($transport) implements TransportFactoryInterface {
+            /**
+             * @var TransportInterface
+             */
+            private $transport;
+
+            public function __construct(TransportInterface $transport)
+            {
+                $this->transport = $transport;
+            }
+
+            public function create(Options $options): TransportInterface
+            {
+                return $this->transport;
+            }
+        };
     }
 }


### PR DESCRIPTION
As reported in #1162, the `logger` option is not being applied on the event object. This is a regression from `2.x`, probably the code went missing during a refactoring and noone noticed it until now.

Side note: I don't have the full historic context of this option, however as of now I cannot find any references to this option in either the JS SDK or the Python SDK, so I believe it was removed at some point. I will open a separate PR, targeting the next minor version, to deprecate it. The field of the same name in the event payload is not affected