### PR TITLE
Replace findUrlFactory with findUriFactory for Psr17FactoryDiscovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "jean85/pretty-package-versions": "^1.5|^2.0.1",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
-        "php-http/discovery": "^1.6.1",
+        "php-http/discovery": "^1.11",
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-factory": "^1.0",

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -186,7 +186,7 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
+            Psr17FactoryDiscovery::findUriFactory(),
             Psr17FactoryDiscovery::findResponseFactory(),
             $streamFactory,
             $this->httpClient,


### PR DESCRIPTION
https://github.com/php-http/discovery/blob/master/src/Psr17FactoryDiscovery.php#L125-L135

```php
    /**
     * @return UriFactoryInterface
     *
     * @throws Exception\NotFoundException
     *
     * @deprecated This will be removed in 2.0. Consider using the findUriFactory() method.
     */
    public static function findUrlFactory()
    {
        return static::findUriFactory();
    }
```