### PR TITLE
Allow PrettyVersion 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow jean85/pretty-package-versions 2.0 (#1170)
+
 ## 3.1.3 (2021-01-25)
 
 - Fix the fetching of the version of the SDK (#1169)

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "guzzlehttp/promises": "^1.4",
         "guzzlehttp/psr7": "^1.7",
         "jean85/pretty-package-versions": "^1.5|^2.0",
-        "ocramius/package-versions": "^1.8",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
         "php-http/discovery": "^1.6.1",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.4",
         "guzzlehttp/psr7": "^1.7",
-        "jean85/pretty-package-versions": "^1.5|^2.0",
+        "jean85/pretty-package-versions": "^1.5|^2.0.1",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
         "php-http/discovery": "^1.6.1",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.4",
         "guzzlehttp/psr7": "^1.7",
-        "jean85/pretty-package-versions": "^1.5",
+        "jean85/pretty-package-versions": "^1.5|^2.0",
         "ocramius/package-versions": "^1.8",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -50,7 +50,7 @@ final class ModulesIntegration implements IntegrationInterface
             foreach (self::getInstalledPackages() as $package) {
                 try {
                     self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
-                } catch (\OutOfBoundsException | VersionMissingExceptionInterface $exception) {
+                } catch (\Throwable $exception) {
                     continue;
                 }
             }

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -50,9 +50,7 @@ final class ModulesIntegration implements IntegrationInterface
             foreach (self::getInstalledPackages() as $package) {
                 try {
                     self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
-                } catch (\OutOfBoundsException $exception) {
-                    continue;
-                } catch (VersionMissingExceptionInterface $exception) {
+                } catch (\OutOfBoundsException | VersionMissingExceptionInterface $exception) {
                     continue;
                 }
             }

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Composer\InstalledVersions;
-use Jean85\Exception\VersionMissingExceptionInterface;
 use Jean85\PrettyVersions;
 use PackageVersions\Versions;
 use Sentry\Event;

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -50,6 +50,8 @@ final class ModulesIntegration implements IntegrationInterface
             foreach (self::getInstalledPackages() as $package) {
                 try {
                     self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
+                } catch (\OutOfBoundsException $exception) {
+                    continue;
                 } catch (VersionMissingExceptionInterface $exception) {
                     continue;
                 }

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Integration;
 
+use Composer\InstalledVersions;
 use Jean85\PrettyVersions;
 use PackageVersions\Versions;
 use Sentry\Event;
@@ -45,11 +46,29 @@ final class ModulesIntegration implements IntegrationInterface
     private static function getComposerPackages(): array
     {
         if (empty(self::$packages)) {
-            foreach (Versions::VERSIONS as $package => $rawVersion) {
+            foreach (self::getInstalledPackages() as $package) {
                 self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
             }
         }
 
         return self::$packages;
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getInstalledPackages(): array
+    {
+        if (class_exists(InstalledVersions::class)) {
+            return InstalledVersions::getInstalledPackages();
+        }
+
+        if (class_exists(Versions::class)) {
+            // BC layer for Composer 1, using a transient dependency
+            return array_keys(Versions::VERSIONS);
+        }
+
+        // this should not happen
+        return ['sentry/sentry'];
     }
 }

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Composer\InstalledVersions;
+use Jean85\Exception\VersionMissingExceptionInterface;
 use Jean85\PrettyVersions;
 use PackageVersions\Versions;
 use Sentry\Event;
@@ -47,7 +48,11 @@ final class ModulesIntegration implements IntegrationInterface
     {
         if (empty(self::$packages)) {
             foreach (self::getInstalledPackages() as $package) {
-                self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
+                try {
+                    self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
+                } catch (VersionMissingExceptionInterface $exception) {
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
This allows https://github.com/Jean85/pretty-package-versions/releases/tag/2.0.0, which I released with very few BC breaks, so that so we can use both versions without issues. In this PR I'm also able to drop the indirect dependency, so we can move forward toward Composer 2.

I'll probably backport this to the 2.x branch.