### PR TITLE
Avoid error when IP address is null for UserDataBag

### DIFF
--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -62,7 +62,7 @@ final class UserDataBag
      *
      * @param string $ipAddress The IP address of the user
      */
-    public static function createFromUserIpAddress(string $ipAddress): self
+    public static function createFromUserIpAddress(?string $ipAddress): self
     {
         return new self(null, null, $ipAddress);
     }


### PR DESCRIPTION
Think it should also be creatable with a null IP Address? 

Used in Symfony getClientIP() can return no IP if no is set: https://github.com/getsentry/sentry-symfony/blob/42787b4f8a8fbff03da56b7291d3de59fb669bfe/src/EventListener/RequestListener.php#L63