### PR TITLE
Allow guzzlehttp/psr7 ^2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow installation of `guzzlehttp/psr7:^2.0` (#1225)
+
 ## 3.3.1 (2021-06-21)
 
 - Fix missing collecting of frames's arguments when using `captureEvent()` without expliciting a stacktrace or an exception (#1223)

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.4",
-        "guzzlehttp/psr7": "^1.7",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "jean85/pretty-package-versions": "^1.5|^2.0.1",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",


### PR DESCRIPTION
As far as I can tell there are no breaking changes for what we are using from the package so it's safe to require both 1.x and 2.x.

See: https://github.com/guzzle/psr7/blob/1dc8d9cba3897165e16d12bb13d813afb1eb3fe7/CHANGELOG.md.

This also eases the installation where 2.0 was already required by earlier dependencies: getsentry/sentry-laravel#500, getsentry/sentry-laravel#501 & getsentry/sentry-laravel#502.