### PR TITLE
Fix default for client version

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -294,7 +294,7 @@ final class Client implements ClientInterface
         }
 
         $event->setStacktrace($this->stacktraceBuilder->buildFromBacktrace(
-            debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS),
+            debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS),
             __FILE__,
             __LINE__ - 3
         ));

--- a/src/Client.php
+++ b/src/Client.php
@@ -109,7 +109,7 @@ final class Client implements ClientInterface
         $this->representationSerializer = $representationSerializer ?? new RepresentationSerializer($this->options);
         $this->stacktraceBuilder = new StacktraceBuilder($options, $this->representationSerializer);
         $this->sdkIdentifier = $sdkIdentifier ?? self::SDK_IDENTIFIER;
-        $this->sdkVersion = $sdkVersion ?? PrettyVersions::getVersion(PrettyVersions::getRootPackageName())->getPrettyVersion();
+        $this->sdkVersion = $sdkVersion ?? PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
     }
 
     /**

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -91,21 +91,21 @@ final class ErrorHandler
      * @var array List of error levels and their description
      */
     private const ERROR_LEVELS_DESCRIPTION = [
-        E_DEPRECATED => 'Deprecated',
-        E_USER_DEPRECATED => 'User Deprecated',
-        E_NOTICE => 'Notice',
-        E_USER_NOTICE => 'User Notice',
-        E_STRICT => 'Runtime Notice',
-        E_WARNING => 'Warning',
-        E_USER_WARNING => 'User Warning',
-        E_COMPILE_WARNING => 'Compile Warning',
-        E_CORE_WARNING => 'Core Warning',
-        E_USER_ERROR => 'User Error',
-        E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
-        E_COMPILE_ERROR => 'Compile Error',
-        E_PARSE => 'Parse Error',
-        E_ERROR => 'Error',
-        E_CORE_ERROR => 'Core Error',
+        \E_DEPRECATED => 'Deprecated',
+        \E_USER_DEPRECATED => 'User Deprecated',
+        \E_NOTICE => 'Notice',
+        \E_USER_NOTICE => 'User Notice',
+        \E_STRICT => 'Runtime Notice',
+        \E_WARNING => 'Warning',
+        \E_USER_WARNING => 'User Warning',
+        \E_COMPILE_WARNING => 'Compile Warning',
+        \E_CORE_WARNING => 'Core Warning',
+        \E_USER_ERROR => 'User Error',
+        \E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
+        \E_COMPILE_ERROR => 'Compile Error',
+        \E_PARSE => 'Parse Error',
+        \E_ERROR => 'Error',
+        \E_CORE_ERROR => 'Core Error',
     ];
 
     /**
@@ -145,7 +145,7 @@ final class ErrorHandler
             // first call to the set_error_handler method would cause the PHP
             // bug https://bugs.php.net/63206 if the handler is not the first
             // one in the chain of handlers
-            set_error_handler($errorHandlerCallback, E_ALL);
+            set_error_handler($errorHandlerCallback, \E_ALL);
         }
 
         return self::$handlerInstance;
@@ -300,7 +300,7 @@ final class ErrorHandler
         self::$reservedMemory = null;
         $error = error_get_last();
 
-        if (!empty($error) && $error['type'] & (E_ERROR | E_PARSE | E_CORE_ERROR | E_CORE_WARNING | E_COMPILE_ERROR | E_COMPILE_WARNING)) {
+        if (!empty($error) && $error['type'] & (\E_ERROR | \E_PARSE | \E_CORE_ERROR | \E_CORE_WARNING | \E_COMPILE_ERROR | \E_COMPILE_WARNING)) {
             $errorAsException = new FatalErrorException(self::ERROR_LEVELS_DESCRIPTION[$error['type']] . ': ' . $error['message'], 0, $error['type'], $error['file'], $error['line']);
 
             $this->exceptionReflection->setValue($errorAsException, []);

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -142,12 +142,12 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 $httpClient = GuzzleHttpClient::createWithConfig($guzzleConfig);
             } elseif (class_exists(CurlHttpClient::class)) {
                 $curlConfig = [
-                    CURLOPT_TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
-                    CURLOPT_CONNECTTIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
+                    \CURLOPT_TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
+                    \CURLOPT_CONNECTTIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
                 ];
 
                 if (null !== $options->getHttpProxy()) {
-                    $curlConfig[CURLOPT_PROXY] = $options->getHttpProxy();
+                    $curlConfig[\CURLOPT_PROXY] = $options->getHttpProxy();
                 }
 
                 /** @psalm-suppress InvalidPropertyAssignmentValue */

--- a/src/HttpClient/Plugin/GzipEncoderPlugin.php
+++ b/src/HttpClient/Plugin/GzipEncoderPlugin.php
@@ -50,7 +50,7 @@ final class GzipEncoderPlugin implements PluginInterface
 
         // Instead of using a stream filter we have to compress the whole request
         // body in one go to work around a PHP bug. See https://github.com/getsentry/sentry-php/pull/877
