### PR TITLE
Return EventId only on successful response

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -162,7 +162,7 @@ final class Client implements ClientInterface
             $response = $this->transport->send($event)->wait();
             $event = $response->getEvent();
 
-            if (null !== $event) {
+            if (null !== $event && $response->getStatus() === ResponseStatus::success()) {
                 return $event->getId();
             }
         } catch (\Throwable $exception) {


### PR DESCRIPTION
Related to this one: https://github.com/getsentry/sentry-symfony/issues/372

I wasn't able to test this properly yet (will do asap), but at least PHPUnit says "ok".

Feel free to reject it since it feels a bit too simple.