### PR TITLE
Run the test suite against PHP `8.1`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,7 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+          - '8.1'
         dependencies:
           - lowest
           - highest


### PR DESCRIPTION
As per title, let's add PHP `8.1` to the test suite to be ready for its release