### PR TITLE
Update the Guzzle tracing middleware to meet the expected standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update the Guzzle tracing middleware to meet the [expected standard](https://develop.sentry.dev/sdk/features/#http-client-integrations) (#1234)
+
 ## 3.3.2 (2021-07-19)
 
 - Allow installation of `guzzlehttp/psr7:^2.0` (#1225)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,6 +116,16 @@ parameters:
 			path: src/State/HubInterface.php
 
 		-
+			message: "#^Call to method getResponse\\(\\) on an unknown class GuzzleHttp\\\\Exception\\\\RequestException\\.$#"
+			count: 1
+			path: src/Tracing/GuzzleTracingMiddleware.php
+
+		-
+			message: "#^Class GuzzleHttp\\\\Exception\\\\RequestException not found\\.$#"
+			count: 1
+			path: src/Tracing/GuzzleTracingMiddleware.php
+
+		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureException\\(\\) invoked with 2 parameters, 1 required\\.$#"
 			count: 1
 			path: src/functions.php

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -53,17 +53,17 @@ final class GuzzleTracingMiddleware
                     ];
 
                     if (null !== $response) {
-                        $childSpan->setStatus(SpanStatus::createFromHttpStatusCode($responseOrException->getStatusCode()));
+                        $childSpan->setStatus(SpanStatus::createFromHttpStatusCode($response->getStatusCode()));
 
-                        $breadcrumbData['status_code'] = $responseOrException->getStatusCode();
-                        $breadcrumbData['response_body_size'] = $responseOrException->getBody()->getSize();
+                        $breadcrumbData['status_code'] = $response->getStatusCode();
+                        $breadcrumbData['response_body_size'] = $response->getBody()->getSize();
                     } else {
                         $childSpan->setStatus(SpanStatus::internalError());
                     }
 
                     $hub->addBreadcrumb(new Breadcrumb(
                         Breadcrumb::LEVEL_INFO,
-                        'http',
+                        Breadcrumb::TYPE_HTTP,
                         'http',
                         null,
                         $breadcrumbData

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -43,9 +43,9 @@ final class GuzzleTracingMiddleware
 
                     $response = null;
 
+                    /** @psalm-suppress UndefinedClass */
                     if ($responseOrException instanceof ResponseInterface) {
                         $response = $responseOrException;
-                    /** @psalm-suppress UndefinedClass */
                     } elseif ($responseOrException instanceof GuzzleRequestException) {
                         $response = $responseOrException->getResponse();
                     }

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Tracing;
 
+use Closure;
+use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 
@@ -13,26 +16,52 @@ use Sentry\State\HubInterface;
  */
 final class GuzzleTracingMiddleware
 {
-    public static function trace(?HubInterface $hub = null): \Closure
+    public static function trace(?HubInterface $hub = null): Closure
     {
-        return function (callable $handler) use ($hub): \Closure {
-            return function (RequestInterface $request, array $options) use ($hub, $handler) {
+        return static function (callable $handler) use ($hub): Closure {
+            return static function (RequestInterface $request, array $options) use ($hub, $handler) {
                 $hub = $hub ?? SentrySdk::getCurrentHub();
                 $span = $hub->getSpan();
-                $childSpan = null;
 
-                if (null !== $span) {
-                    $spanContext = new SpanContext();
-                    $spanContext->setOp('http.guzzle');
-                    $spanContext->setDescription($request->getMethod() . ' ' . $request->getUri());
-
-                    $childSpan = $span->startChild($spanContext);
+                if (null === $span) {
+                    return $handler($request, $options);
                 }
 
+                $spanContext = new SpanContext();
+                $spanContext->setOp('http.client');
+                $spanContext->setData([
+                    'url' => (string) $request->getUri(),
+                    'method' => $request->getMethod(),
+                    'request_body_size' => $request->getBody()->getSize(),
+                ]);
+                $spanContext->setDescription($request->getMethod() . ' ' . $request->getUri());
+
+                $childSpan = $span->startChild($spanContext);
+
+                $request->withHeader('sentry-trace', $childSpan->toTraceparent());
+
                 $handlerPromiseCallback = static function ($responseOrException) use ($childSpan) {
-                    if (null !== $childSpan) {
-                        $childSpan->finish();
+                    $response = $responseOrException instanceof ResponseInterface ? $responseOrException : null;
+
+                    /** @psalm-suppress UndefinedClass */
+                    if ($responseOrException instanceof GuzzleRequestException) {
+                        $response = $responseOrException->getResponse();
                     }
+
+                    if (null !== $response) {
+                        $spanData = $childSpan->getData();
+
+                        $childSpan->setStatus(SpanStatus::createFromHttpStatusCode($responseOrException->getStatusCode()));
+
+                        $spanData['status_code'] = $responseOrException->getStatusCode();
+                        $spanData['response_body_size'] = $responseOrException->getBody()->getSize();
+
+                        $childSpan->setData($spanData);
+                    } else {
+                        $childSpan->setStatus(SpanStatus::internalError());
+                    }
+
+                    $childSpan->finish();
 
                     if ($responseOrException instanceof \Throwable) {
                         throw $responseOrException;

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -39,7 +39,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
             ->with($this->callback(function (Event $eventArg) use ($hub, $expectedPromiseResult): bool {
                 $this->assertSame(EventType::transaction(), $eventArg->getType());
 
-                $hub->configureScope(function (Scope $scope) use ($eventArg) {
+                $hub->configureScope(static function (Scope $scope) use ($eventArg): void {
                     $scope->applyToEvent($eventArg);
                 });
 

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -104,7 +104,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'request_body_size' => 0,
                 'status_code' => 200,
                 'response_body_size' => 0,
-            ]
+            ],
         ];
 
         yield [
@@ -116,7 +116,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'request_body_size' => 10,
                 'status_code' => 403,
                 'response_body_size' => 6,
-            ]
+            ],
         ];
 
         yield [
@@ -126,7 +126,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'url' => 'https://www.example.com',
                 'method' => 'GET',
                 'request_body_size' => 0,
-            ]
+            ],
         ];
 
         yield [
@@ -136,7 +136,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'url' => 'https://www.example.com',
                 'method' => 'POST',
                 'request_body_size' => 6,
-            ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
As described here: https://develop.sentry.dev/sdk/features/#http-client-integrations.

- [x] Use correct operation name for HTTP client spans
- [x] Add `sentry-trace` header to HTTP client requests
- [x] Convert some data to be included in a breadcrumb

Fixes: #1233.