### PR TITLE
Remove final for State/Scope

### DIFF
--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -16,7 +16,7 @@ use Sentry\UserDataBag;
  * The scope holds data that should implicitly be sent with Sentry events. It
  * can hold context data, extra parameters, level overrides, fingerprints etc.
  */
-final class Scope
+class Scope
 {
     /**
      * @var Breadcrumb[] The list of breadcrumbs recorded in this scope


### PR DESCRIPTION
Hi! I make error handler for different logic for different environments and other conditions.
While writing unit tests, I ran into the problem that I cannot make a mock for the State/Scope because it is final.
I propose to remove the final.

If you are against, then please add an interface that can be mocked.