### PR TITLE
Set scope context based on record

### DIFF
--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -60,6 +60,7 @@ final class Handler extends AbstractProcessingHandler
         $this->hub->withScope(function (Scope $scope) use ($record, $event, $hint): void {
             $scope->setExtra('monolog.channel', $record['channel']);
             $scope->setExtra('monolog.level', $record['level_name']);
+            $scope->setContext('context', $record['context']);
 
             $this->hub->captureEvent($event, $hint);
         });


### PR DESCRIPTION
This PR sets the context on the log handler, getting it from the current record.

We have some warning that uses context and it's better to understand what was going on.

Here's how it looks when passing big contexts:
<img width="361" alt="Screen Shot 2021-07-09 at 16 22 05" src="https://user-images.githubusercontent.com/1981726/125127197-8be92b00-e0d2-11eb-8ae2-df4efdd862f8.png">