-        $encodedBody = gzcompress($requestBody->getContents(), -1, ZLIB_ENCODING_GZIP);
+        $encodedBody = gzcompress($requestBody->getContents(), -1, \ZLIB_ENCODING_GZIP);
 
         if (false === $encodedBody) {
             throw new \RuntimeException('Failed to GZIP-encode the request body.');

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -149,7 +149,7 @@ final class RequestIntegration implements IntegrationInterface
             static function (string $key) use ($keysToRemove): bool {
                 return !\in_array(strtolower($key), $keysToRemove, true);
             },
-            ARRAY_FILTER_USE_KEY
+            \ARRAY_FILTER_USE_KEY
         );
     }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -680,7 +680,7 @@ final class Options
             'integrations' => [],
             'default_integrations' => true,
             'send_attempts' => 3,
-            'prefixes' => array_filter(explode(PATH_SEPARATOR, get_include_path() ?: '')),
+            'prefixes' => array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: '')),
             'sample_rate' => 1,
             'traces_sample_rate' => 0,
             'traces_sampler' => null,

--- a/src/Severity.php
+++ b/src/Severity.php
@@ -89,24 +89,24 @@ final class Severity
     public static function fromError(int $severity): self
     {
         switch ($severity) {
-             case E_DEPRECATED:
-             case E_USER_DEPRECATED:
-             case E_WARNING:
-             case E_USER_WARNING:
+             case \E_DEPRECATED:
+             case \E_USER_DEPRECATED:
+             case \E_WARNING:
+             case \E_USER_WARNING:
                  return self::warning();
-             case E_ERROR:
-             case E_PARSE:
-             case E_CORE_ERROR:
-             case E_CORE_WARNING:
-             case E_COMPILE_ERROR:
-             case E_COMPILE_WARNING:
+             case \E_ERROR:
+             case \E_PARSE:
+             case \E_CORE_ERROR:
+             case \E_CORE_WARNING:
+             case \E_COMPILE_ERROR:
+             case \E_COMPILE_WARNING:
                  return self::fatal();
-             case E_RECOVERABLE_ERROR:
-             case E_USER_ERROR:
+             case \E_RECOVERABLE_ERROR:
+             case \E_USER_ERROR:
                  return self::error();
-             case E_NOTICE:
-             case E_USER_NOTICE:
-             case E_STRICT:
+             case \E_NOTICE:
+             case \E_USER_NOTICE:
+             case \E_STRICT:
                  return self::info();
              default:
                  return self::error();

--- a/src/Tracing/SpanContext.php
+++ b/src/Tracing/SpanContext.php
@@ -199,7 +199,7 @@ class SpanContext
      */
     public static function fromTraceparent(string $header)
     {
-        @trigger_error(sprintf('The %s() method is deprecated since version 3.1 and will be removed in 4.0. Use TransactionContext::fromSentryTrace() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('The %s() method is deprecated since version 3.1 and will be removed in 4.0. Use TransactionContext::fromSentryTrace() instead.', __METHOD__), \E_USER_DEPRECATED);
 
         /** @phpstan-ignore-next-line */ /** @psalm-suppress UnsafeInstantiation */
         $context = new static();

--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -174,7 +174,7 @@ final class UserDataBag
      */
     public function setIpAddress(?string $ipAddress): void
     {
-        if (null !== $ipAddress && false === filter_var($ipAddress, FILTER_VALIDATE_IP)) {
+        if (null !== $ipAddress && false === filter_var($ipAddress, \FILTER_VALIDATE_IP)) {
             throw new \InvalidArgumentException(sprintf('The "%s" value is not a valid IP address.', $ipAddress));
         }
 

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -28,11 +28,11 @@ final class JSON
      */
     public static function encode($data, int $options = 0, int $maxDepth = 512)
     {
-        $options |= JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE;
+        $options |= \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE;
 
         $encodedData = json_encode($data, $options, $maxDepth);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (\JSON_ERROR_NONE !== json_last_error()) {
             throw new JsonException(sprintf('Could not encode value into JSON format. Error was: "%s".', json_last_error_msg()));
         }
 
@@ -52,7 +52,7 @@ final class JSON
     {
         $decodedData = json_decode($data, true);
 
-        if (JSON_ERROR_NONE !== json_last_error()) {
+        if (\JSON_ERROR_NONE !== json_last_error()) {
             throw new JsonException(sprintf('Could not decode value from JSON format. Error was: "%s".', json_last_error_msg()));
         }
 

--- a/src/Util/PHPVersion.php
+++ b/src/Util/PHPVersion.php
@@ -20,7 +20,7 @@ final class PHPVersion
      *
      * @param string $version The string to parse
      */
-    public static function parseVersion(string $version = PHP_VERSION): string
+    public static function parseVersion(string $version = \PHP_VERSION): string
     {
         if (!preg_match(self::VERSION_PARSING_REGEX, $version, $matches)) {
             return $version;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -297,7 +297,7 @@ final class ClientTest extends TestCase
             ->setTransportFactory($this->createTransportFactory($transport))
             ->getClient();
 
-        @trigger_error('foo', E_USER_NOTICE);
+        @trigger_error('foo', \E_USER_NOTICE);
 
         $this->assertNotNull($client->captureLastError());
 
@@ -552,7 +552,7 @@ final class ClientTest extends TestCase
     public function testBuildWithErrorException(): void
     {
         $options = new Options();
-        $exception = new \ErrorException('testMessage', 0, E_USER_ERROR);
+        $exception = new \ErrorException('testMessage', 0, \E_USER_ERROR);
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -96,7 +96,7 @@ final class FunctionsTest extends TestCase
 
         SentrySdk::getCurrentHub()->bindClient($client);
 
-        @trigger_error('foo', E_USER_NOTICE);
+        @trigger_error('foo', \E_USER_NOTICE);
 
         $this->assertSame($eventId, captureLastError());
     }

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -60,7 +60,7 @@ final class HttpClientFactoryTest extends TestCase
 
         yield [
             true,
-            gzcompress('foo bar', -1, ZLIB_ENCODING_GZIP),
+            gzcompress('foo bar', -1, \ZLIB_ENCODING_GZIP),
         ];
     }
 

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -28,7 +28,7 @@ final class GzipEncoderPluginTest extends TestCase
             $request,
             function (RequestInterface $requestArg) use ($expectedPromise): PromiseInterface {
                 $this->assertSame('gzip', $requestArg->getHeaderLine('Content-Encoding'));
-                $this->assertSame(gzcompress('foo', -1, ZLIB_ENCODING_GZIP), (string) $requestArg->getBody());
+                $this->assertSame(gzcompress('foo', -1, \ZLIB_ENCODING_GZIP), (string) $requestArg->getBody());
 
                 return $expectedPromise;
             },

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -327,8 +327,8 @@ final class RequestIntegrationTest extends TestCase
                 ->withHeader('Content-Length', '444')
                 ->withUploadedFiles([
                     'foo' => [
-                        new UploadedFile('foo content', 123, UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
-                        new UploadedFile('bar content', 321, UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
+                        new UploadedFile('foo content', 123, \UPLOAD_ERR_OK, 'foo.ext', 'application/text'),
+                        new UploadedFile('bar content', 321, \UPLOAD_ERR_OK, 'bar.ext', 'application/octet-stream'),
                     ],
                 ]),
             [

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -187,7 +187,7 @@ final class SerializerTest extends AbstractSerializerTest
 
         $this->assertSame('Прекратит {clipped}', $clipped);
         $this->assertNotNull(json_encode($clipped));
-        $this->assertSame(JSON_ERROR_NONE, json_last_error());
+        $this->assertSame(\JSON_ERROR_NONE, json_last_error());
     }
 
     /**

--- a/tests/SeverityTest.php
+++ b/tests/SeverityTest.php
@@ -66,24 +66,24 @@ final class SeverityTest extends TestCase
     {
         return [
             // Warning
-            [E_DEPRECATED, 'warning'],
-            [E_USER_DEPRECATED, 'warning'],
-            [E_WARNING, 'warning'],
-            [E_USER_WARNING, 'warning'],
+            [\E_DEPRECATED, 'warning'],
+            [\E_USER_DEPRECATED, 'warning'],
+            [\E_WARNING, 'warning'],
+            [\E_USER_WARNING, 'warning'],
             // Fatal
-            [E_ERROR, 'fatal'],
-            [E_PARSE, 'fatal'],
-            [E_CORE_ERROR, 'fatal'],
-            [E_CORE_WARNING, 'fatal'],
-            [E_COMPILE_ERROR, 'fatal'],
-            [E_COMPILE_WARNING, 'fatal'],
+            [\E_ERROR, 'fatal'],
+            [\E_PARSE, 'fatal'],
+            [\E_CORE_ERROR, 'fatal'],
+            [\E_CORE_WARNING, 'fatal'],
+            [\E_COMPILE_ERROR, 'fatal'],
+            [\E_COMPILE_WARNING, 'fatal'],
             // Error
-            [E_RECOVERABLE_ERROR, 'error'],
-            [E_USER_ERROR, 'error'],
+            [\E_RECOVERABLE_ERROR, 'error'],
+            [\E_USER_ERROR, 'error'],
             // Info
-            [E_NOTICE, 'info'],
-            [E_USER_NOTICE, 'info'],
-            [E_STRICT, 'info'],
+            [\E_NOTICE, 'info'],
+            [\E_USER_NOTICE, 'info'],
+            [\E_STRICT, 'info'],
         ];
     }
 }

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -115,7 +115,7 @@ final class JSONTest extends TestCase
 
     public function testEncodeRespectsOptionsArgument(): void
     {
-        $this->assertSame('{}', JSON::encode([], JSON_FORCE_OBJECT));
+        $this->assertSame('{}', JSON::encode([], \JSON_FORCE_OBJECT));
     }
 
     /**


### PR DESCRIPTION
The usage of the `PrettyVersion` class there is wrong: the root package is the project using Sentry, not our lib.