### PR TITLE
Fix codecov warning due to too low fetch depth

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,16 +1,16 @@
-minVersion: '0.9.0'
+minVersion: 0.9.0
 github:
-    owner: getsentry
-    repo: sentry-php
+  owner: getsentry
+  repo: sentry-php
 changelogPolicy: simple
-statusProvider: 
-    name: github
+statusProvider:
+  name: github
 artifactProvider:
   name: none
 preReleaseCommand: ""
 targets:
-    - name: github
-    - name: registry
-      type: sdk
-      config:
-          canonical: 'composer:sentry/sentry'
+  - name: github
+  - name: registry
+    type: sdk
+    config:
+      canonical: 'composer:sentry/sentry'

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,8 @@ indent_size = 4
 [*.md]
 max_line_length = 80
 
+[*.{yml, yaml}]
+indent_size = 2
+
 [COMMIT_EDITMSG]
 max_line_length = 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v2
+              with:
+                  fetch-depth: 2
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,69 +1,69 @@
 name: CI
 
 on:
-    pull_request:
-    push:
-        branches:
-            - master
-            - develop
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
 
 jobs:
-    tests:
-        name: Tests
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os:
-                    - ubuntu-latest
-                    - windows-latest
-                php:
-                    - '7.2'
-                    - '7.3'
-                    - '7.4'
-                    - '8.0'
-                dependencies:
-                    - lowest
-                    - highest
+  tests:
+    name: Tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        php:
+          - '7.2'
+          - '7.3'
+          - '7.4'
+          - '8.0'
+        dependencies:
+          - lowest
+          - highest
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-              with:
-                  fetch-depth: 2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  coverage: xdebug
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
 
-            - name: Setup Problem Matchers for PHPUnit
-              run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+      - name: Setup Problem Matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            - name: Determine Composer cache directory
-              id: composer-cache
-              run: echo "::set-output name=directory::$(composer config cache-dir)"
+      - name: Determine Composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=directory::$(composer config cache-dir)"
 
-            - name: Cache Composer dependencies
-              uses: actions/cache@v2
-              with:
-                  path: ${{ steps.composer-cache.outputs.directory }}
-                  key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.dependencies }}-composer-
+      - name: Cache Composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.directory }}
+          key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ matrix.dependencies }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.dependencies }}-composer-
 
-            - name: Install highest dependencies
-              run: composer update --no-progress --no-interaction --prefer-dist
-              if: ${{ matrix.dependencies == 'highest' }}
+      - name: Install highest dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist
+        if: ${{ matrix.dependencies == 'highest' }}
 
-            - name: Install lowest dependencies
-              run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest
-              if: ${{ matrix.dependencies == 'lowest' }}
+      - name: Install lowest dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest
+        if: ${{ matrix.dependencies == 'lowest' }}
 
-            - name: Run tests
-              run: vendor/bin/phpunit --coverage-clover=build/coverage-report.xml
+      - name: Run tests
+        run: vendor/bin/phpunit --coverage-clover=build/coverage-report.xml
 
-            - name: Upload code coverage
-              uses: codecov/codecov-action@v1
-              with:
-                  file: build/coverage-report.xml
+      - name: Upload code coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: build/coverage-report.xml

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,29 +1,29 @@
 name: Prepare Release
 
 on:
-    workflow_dispatch:
-        inputs:
-            version:
-                description: Version to release
-                required: true
-            force:
-                description: Force a release even when there are release-blockers (optional)
-                required: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
-        name: Release version
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  token: ${{ secrets.GH_RELEASE_PAT }}
-                  fetch-depth: 0
+  release:
+    runs-on: ubuntu-latest
+    name: Release version
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GH_RELEASE_PAT }}
+          fetch-depth: 0
 
-            - name: Prepare release
-              uses: getsentry/action-prepare-release@v1
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
-              with:
-                  version: ${{ github.event.inputs.version }}
-                  force: ${{ github.event.inputs.force }}
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,59 +1,59 @@
 name: Code style and static analysis
 
 on:
-    pull_request:
-    push:
-        branches:
-            - master
-            - develop
+  pull_request:
+  push:
+    branches:
+      - master
+      - develop
 
 jobs:
-    php-cs-fixer:
-        name: PHP-CS-Fixer
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '7.4'
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
 
-            - name: Install dependencies
-              run: composer update --no-progress --no-interaction --prefer-dist
+      - name: Install dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist
 
-            - name: Run script
-              run: composer phpcs
+      - name: Run script
+        run: composer phpcs
 
-    phpstan:
-        name: PHPStan
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
 
-            - name: Install dependencies
-              run: composer update --no-progress --no-interaction --prefer-dist
+      - name: Install dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist
 
-            - name: Run script
-              run: composer phpstan
+      - name: Run script
+        run: composer phpstan
 
-    psalm:
-        name: Psalm
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
 
-            - name: Install dependencies
-              run: composer update --no-progress --no-interaction --prefer-dist
+      - name: Install dependencies
+        run: composer update --no-progress --no-interaction --prefer-dist
 
-            - name: Run script
-              run: composer psalm
+      - name: Run script
+        run: composer psalm

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 comment: false
 ignore:
-    - tests/data
-    - tests/resources
-    - tests/Fixtures
+  - tests/data
+  - tests/resources
+  - tests/Fixtures


### PR DESCRIPTION
Since a while I noticed that when I force push the commits of a PR we get the following warning in the GitHub Actions log and no Codecov status check is shown anymore:

`Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0`

According to codecov/codecov-action#190 we should definitely set `fetch-depth` to something greater than `1`. As a side note, I also switched the indentation of the YAML files from 4 spaces to 2 as it looks like it's the common standard