### PR TITLE
Add user capturing for Monolog handler

### DIFF
--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -61,6 +61,10 @@ final class Handler extends AbstractProcessingHandler
             $scope->setExtra('monolog.channel', $record['channel']);
             $scope->setExtra('monolog.level', $record['level_name']);
 
+            if (!empty($record['context']['user'])) {
+                $scope->setUser($record['context']['user']);
+            }
+
             $this->hub->captureEvent($event, $hint);
         });
     }


### PR DESCRIPTION
Hi! It would be great to have user identification feature for Monolog handler.

https://docs.sentry.io/platforms/php/enriching-events/identify-user/