### PR TITLE
Add 3rd party integration for CakePHP to REAME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The following integrations are available and maintained by members of the Sentry
 - [Neos Flow](https://github.com/networkteam/Networkteam.SentryClient)
 - [OXID eShop](https://github.com/OXIDprojects/sentry)
 - [TYPO3](https://github.com/networkteam/sentry_client)
+- [CakePHP](https://github.com/Connehito/cake-sentry/tree/3.x)
 
 ### 3rd party integrations using old SDK 1.x
 


### PR DESCRIPTION
We created and maintains CakePHP's sentry integration.
The plugin is ready for the latest CakePHP and Sentry SDK 3.2+, and listed on [CakePHP's awesome-list](https://github.com/FriendsOfCake/awesome-cakephp).

If you think it might be useful, please let the community know in the README of this repository.
Thanks!