### PR TITLE
Update list of 3rd party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,14 +76,18 @@ The following integrations are fully supported and maintained by the Sentry team
 The following integrations are available and maintained by members of the Sentry community.
 
 - [Drupal](https://www.drupal.org/project/raven)
-- [Flow Framework](https://github.com/networkteam/Networkteam.SentryClient)
-- [OXID eShop](https://github.com/OXIDprojects/sentry)
+- [Neos Flow](https://github.com/flownative/flow-sentry)
 - [WordPress](https://wordpress.org/plugins/wp-sentry-integration/)
 - [ZendFramework](https://github.com/facile-it/sentry-module)
-- [SilverStripe](https://github.com/phptek/silverstripe-sentry)
-- [TYPO3](https://github.com/networkteam/sentry_client)
 - [Yii2](https://github.com/notamedia/yii2-sentry)
 - ... feel free to be famous, create a port to your favourite platform!
+
+### 3rd party integrations using old SDK 2.x
+
+- [Neos Flow](https://github.com/networkteam/Networkteam.SentryClient)
+- [OXID eShop](https://github.com/OXIDprojects/sentry)
+- [SilverStripe](https://github.com/phptek/silverstripe-sentry)
+- [TYPO3](https://github.com/networkteam/sentry_client)
 
 ### 3rd party integrations using old SDK 1.x
 


### PR DESCRIPTION
Added a new section for integrations using the 2.x SDK and included an alternative package for Neos Flow (previously "Flow Framework") which supports Flow 7.x and Sentry SDK 3.x.