### PR TITLE
Deprecate the logger option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Deprecate the `logger` option (#1167)
+
 ## 3.1.2 (2021-01-08)
 
 - Fix unwanted call to the `before_send` callback with transaction events, use `traces_sampler` instead to filter transactions (#1158)

--- a/src/Client.php
+++ b/src/Client.php
@@ -242,7 +242,7 @@ final class Client implements ClientInterface
         }
 
         if (null === $event->getLogger()) {
-            $event->setLogger($this->options->getLogger());
+            $event->setLogger($this->options->getLogger(false));
         }
 
         $isTransaction = EventType::transaction() === $event->getType();

--- a/src/Options.php
+++ b/src/Options.php
@@ -270,9 +270,15 @@ final class Options
 
     /**
      * Gets the logger used by Sentry.
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
-    public function getLogger(): string
+    public function getLogger(/*bool $triggerDeprecation = true*/): string
     {
+        if (0 === \func_num_args() || (\func_num_args() > 0 && false !== func_get_arg(0))) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         return $this->options['logger'];
     }
 
@@ -280,9 +286,13 @@ final class Options
      * Sets the logger used by Sentry.
      *
      * @param string $logger The logger
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
     public function setLogger(string $logger): void
     {
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+
         $options = array_merge($this->options, ['logger' => $logger]);
 
         $this->options = $this->resolver->resolve($options);
@@ -722,7 +732,7 @@ final class Options
         $resolver->setAllowedTypes('environment', ['null', 'string']);
         $resolver->setAllowedTypes('in_app_exclude', 'string[]');
         $resolver->setAllowedTypes('in_app_include', 'string[]');
-        $resolver->setAllowedTypes('logger', 'string');
+        $resolver->setAllowedTypes('logger', ['null', 'string']);
         $resolver->setAllowedTypes('release', ['null', 'string']);
         $resolver->setAllowedTypes('dsn', ['null', 'string', 'bool', Dsn::class]);
         $resolver->setAllowedTypes('server_name', 'string');
@@ -758,6 +768,14 @@ final class Options
 
         $resolver->setNormalizer('in_app_include', function (SymfonyOptions $options, array $value) {
             return array_map([$this, 'normalizeAbsolutePath'], $value);
+        });
+
+        $resolver->setNormalizer('logger', function (SymfonyOptions $options, ?string $value): ?string {
+            if ('php' !== $value) {
+                @trigger_error('The option "logger" is deprecated.', E_USER_DEPRECATED);
+            }
+
+            return $value;
         });
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -275,7 +275,7 @@ final class Options
      */
     public function getLogger(/*bool $triggerDeprecation = true*/): string
     {
-        if (0 === \func_num_args() || (\func_num_args() > 0 && false !== func_get_arg(0))) {
+        if (0 === \func_num_args() || false !== func_get_arg(0)) {
             @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
         }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -29,9 +29,12 @@ use Sentry\Stacktrace;
 use Sentry\State\Scope;
 use Sentry\Transport\TransportFactoryInterface;
 use Sentry\Transport\TransportInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class ClientTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testConstructorSetupsIntegrations(): void
     {
         $integrationCalled = false;

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -7,62 +7,289 @@ namespace Sentry\Tests;
 use PHPUnit\Framework\TestCase;
 use Sentry\Dsn;
 use Sentry\Options;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class OptionsTest extends TestCase
 {
-    /**
-     * @dataProvider optionsDataProvider
-     */
-    public function testConstructor($option, $value, $getterMethod): void
-    {
-        $configuration = new Options([$option => $value]);
-
-        $this->assertEquals($value, $configuration->$getterMethod());
-    }
+    use ExpectDeprecationTrait;
 
     /**
+     * @group legacy
+     *
      * @dataProvider optionsDataProvider
      */
-    public function testGettersAndSetters(string $option, $value, string $getterMethod, ?string $setterMethod = null): void
-    {
-        $configuration = new Options();
-
-        if (null !== $setterMethod) {
-            $configuration->$setterMethod($value);
+    public function testConstructor(
+        string $option,
+        $value,
+        string $getterMethod,
+        ?string $setterMethod,
+        ?string $expectedGetterDeprecationMessage
+    ): void {
+        if (null !== $expectedGetterDeprecationMessage) {
+            $this->expectDeprecation($expectedGetterDeprecationMessage);
         }
 
-        $this->assertEquals($value, $configuration->$getterMethod());
+        $options = new Options([$option => $value]);
+
+        $this->assertSame($value, $options->$getterMethod());
     }
 
-    public function optionsDataProvider(): array
+    /**
+     * @group legacy
+     *
+     * @dataProvider optionsDataProvider
+     */
+    public function testGettersAndSetters(
+        string $option,
+        $value,
+        string $getterMethod,
+        ?string $setterMethod,
+        ?string $expectedGetterDeprecationMessage,
+        ?string $expectedSetterDeprecationMessage
+    ): void {
+        if (null !== $expectedSetterDeprecationMessage) {
+            $this->expectDeprecation($expectedSetterDeprecationMessage);
+        }
+
+        if (null !== $expectedGetterDeprecationMessage) {
+            $this->expectDeprecation($expectedGetterDeprecationMessage);
+        }
+
+        $options = new Options();
+
+        if (null !== $setterMethod) {
+            $options->$setterMethod($value);
+        }
+
+        $this->assertSame($value, $options->$getterMethod());
+    }
+
+    public function optionsDataProvider(): \Generator
     {
-        return [
-            ['send_attempts', 1, 'getSendAttempts', 'setSendAttempts'],
-            ['prefixes', ['foo', 'bar'], 'getPrefixes', 'setPrefixes'],
-            ['sample_rate', 0.5, 'getSampleRate', 'setSampleRate'],
-            ['traces_sample_rate', 0.5, 'getTracesSampleRate', 'setTracesSampleRate'],
-            ['traces_sampler', static function (): void {}, 'getTracesSampler', 'setTracesSampler'],
-            ['attach_stacktrace', false, 'shouldAttachStacktrace', 'setAttachStacktrace'],
-            ['context_lines', 3, 'getContextLines', 'setContextLines'],
-            ['enable_compression', false, 'isCompressionEnabled', 'setEnableCompression'],
-            ['environment', 'foo', 'getEnvironment', 'setEnvironment'],
-            ['in_app_exclude', ['foo', 'bar'], 'getInAppExcludedPaths', 'setInAppExcludedPaths'],
-            ['in_app_include', ['foo', 'bar'], 'getInAppIncludedPaths', 'setInAppIncludedPaths'],
-            ['logger', 'foo', 'getLogger', 'setLogger'],
-            ['release', 'dev', 'getRelease', 'setRelease'],
-            ['server_name', 'foo', 'getServerName', 'setServerName'],
-            ['tags', ['foo', 'bar'], 'getTags', 'setTags'],
-            ['error_types', 0, 'getErrorTypes', 'setErrorTypes'],
-            ['max_breadcrumbs', 50, 'getMaxBreadcrumbs', 'setMaxBreadcrumbs'],
-            ['before_send', static function (): void {}, 'getBeforeSendCallback', 'setBeforeSendCallback'],
-            ['before_breadcrumb', static function (): void {}, 'getBeforeBreadcrumbCallback', 'setBeforeBreadcrumbCallback'],
-            ['send_default_pii', true, 'shouldSendDefaultPii', 'setSendDefaultPii'],
-            ['default_integrations', false, 'hasDefaultIntegrations', 'setDefaultIntegrations'],
-            ['max_value_length', 50, 'getMaxValueLength', 'setMaxValueLength'],
-            ['http_proxy', '127.0.0.1', 'getHttpProxy', 'setHttpProxy'],
-            ['capture_silenced_errors', true, 'shouldCaptureSilencedErrors', 'setCaptureSilencedErrors'],
-            ['max_request_body_size', 'small', 'getMaxRequestBodySize', 'setMaxRequestBodySize'],
+        yield [
+            'send_attempts',
+            1,
+            'getSendAttempts',
+            'setSendAttempts',
+            null,
+            null,
+        ];
+
+        yield [
+            'prefixes',
+            ['foo', 'bar'],
+            'getPrefixes',
+            'setPrefixes',
+            null,
+            null,
+        ];
+
+        yield [
+            'sample_rate',
+            0.5,
+            'getSampleRate',
+            'setSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
+            'traces_sample_rate',
+            0.5,
+            'getTracesSampleRate',
+            'setTracesSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
+            'traces_sampler',
+            static function (): void {},
+            'getTracesSampler',
+            'setTracesSampler',
+            null,
+            null,
+        ];
+
+        yield [
+            'attach_stacktrace',
+            false,
+            'shouldAttachStacktrace',
+            'setAttachStacktrace',
+            null,
+            null,
+        ];
+
+        yield [
+            'context_lines',
+            3,
+            'getContextLines',
+            'setContextLines',
+            null,
+            null,
+        ];
+
+        yield [
+            'enable_compression',
+            false,
+            'isCompressionEnabled',
+            'setEnableCompression',
+            null,
+            null,
+        ];
+
+        yield [
+            'environment',
+            'foo',
+            'getEnvironment',
+            'setEnvironment',
+            null,
+            null,
+        ];
+
+        yield [
+            'in_app_exclude',
+            ['foo', 'bar'],
+            'getInAppExcludedPaths',
+            'setInAppExcludedPaths',
+            null,
+            null,
+        ];
+
+        yield [
+            'in_app_include',
+            ['foo', 'bar'],
+            'getInAppIncludedPaths',
+            'setInAppIncludedPaths',
+            null,
+            null,
+        ];
+
+        yield [
+            'logger',
+            'foo',
+            'getLogger',
+            'setLogger',
+            'Method Sentry\\Options::getLogger() is deprecated since version 3.2 and will be removed in 4.0.',
+            'Method Sentry\\Options::setLogger() is deprecated since version 3.2 and will be removed in 4.0.',
+        ];
+
+        yield [
+            'release',
+            'dev',
+            'getRelease',
+            'setRelease',
+            null,
+            null,
+        ];
+
+        yield [
+            'server_name',
+            'foo',
+            'getServerName',
+            'setServerName',
+            null,
+            null,
+        ];
+
+        yield [
+            'tags',
+            ['foo', 'bar'],
+            'getTags',
+            'setTags',
+            null,
+            null,
+        ];
+
+        yield [
+            'error_types',
+            0,
+            'getErrorTypes',
+            'setErrorTypes',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_breadcrumbs',
+            50,
+            'getMaxBreadcrumbs',
+            'setMaxBreadcrumbs',
+            null,
+            null,
+        ];
+
+        yield [
+            'before_send',
+            static function (): void {},
+            'getBeforeSendCallback',
+            'setBeforeSendCallback',
+            null,
+            null,
+        ];
+
+        yield [
+            'before_breadcrumb',
+            static function (): void {},
+            'getBeforeBreadcrumbCallback',
+            'setBeforeBreadcrumbCallback',
+            null,
+            null,
+        ];
+
+        yield [
+            'send_default_pii',
+            true,
+            'shouldSendDefaultPii',
+            'setSendDefaultPii',
+            null,
+            null,
+        ];
+
+        yield [
+            'default_integrations',
+            false,
+            'hasDefaultIntegrations',
+            'setDefaultIntegrations',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_value_length',
+            50,
+            'getMaxValueLength',
+            'setMaxValueLength',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_proxy',
+            '127.0.0.1',
+            'getHttpProxy',
+            'setHttpProxy',
+            null,
+            null,
+        ];
+
+        yield [
+            'capture_silenced_errors',
+            true,
+            'shouldCaptureSilencedErrors',
+            'setCaptureSilencedErrors',
+            null,
+            null,
+        ];
+
+        yield [
+            'max_request_body_size',
+            'small',
+            'getMaxRequestBodySize',
+            'setMaxRequestBodySize',
+            null,
+            null,
         ];
     }
 


### PR DESCRIPTION
As mentioned in #1165, while fixing a bug involving the `logger` option I found out that at some point in time both the JS and Python SDK stopped supporting it (or they never did, to be honest I don't have the full historic context to say it). Anyway, since the code of those libraries is mainly our reference and I don't think that having this option adds much value as there is usually one logger per application, I decided to deprecate the option and remove it in the next major version. The field with the same name in the event object is not affected.