### PR TITLE
Verify availability of php_uname in EnvironmentIntegration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Verify availability of `php_uname` in `EnvironmentIntegration` (#1243)
+
 ## 3.3.2 (2021-07-19)
 
 - Allow installation of `guzzlehttp/psr7:^2.0` (#1225)

--- a/src/Integration/EnvironmentIntegration.php
+++ b/src/Integration/EnvironmentIntegration.php
@@ -50,8 +50,8 @@ final class EnvironmentIntegration implements IntegrationInterface
 
     private function updateServerOsContext(?OsContext $osContext): ?OsContext
     {
-        if (!function_exists('php_uname')) {
-            return null;
+        if (!\function_exists('php_uname')) {
+            return $osContext;
         }
 
         if (null === $osContext) {

--- a/src/Integration/EnvironmentIntegration.php
+++ b/src/Integration/EnvironmentIntegration.php
@@ -28,7 +28,10 @@ final class EnvironmentIntegration implements IntegrationInterface
 
             if (null !== $integration) {
                 $event->setRuntimeContext($integration->updateRuntimeContext($event->getRuntimeContext()));
-                $event->setOsContext($integration->updateServerOsContext($event->getOsContext()));
+
+                if (function_exists('php_uname')) {
+                    $event->setOsContext($integration->updateServerOsContext($event->getOsContext()));
+                }
             }
 
             return $event;

--- a/src/Integration/EnvironmentIntegration.php
+++ b/src/Integration/EnvironmentIntegration.php
@@ -28,10 +28,7 @@ final class EnvironmentIntegration implements IntegrationInterface
 
             if (null !== $integration) {
                 $event->setRuntimeContext($integration->updateRuntimeContext($event->getRuntimeContext()));
-
-                if (function_exists('php_uname')) {
-                    $event->setOsContext($integration->updateServerOsContext($event->getOsContext()));
-                }
+                $event->setOsContext($integration->updateServerOsContext($event->getOsContext()));
             }
 
             return $event;
@@ -51,8 +48,12 @@ final class EnvironmentIntegration implements IntegrationInterface
         return $runtimeContext;
     }
 
-    private function updateServerOsContext(?OsContext $osContext): OsContext
+    private function updateServerOsContext(?OsContext $osContext): ?OsContext
     {
+        if (!function_exists('php_uname')) {
+            return null;
+        }
+
         if (null === $osContext) {
             $osContext = new OsContext(php_uname('s'));
         }


### PR DESCRIPTION
Per #1243, some hosting environments disable the use of `php_uname`. When using `EnvironmentIntegration` (enabled by default) in these environments, errors like this occur:

```
PHP Fatal error: Uncaught TypeError: Argument 1 passed to Sentry\Context\OsContext::__construct() must be of the type string, null given, called in [...]/src/Integration/EnvironmentIntegration.php on line 46 and defined in [...]/src/Context/OsContext.php:37
```

This small change updates `EnvironmentIntegration` to check for the existence of `php_uname` before calling it.