### PR TITLE
Fatal Error Listener: Allow configuring of error limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Allow setting a custom amount of memory for the FatalErrorHandler. (#1214)
 - Allow setting a custom timestamp on the breadcrumbs (#1193)
 - Add option `ignore_tags` to `IgnoreErrorsIntegration` in order to ignore exceptions by tags values. (#1201)
 

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -22,7 +22,7 @@ final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegrati
     {
         $client = SentrySdk::getCurrentHub()->getClient();
         $reservedMemory = $client
-         ? $client->getOptions()->getFatalReservedMemory()
+         ? $client->getOptions()->getFatalErrorHandlerReservedMemoryAmount()
          : ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
         $errorHandler = ErrorHandler::registerOnceFatalErrorHandler($reservedMemory);
         $errorHandler->addFatalErrorHandlerListener(static function (FatalErrorException $exception): void {

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -20,7 +20,11 @@ final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegrati
      */
     public function setupOnce(): void
     {
-        $errorHandler = ErrorHandler::registerOnceFatalErrorHandler();
+        $client = SentrySdk::getCurrentHub()->getClient();
+        $reservedMemory = $client
+         ? $client->getOptions()->getFatalReservedMemory() ?? ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE
+         : ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
+        $errorHandler = ErrorHandler::registerOnceFatalErrorHandler($reservedMemory);
         $errorHandler->addFatalErrorHandlerListener(static function (FatalErrorException $exception): void {
             $currentHub = SentrySdk::getCurrentHub();
             $integration = $currentHub->getIntegration(self::class);

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -22,7 +22,7 @@ final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegrati
     {
         $client = SentrySdk::getCurrentHub()->getClient();
         $reservedMemory = $client
-         ? $client->getOptions()->getFatalReservedMemory() ?? ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE
+         ? $client->getOptions()->getFatalReservedMemory()
          : ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
         $errorHandler = ErrorHandler::registerOnceFatalErrorHandler($reservedMemory);
         $errorHandler->addFatalErrorHandlerListener(static function (FatalErrorException $exception): void {

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -24,6 +24,7 @@ final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegrati
         $reservedMemory = $client
          ? $client->getOptions()->getFatalErrorHandlerReservedMemoryAmount()
          : ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
+
         $errorHandler = ErrorHandler::registerOnceFatalErrorHandler($reservedMemory);
         $errorHandler->addFatalErrorHandlerListener(static function (FatalErrorException $exception): void {
             $currentHub = SentrySdk::getCurrentHub();

--- a/src/Options.php
+++ b/src/Options.php
@@ -687,6 +687,24 @@ final class Options
     }
 
     /**
+     * Gets the amount of memory to reserve in case of a fatal error.
+     * The number is in bytes. Null indicated the default should be used.
+     */
+    public function getFatalReservedMemory(): ?int
+    {
+        return $this->options['fatal_error_reserved_memory'];
+    }
+
+    /**
+     * Sets the amount of memory to reserve in case of a fatal error.
+     * The number is in bytes. Null indicated the default should be used.
+     */
+    public function setFatalReservedMemory(?int $reservedMemory): void
+    {
+        $this->options['fatal_error_reserved_memory'] = $reservedMemory;
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -729,6 +747,7 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
+            'fatal_error_reserved_memory' => null,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -759,6 +778,7 @@ final class Options
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
+        $resolver->setAllowedTypes('fatal_error_reserved_memory', ['null', 'int']);
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -692,7 +692,7 @@ final class Options
      */
     public function getFatalReservedMemory(): int
     {
-        return $this->options['fatal_error_reserved_memory'] ?? ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
+        return $this->options['fatal_error_handler_reserved_memory_amount'] ?? ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
     }
 
     /**
@@ -701,7 +701,7 @@ final class Options
      */
     public function setFatalReservedMemory(?int $reservedMemory): void
     {
-        $this->options['fatal_error_reserved_memory'] = $reservedMemory;
+        $this->options['fatal_error_handler_reserved_memory_amount'] = $reservedMemory;
     }
 
     /**
@@ -747,7 +747,7 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
-            'fatal_error_reserved_memory' => null,
+            'fatal_error_handler_reserved_memory_amount' => null,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -778,7 +778,7 @@ final class Options
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
-        $resolver->setAllowedTypes('fatal_error_reserved_memory', ['null', 'int']);
+        $resolver->setAllowedTypes('fatal_error_handler_reserved_memory_amount', ['null', 'int']);
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -747,7 +747,7 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
-            'fatal_error_handler_reserved_memory_amount' => null,
+            'fatal_error_handler_reserved_memory_amount' => ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -778,7 +778,7 @@ final class Options
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
-        $resolver->setAllowedTypes('fatal_error_handler_reserved_memory_amount', ['null', 'int']);
+        $resolver->setAllowedTypes('fatal_error_handler_reserved_memory_amount', 'int');
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -688,11 +688,11 @@ final class Options
 
     /**
      * Gets the amount of memory to reserve in case of a fatal error.
-     * The number is in bytes. Null indicated the default should be used.
+     * The number is in bytes.
      */
-    public function getFatalReservedMemory(): ?int
+    public function getFatalReservedMemory(): int
     {
-        return $this->options['fatal_error_reserved_memory'];
+        return $this->options['fatal_error_reserved_memory'] ?? ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
     }
 
     /**

--- a/src/Options.php
+++ b/src/Options.php
@@ -690,7 +690,7 @@ final class Options
      * Gets the amount of memory to reserve in case of a fatal error.
      * The number is in bytes.
      */
-    public function getFatalReservedMemory(): int
+    public function getFatalErrorHandlerReservedMemoryAmount(): int
     {
         return $this->options['fatal_error_handler_reserved_memory_amount'] ?? ErrorHandler::DEFAULT_RESERVED_MEMORY_SIZE;
     }
@@ -699,7 +699,7 @@ final class Options
      * Sets the amount of memory to reserve in case of a fatal error.
      * The number is in bytes. Null indicated the default should be used.
      */
-    public function setFatalReservedMemory(?int $reservedMemory): void
+    public function setFatalErrorHandlerReservedMemoryAmount(?int $reservedMemory): void
     {
         $this->options['fatal_error_handler_reserved_memory_amount'] = $reservedMemory;
     }

--- a/src/Options.php
+++ b/src/Options.php
@@ -696,15 +696,6 @@ final class Options
     }
 
     /**
-     * Sets the amount of memory to reserve in case of a fatal error.
-     * The number is in bytes. Null indicated the default should be used.
-     */
-    public function setFatalErrorHandlerReservedMemoryAmount(?int $reservedMemory): void
-    {
-        $this->options['fatal_error_handler_reserved_memory_amount'] = $reservedMemory;
-    }
-
-    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -291,6 +291,15 @@ final class OptionsTest extends TestCase
             null,
             null,
         ];
+
+        yield [
+            'fatal_error_reserved_memory',
+            null,
+            'getFatalReservedMemory',
+            'setFatalReservedMemory',
+            null,
+            null,
+        ];
     }
 
     /**

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -294,7 +294,7 @@ final class OptionsTest extends TestCase
 
         yield [
             'fatal_error_handler_reserved_memory_amount',
-            null,
+            10240,
             'getFatalErrorHandlerReservedMemoryAmount',
             'setFatalErrorHandlerReservedMemoryAmount',
             null,

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -296,7 +296,7 @@ final class OptionsTest extends TestCase
             'fatal_error_handler_reserved_memory_amount',
             10240,
             'getFatalErrorHandlerReservedMemoryAmount',
-            'setFatalErrorHandlerReservedMemoryAmount',
+            null,
             null,
             null,
         ];

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -295,8 +295,8 @@ final class OptionsTest extends TestCase
         yield [
             'fatal_error_handler_reserved_memory_amount',
             null,
-            'getFatalReservedMemory',
-            'setFatalReservedMemory',
+            'getFatalErrorHandlerReservedMemoryAmount',
+            'setFatalErrorHandlerReservedMemoryAmount',
             null,
             null,
         ];

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -293,7 +293,7 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
-            'fatal_error_reserved_memory',
+            'fatal_error_handler_reserved_memory_amount',
             null,
             'getFatalReservedMemory',
             'setFatalReservedMemory',


### PR DESCRIPTION
From the looks of the code, this was meant to be configurable, but
was never lifted up into a user option. We ran into a case where we needed
to bump the reserved memory (currently doing so with a custom integration).

This change does not affect the interface of registerOnceFatalErrorHandler
thus is backwards compatible.

I believe the code can be a bit cleaner if we can change the param to be ?int