### PR TITLE
Fix missing frames's arguments when calling `captureEvent()` without explicit stacktrace or exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix missing collecting of frames's arguments when using `captureEvent()` without expliciting a stacktrace or an exception (#1223)
+
 ## 3.3.0 (2021-05-26)
 
 - Allow setting a custom timestamp on the breadcrumbs (#1193)

--- a/src/Client.php
+++ b/src/Client.php
@@ -298,7 +298,7 @@ final class Client implements ClientInterface
         }
 
         $event->setStacktrace($this->stacktraceBuilder->buildFromBacktrace(
-            debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS),
+            debug_backtrace(0),
             __FILE__,
             __LINE__ - 3
         ));


### PR DESCRIPTION
Fixes #1220 by removing the `DEBUG_BACKTRACE_IGNORE_ARGS` constant from the call to the `debug_backtrace()` function. I think I've used it to lower the memory usage, however it makes sense to collect these information.