### PR TITLE
Allow `psr/log` 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "php-http/message": "^1.5",
         "psr/http-factory": "^1.0",
         "psr/http-message-implementation": "^1.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0|^2.0|^3.0",
         "symfony/options-resolver": "^3.4.43|^4.4.11|^5.0.11",
         "symfony/polyfill-php80": "^1.17",
         "symfony/polyfill-uuid": "^1.13.1"


### PR DESCRIPTION
👋🏻 

Versions 2 and 3 of the `psr/log` interfaces have been released with updated type declarations. This library does not provide any own implementations of those interfaces and thus should be compatible right away.