### PR TITLE
Deprecate the tags option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Deprecate the `logger` option (#1167)
 - Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
+- Deprecate the `tags` option (#1174)
 
 ## 3.1.2 (2021-01-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Deprecate the `logger` option (#1167)
 - Pass the event hint from the `capture*()` methods down to the `before_send` callback (#1138)
-- Deprecate the `tags` option (#1174)
+- Deprecate the `tags` option, see the [docs](https://docs.sentry.io/platforms/php/guides/laravel/enriching-events/tags/) for other ways to set tags (#1174)
 
 ## 3.1.2 (2021-01-08)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -231,7 +231,7 @@ final class Client implements ClientInterface
 
         $event->setSdkIdentifier($this->sdkIdentifier);
         $event->setSdkVersion($this->sdkVersion);
-        $event->setTags(array_merge($this->options->getTags(), $event->getTags()));
+        $event->setTags(array_merge($this->options->getTags(false), $event->getTags()));
 
         if (null === $event->getServerName()) {
             $event->setServerName($this->options->getServerName());

--- a/src/Options.php
+++ b/src/Options.php
@@ -384,7 +384,7 @@ final class Options
     public function getTags(/*bool $triggerDeprecation = true*/): array
     {
         if (0 === \func_num_args() || false !== func_get_arg(0)) {
-            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), \E_USER_DEPRECATED);
         }
 
         return $this->options['tags'];
@@ -399,7 +399,7 @@ final class Options
      */
     public function setTags(array $tags): void
     {
-        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.', __METHOD__), E_USER_DEPRECATED);
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.', __METHOD__), \E_USER_DEPRECATED);
 
         $options = array_merge($this->options, ['tags' => $tags]);
 
@@ -769,7 +769,7 @@ final class Options
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
         $resolver->setNormalizer('tags', static function (SymfonyOptions $options, array $value): array {
             if (!empty($value)) {
-                @trigger_error('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.', E_USER_DEPRECATED);
+                @trigger_error('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.', \E_USER_DEPRECATED);
             }
 
             return $value;

--- a/src/Options.php
+++ b/src/Options.php
@@ -378,9 +378,15 @@ final class Options
      * Gets a list of default tags for events.
      *
      * @return array<string, string>
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
-    public function getTags(): array
+    public function getTags(/*bool $triggerDeprecation = true*/): array
     {
+        if (0 === \func_num_args() || false !== func_get_arg(0)) {
+            @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0.', __METHOD__), E_USER_DEPRECATED);
+        }
+
         return $this->options['tags'];
     }
 
@@ -388,9 +394,13 @@ final class Options
      * Sets a list of default tags for events.
      *
      * @param array<string, string> $tags A list of tags
+     *
+     * @deprecated since version 3.2, to be removed in 4.0
      */
     public function setTags(array $tags): void
     {
+        @trigger_error(sprintf('Method %s() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.', __METHOD__), E_USER_DEPRECATED);
+
         $options = array_merge($this->options, ['tags' => $tags]);
 
         $this->options = $this->resolver->resolve($options);
@@ -757,6 +767,13 @@ final class Options
         $resolver->setAllowedValues('context_lines', \Closure::fromCallable([$this, 'validateContextLinesOption']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
+        $resolver->setNormalizer('tags', static function (SymfonyOptions $options, array $value): array {
+            if (!empty($value)) {
+                @trigger_error('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.', E_USER_DEPRECATED);
+            }
+
+            return $value;
+        });
 
         $resolver->setNormalizer('prefixes', function (SymfonyOptions $options, array $value) {
             return array_map([$this, 'normalizeAbsolutePath'], $value);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -198,10 +198,14 @@ final class ClientTest extends TestCase
     }
 
     /**
+     * @group legacy
+     *
      * @dataProvider captureEventDataProvider
      */
     public function testCaptureEvent(array $options, Event $event, Event $expectedEvent): void
     {
+        $this->expectDeprecation('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.');
+
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
             ->method('send')

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -198,8 +198,8 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getTags',
             'setTags',
-            null,
-            null,
+            'Method Sentry\\Options::getTags() is deprecated since version 3.2 and will be removed in 4.0.',
+            'Method Sentry\\Options::setTags() is deprecated since version 3.2 and will be removed in 4.0. Use Sentry\\Scope::setTags() instead.',
         ];
 
         yield [


### PR DESCRIPTION
As it was done for the `logger` option, also this one is going to be deprecated. Instead, the tags should be set either on the event object or on the scope. Both the Python and JS SDK already do not support this option anymore, although I'm not sure if they ever did it or they stopped doing it recently