### PR TITLE
Get request data from event

### DIFF
--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -122,13 +122,13 @@ final class RequestIntegration implements IntegrationInterface
             return;
         }
 
-        $requestData = [
-            'url' => (string) $request->getUri(),
-            'method' => $request->getMethod(),
-        ];
+        $requestData = $event->getRequest();
+
+        $requestData['url'] = $requestData['url'] ?? (string) $request->getUri();
+        $requestData['method'] = $requestData['method'] ?? $request->getMethod();
 
         if ($request->getUri()->getQuery()) {
-            $requestData['query_string'] = $request->getUri()->getQuery();
+            $requestData['query_string'] = $requestData['query_string'] ?? $request->getUri()->getQuery();
         }
 
         if ($options->shouldSendDefaultPii()) {
@@ -136,7 +136,7 @@ final class RequestIntegration implements IntegrationInterface
 
             if (isset($serverParams['REMOTE_ADDR'])) {
                 $user = $event->getUser();
-                $requestData['env']['REMOTE_ADDR'] = $serverParams['REMOTE_ADDR'];
+                $requestData['env']['REMOTE_ADDR'] = $requestData['env']['REMOTE_ADDR'] ?? $serverParams['REMOTE_ADDR'];
 
                 if (null === $user) {
                     $user = UserDataBag::createFromUserIpAddress($serverParams['REMOTE_ADDR']);
@@ -147,16 +147,16 @@ final class RequestIntegration implements IntegrationInterface
                 $event->setUser($user);
             }
 
-            $requestData['cookies'] = $request->getCookieParams();
-            $requestData['headers'] = $request->getHeaders();
+            $requestData['cookies'] = $requestData['cookies'] ?? $request->getCookieParams();
+            $requestData['headers'] = $requestData['headers'] ?? $request->getHeaders();
         } else {
-            $requestData['headers'] = $this->sanitizeHeaders($request->getHeaders());
+            $requestData['headers'] = $this->sanitizeHeaders($requestData['headers'] ?? $request->getHeaders());
         }
 
         $requestBody = $this->captureRequestBody($options, $request);
 
         if (!empty($requestBody)) {
-            $requestData['data'] = $requestBody;
+            $requestData['data'] = $requestData['data'] ?? $requestBody;
         }
 
         $event->setRequest($requestData);


### PR DESCRIPTION
It might be better to get the requested data from the event, otherwise, the src/Integration/RequestIntegration.php class will overwrite the previous data.

For example, I create a CustomRequestIntegration.php.

```php
final class CustomRequestIntegration implements IntegrationInterface
{
    public function setupOnce(): void
    {
        Scope::addGlobalEventProcessor(function (Event $event): Event {
            $event->setRequest([
                'data' => [
                    'custom_key' => 'value'
                ]
            ]);

            return $event;
        });
    }
}
```

In Laravel, the order of src/Integration/RequestIntegration.php will be executed last.

https://github.com/getsentry/sentry-laravel/blob/c2494c16335da24029b73b9358cd843ec7c82620/src/Sentry/Laravel/ServiceProvider.php#L191-L203

The [src/Integration/RequestIntegration.php](https://github.com/getsentry/sentry-php/blob/1b4acb089c63246d1a6f074e4b5ebcfe80be2057/src/Integration/RequestIntegration.php#L162) will overwrite the custom key.