### PR TITLE
Fix `error_reporting` value not evaluated on the moment of the error being reported by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix `error_reporting()` not being evaluated when handling errors when the `error_types` option is not set (#1196)
+- Changes behaviour of `error_types` option when not set: before it defaulted to `error_reporting()` statically at SDK initialization; now it will be evaluated each time during error handling to allow silencing errors temporarily (#1196)
 
 ## 3.2.0 (2021-03-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `error_reporting()` not being evaluated when handling errors when the `error_types` option is not set (#1196)
+
 ## 3.2.0 (2021-03-03)
 
 - Make the HTTP headers sanitizable in the `RequestIntegration` integration instead of removing them entirely (#1161)

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -35,7 +35,7 @@ final class ErrorListenerIntegration extends AbstractErrorListenerIntegration
                 return;
             }
 
-            if (!($client->getOptions()->getErrorTypes() & $exception->getSeverity())) {
+            if (!$exception instanceof SilencedErrorException && !($client->getOptions()->getErrorTypes() & $exception->getSeverity())) {
                 return;
             }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -411,7 +411,7 @@ final class Options
      */
     public function getErrorTypes(): int
     {
-        return $this->options['error_types'];
+        return $this->options['error_types'] ?? error_reporting();
     }
 
     /**
@@ -716,7 +716,7 @@ final class Options
                 return $event;
             },
             'tags' => [],
-            'error_types' => error_reporting(),
+            'error_types' => null,
             'max_breadcrumbs' => self::DEFAULT_MAX_BREADCRUMBS,
             'before_breadcrumb' => static function (Breadcrumb $breadcrumb): Breadcrumb {
                 return $breadcrumb;
@@ -748,7 +748,7 @@ final class Options
         $resolver->setAllowedTypes('server_name', 'string');
         $resolver->setAllowedTypes('before_send', ['callable']);
         $resolver->setAllowedTypes('tags', 'string[]');
-        $resolver->setAllowedTypes('error_types', ['int']);
+        $resolver->setAllowedTypes('error_types', ['null', 'int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');
         $resolver->setAllowedTypes('before_breadcrumb', ['callable']);
         $resolver->setAllowedTypes('integrations', ['Sentry\\Integration\\IntegrationInterface[]', 'callable']);

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -539,23 +539,6 @@ final class OptionsTest extends TestCase
         $this->assertSame('0.0.1', (new Options())->getRelease());
     }
 
-    public function testErrorTypesIsDynamiclyReadFromErrorReportingLevelWhenUnset(): void
-    {
-        $options = new Options(['error_types' => null]);
-
-        $errorReportingBeforeTest = error_reporting($currentErrorReporting = \E_NOTICE & \E_USER_NOTICE);
-
-        $this->assertEquals($currentErrorReporting, $options->getErrorTypes());
-
-        error_reporting($currentErrorReporting = \E_WARNING & \E_USER_WARNING);
-
-        $this->assertEquals($currentErrorReporting, $options->getErrorTypes());
-
-        error_reporting($errorReportingBeforeTest);
-
-        $this->assertEquals($errorReportingBeforeTest, $options->getErrorTypes());
-    }
-
     public function testErrorTypesIsNotDynamiclyReadFromErrorReportingLevelWhenSet(): void
     {
         $errorReportingBeforeTest = error_reporting(\E_ERROR);

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -539,16 +539,18 @@ final class OptionsTest extends TestCase
         $this->assertSame('0.0.1', (new Options())->getRelease());
     }
 
-    public function testErrorTypesIsNotDynamiclyReadFromErrorReportingLevelWhenSet(): void
+    public function testErrorTypesOptionIsNotDynamiclyReadFromErrorReportingLevelWhenSet(): void
     {
         $errorReportingBeforeTest = error_reporting(\E_ERROR);
 
-        $options = new Options(['error_types' => $currentErrorTypes = \E_NOTICE & \E_USER_NOTICE]);
+        $errorTypesOptionValue = \E_NOTICE;
 
-        $this->assertEquals($currentErrorTypes, $options->getErrorTypes());
+        $options = new Options(['error_types' => $errorTypesOptionValue]);
+
+        $this->assertEquals($errorTypesOptionValue, $options->getErrorTypes());
 
         error_reporting($errorReportingBeforeTest);
 
-        $this->assertEquals($currentErrorTypes, $options->getErrorTypes());
+        $this->assertEquals($errorTypesOptionValue, $options->getErrorTypes());
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -519,4 +519,34 @@ final class OptionsTest extends TestCase
 
         $this->assertSame('0.0.1', (new Options())->getRelease());
     }
+
+    public function testErrorTypesIsDynamiclyReadingErrorReportingLevelWhenUnset(): void
+    {
+        $options = new Options(['error_types' => null]);
+
+        $errorReportingBeforeTest = error_reporting($currentErrorReporting = E_NOTICE & E_USER_NOTICE);
+
+        $this->assertEquals($currentErrorReporting, $options->getErrorTypes());
+
+        error_reporting($currentErrorReporting = E_WARNING & E_USER_WARNING);
+
+        $this->assertEquals($currentErrorReporting, $options->getErrorTypes());
+
+        error_reporting($errorReportingBeforeTest);
+
+        $this->assertEquals($errorReportingBeforeTest, $options->getErrorTypes());
+    }
+
+    public function testErrorTypesIsNotDynamiclyReadingErrorReportingLevelWhenSet(): void
+    {
+        $errorReportingBeforeTest = error_reporting(E_ERROR);
+
+        $options = new Options(['error_types' => $currentErrorTypes = E_NOTICE & E_USER_NOTICE]);
+
+        $this->assertEquals($currentErrorTypes, $options->getErrorTypes());
+
+        error_reporting($errorReportingBeforeTest);
+
+        $this->assertEquals($currentErrorTypes, $options->getErrorTypes());
+    }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -17,22 +17,20 @@ final class OptionsTest extends TestCase
     /**
      * @var int
      */
-    private $errorReportingOnSetup;
+    private $errorReportingOnSetUp;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        // There are tests changing the error reporting level in this class so we store the current value before running the tests
-        $this->errorReportingOnSetup = error_reporting();
+        $this->errorReportingOnSetUp = error_reporting();
     }
 
     protected function tearDown(): void
     {
-        parent::tearDown();
+        error_reporting($this->errorReportingOnSetUp);
 
-        // There are tests changing the error reporting level in this class so we restore it to the value before running the tests
-        error_reporting($this->errorReportingOnSetup);
+        parent::tearDown();
     }
 
     /**

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -524,11 +524,11 @@ final class OptionsTest extends TestCase
     {
         $options = new Options(['error_types' => null]);
 
-        $errorReportingBeforeTest = error_reporting($currentErrorReporting = E_NOTICE & E_USER_NOTICE);
+        $errorReportingBeforeTest = error_reporting($currentErrorReporting = \E_NOTICE & \E_USER_NOTICE);
 
         $this->assertEquals($currentErrorReporting, $options->getErrorTypes());
 
-        error_reporting($currentErrorReporting = E_WARNING & E_USER_WARNING);
+        error_reporting($currentErrorReporting = \E_WARNING & \E_USER_WARNING);
 
         $this->assertEquals($currentErrorReporting, $options->getErrorTypes());
 
@@ -539,9 +539,9 @@ final class OptionsTest extends TestCase
 
     public function testErrorTypesIsNotDynamiclyReadingErrorReportingLevelWhenSet(): void
     {
-        $errorReportingBeforeTest = error_reporting(E_ERROR);
+        $errorReportingBeforeTest = error_reporting(\E_ERROR);
 
-        $options = new Options(['error_types' => $currentErrorTypes = E_NOTICE & E_USER_NOTICE]);
+        $options = new Options(['error_types' => $currentErrorTypes = \E_NOTICE & \E_USER_NOTICE]);
 
         $this->assertEquals($currentErrorTypes, $options->getErrorTypes());
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -15,6 +15,27 @@ final class OptionsTest extends TestCase
     use ExpectDeprecationTrait;
 
     /**
+     * @var int
+     */
+    private $errorReportingOnSetup;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // There are tests changing the error reporting level in this class so we store the current value before running the tests
+        $this->errorReportingOnSetup = error_reporting();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // There are tests changing the error reporting level in this class so we restore it to the value before running the tests
+        error_reporting($this->errorReportingOnSetup);
+    }
+
+    /**
      * @group legacy
      *
      * @dataProvider optionsDataProvider
@@ -520,7 +541,7 @@ final class OptionsTest extends TestCase
         $this->assertSame('0.0.1', (new Options())->getRelease());
     }
 
-    public function testErrorTypesIsDynamiclyReadingErrorReportingLevelWhenUnset(): void
+    public function testErrorTypesIsDynamiclyReadFromErrorReportingLevelWhenUnset(): void
     {
         $options = new Options(['error_types' => null]);
 
@@ -537,7 +558,7 @@ final class OptionsTest extends TestCase
         $this->assertEquals($errorReportingBeforeTest, $options->getErrorTypes());
     }
 
-    public function testErrorTypesIsNotDynamiclyReadingErrorReportingLevelWhenSet(): void
+    public function testErrorTypesIsNotDynamiclyReadFromErrorReportingLevelWhenSet(): void
     {
         $errorReportingBeforeTest = error_reporting(\E_ERROR);
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -542,15 +542,14 @@ final class OptionsTest extends TestCase
     public function testErrorTypesOptionIsNotDynamiclyReadFromErrorReportingLevelWhenSet(): void
     {
         $errorReportingBeforeTest = error_reporting(\E_ERROR);
-
         $errorTypesOptionValue = \E_NOTICE;
 
         $options = new Options(['error_types' => $errorTypesOptionValue]);
 
-        $this->assertEquals($errorTypesOptionValue, $options->getErrorTypes());
+        $this->assertSame($errorTypesOptionValue, $options->getErrorTypes());
 
         error_reporting($errorReportingBeforeTest);
 
-        $this->assertEquals($errorTypesOptionValue, $options->getErrorTypes());
+        $this->assertSame($errorTypesOptionValue, $options->getErrorTypes());
     }
 }

--- a/tests/phpt/error_handler_respects_current_error_reporting_level.phpt
+++ b/tests/phpt/error_handler_respects_current_error_reporting_level.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Test that the error handler uses the current error_reporting() level.
+--INI--
+error_reporting=E_ALL
+display_errors=Off
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\PromiseInterface;
+use Sentry\ClientBuilder;
+use Sentry\Event;
+use Sentry\Options;
+use Sentry\Response;
+use Sentry\ResponseStatus;
+use Sentry\SentrySdk;
+use Sentry\Transport\TransportFactoryInterface;
+use Sentry\Transport\TransportInterface;
+
+$vendor = __DIR__;
+
+while (!file_exists($vendor . '/vendor')) {
+    $vendor = \dirname($vendor);
+}
+
+require $vendor . '/vendor/autoload.php';
+
+$transportFactory = new class implements TransportFactoryInterface {
+    public function create(Options $options): TransportInterface
+    {
+        return new class implements TransportInterface {
+            public function send(Event $event): PromiseInterface
+            {
+                echo 'Transport called' . PHP_EOL;
+
+                return new FulfilledPromise(new Response(ResponseStatus::success()));
+            }
+
+            public function close(?int $timeout = null): PromiseInterface
+            {
+                return new FulfilledPromise(true);
+            }
+        };
+    }
+};
+
+$client = ClientBuilder::create(['error_types' => null])
+    ->setTransportFactory($transportFactory)
+    ->getClient();
+
+SentrySdk::getCurrentHub()->bindClient($client);
+
+echo 'Triggering E_USER_NOTICE with error reporting on E_ALL' . PHP_EOL;
+
+trigger_error('A notice that should be captured', E_USER_NOTICE);
+
+$old_error_reporting = error_reporting(E_ALL & ~E_USER_NOTICE);
+
+echo 'Triggering E_USER_NOTICE with error reporting on E_ALL & ~E_USER_NOTICE' . PHP_EOL;
+
+trigger_error('A notice that should not be captured', E_USER_NOTICE);
+
+error_reporting($old_error_reporting);
+
+echo 'Triggering E_USER_NOTICE with error reporting on E_ALL again' . PHP_EOL;
+
+trigger_error('A notice that should be captured', E_USER_NOTICE);
+
+?>
+--EXPECT--
+Triggering E_USER_NOTICE with error reporting on E_ALL
+Transport called
+Triggering E_USER_NOTICE with error reporting on E_ALL & ~E_USER_NOTICE
+Triggering E_USER_NOTICE with error reporting on E_ALL again
+Transport called


### PR DESCRIPTION
This PR aims to fix a bug where `error_reporting()` is copied on initialisation of the SDK and not evaluated on the moment of the error capture.

There are 2 changed to the behaviour of the SDK after this bug fix:

- When not explicitly setting the `error_types` option on the SDK the `error_reporting()` value is used to determine if an error should be reported to Sentry
- Errors silenced by the `@` operator are reported regardless of their level, only taking `capture_silenced_errors` (defaults to `false`) into consideration

The last point is a side effect (IMO perfectly acceptable) because we cannot know the actual error reporting level while handling silenced (by the `@` operator) errors because PHP temporarily modifies the `error_reporting()` level while handling such errors.

Fixes #1195.