### PR TITLE
Try to fix the CI build for PHP 8 + Windows

### DIFF
--- a/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
@@ -1,7 +1,5 @@
 --TEST--
 Test catching out of memory fatal error
---INI--
-memory_limit=64M
 --FILE--
 <?php
 
@@ -34,6 +32,7 @@ $errorHandler->addExceptionHandlerListener(static function (): void {
     echo 'Exception listener called (it should not have been)' . PHP_EOL;
 });
 
+ini_set('memory_limit', '64M');
 $foo = str_repeat('x', 1024 * 1024 * 70);
 ?>
 --EXPECTF--

--- a/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
@@ -34,7 +34,7 @@ $errorHandler->addExceptionHandlerListener(static function (): void {
     echo 'Exception listener called (it should not have been)' . PHP_EOL;
 });
 
-$foo = str_repeat('x', 1024 * 1024 * 70);
+$foo = str_repeat('x', 1024 * 1024 * 1024);
 ?>
 --EXPECTF--
 Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line %d

--- a/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
@@ -24,10 +24,9 @@ $errorHandler->addErrorHandlerListener(static function (): void {
     echo 'Error listener called (it should not have been)' . PHP_EOL;
 });
 
-$errorHandler = ErrorHandler::registerOnceFatalErrorHandler();
+$errorHandler = ErrorHandler::registerOnceFatalErrorHandler(1024 * 1024);
 $errorHandler->addFatalErrorHandlerListener(static function (): void {
     echo 'Fatal error listener called' . PHP_EOL;
-    ini_set('memory_limit', -1);
 });
 
 $errorHandler = ErrorHandler::registerOnceExceptionHandler();

--- a/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Test catching out of memory fatal error
+--INI--
+memory_limit=128M
 --FILE--
 <?php
 
@@ -32,7 +34,6 @@ $errorHandler->addExceptionHandlerListener(static function (): void {
     echo 'Exception listener called (it should not have been)' . PHP_EOL;
 });
 
-ini_set('memory_limit', '64M');
 $foo = str_repeat('x', 1024 * 1024 * 70);
 ?>
 --EXPECTF--

--- a/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
+++ b/tests/phpt/error_handler_captures_out_of_memory_fatal_error.phpt
@@ -27,6 +27,7 @@ $errorHandler->addErrorHandlerListener(static function (): void {
 $errorHandler = ErrorHandler::registerOnceFatalErrorHandler();
 $errorHandler->addFatalErrorHandlerListener(static function (): void {
     echo 'Fatal error listener called' . PHP_EOL;
+    ini_set('memory_limit', -1);
 });
 
 $errorHandler = ErrorHandler::registerOnceExceptionHandler();


### PR DESCRIPTION
We have a PHPT test that is randomly failing under PHP 8 + Windows due to memory constraints:
 * https://github.com/getsentry/sentry-php/pull/1199/checks?check_run_id=2129595114#step:9:43
 * https://github.com/getsentry/sentry-php/runs/2095230888?check_suite_focus=true#step:9:42
 * https://github.com/getsentry/sentry-php/runs/2085509080?check_suite_focus=true#step:9:43
 * https://github.com/getsentry/sentry-php/runs/2084796288?check_suite_focus=true#step:9:43

Since we can alter that memory constraint once the error is triggered, this should fix the test for good.