### PR TITLE
Merge master into develop

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -48,6 +48,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # needed by codecov sometimes
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 <p align="center">
-    <a href="https://sentry.io" target="_blank" align="center">
-        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-    </a>
+  <a href="https://sentry.io" target="_blank" align="center">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
+  </a>
+  <br />
 </p>
+
+_Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
 
 # Sentry SDK for PHP
 


### PR DESCRIPTION
We have a couple of commits in master that are not present in develop, and those popped up in #1193 due to changing the target (still from master to develop).

This will align everything (and port the Codecov fix).