### PR TITLE
Allow passed context data to be sent into sentry

### DIFF
--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -51,6 +51,11 @@ final class Handler extends AbstractProcessingHandler
 
         if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Throwable) {
             $hint->exception = $record['context']['exception'];
+            unset($record['context']['exception']);
+        }
+
+        if (!empty($record['context'])) {
+            $event->setContext('context', $record['context']);
         }
 
         $this->hub->withScope(function (Scope $scope) use ($record, $event, $hint): void {


### PR DESCRIPTION
Currently if you pass additional context to monolog (through `$logger->error('My error', ['my_context' => 'data'])`) the current sentry handler ignores that information.  With this proposed change, we can maintain the functionality around context with exceptions, but if additional context is passed, we send that to sentry as well.