### PR TITLE
Add a GitHub Action workflow to release a new version

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,29 @@
+name: Prepare Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            version:
+                description: Version to release
+                required: true
+            force:
+                description: Force a release even when there are release-blockers (optional)
+                required: false
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        name: Release version
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  token: ${{ secrets.GH_RELEASE_PAT }}
+                  fetch-depth: 0
+
+            - name: Prepare release
+              uses: getsentry/action-prepare-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+              with:
+                  version: ${{ github.event.inputs.version }}
+                  force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
As per title, this workflow comes straight from the repo of the Javascript SDK and should enable releasing a new version without depending on @HazAT