### PR TITLE
Support PHP 8.1 for sentry-php 2.x

### DIFF
--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -149,7 +149,7 @@ class Context implements \ArrayAccess, \JsonSerializable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->data[$offset];
     }


### PR DESCRIPTION
We can't update to sentry-php 3.x, because of this issue: https://github.com/getsentry/sentry-symfony/issues/421.

With this change we can still use Sentry and upgrade to the latest PHP 8.1. 🙂 

