### PR TITLE
nikic/php-parser dependency resolution to major version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "friendsofphp/php-cs-fixer": "^2.17",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.3|^2.0",
-        "nikic/php-parser": "^4.10.3",
+        "nikic/php-parser": "^4.10",
         "php-http/mock-client": "^1.3",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",


### PR DESCRIPTION
There is no reason to lock this dependency on patch version, because minor changes don't have breaking changes.