### PR TITLE
Return original return value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ## 3.3.4 (2021-11-08)
 
-- Update the Guzzle tracing middleware to meet the [expected standard](https://develop.sentry.dev/sdk/features/#http-client-integrations) (#1234)
+- Update Guzzle tracing middleware to meet the [expected standard](https://develop.sentry.dev/sdk/features/#http-client-integrations) (#1234)
 - Run the test suite against PHP `8.1` (#1245)
 - Avoid overwriting the error level set by the user on the event when capturing an `ErrorException` exception (#1251)
 - Allow installing the project alongside Symfony `6.x` components (#1257)
 - Add `toArray` public method in `PayloadSerializer` to be able to re-use Event serialization
+- The `withScope` methods now return the callback's return value (#1263)
 
 ## 3.3.3 (2021-10-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ## 3.3.4 (2021-11-08)
 
-- Run the test suite against PHP `8.1` (#1245)
 - Avoid overwriting the error level set by the user on the event when capturing an `ErrorException` exception (#1251)
 - Allow installing the project alongside Symfony `6.x` components (#1257)
+- Run the test suite against PHP `8.1` (#1245)
 
 ## 3.3.3 (2021-10-04)
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -85,12 +85,12 @@ final class Hub implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function withScope(callable $callback): void
+    public function withScope(callable $callback)
     {
         $scope = $this->pushScope();
 
         try {
-            $callback($scope);
+            return $callback($scope);
         } finally {
             $this->popScope();
         }

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -82,9 +82,9 @@ final class HubAdapter implements HubInterface
     /**
      * {@inheritdoc}
      */
-    public function withScope(callable $callback): void
+    public function withScope(callable $callback)
     {
-        SentrySdk::getCurrentHub()->withScope($callback);
+        return SentrySdk::getCurrentHub()->withScope($callback);
     }
 
     /**

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -54,8 +54,9 @@ interface HubInterface
      * is automatically removed once the operation finishes or throws.
      *
      * @param callable $callback The callback to be executed
+     * @return mixed|void The callback's return value
      */
-    public function withScope(callable $callback): void;
+    public function withScope(callable $callback);
 
     /**
      * Calls the given callback passing to it the current scope so that any

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -56,6 +56,10 @@ interface HubInterface
      * @param callable $callback The callback to be executed
      *
      * @return mixed|void The callback's return value, upon successful execution
+     *
+     * @phpstan-template T
+     * @phpstan-param callable(Scope): T $callback
+     * @phpstan-return T
      */
     public function withScope(callable $callback);
 

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -54,7 +54,8 @@ interface HubInterface
      * is automatically removed once the operation finishes or throws.
      *
      * @param callable $callback The callback to be executed
-     * @return mixed|void The callback's return value
+     *
+     * @return mixed|void The callback's return value, upon successful execution
      */
     public function withScope(callable $callback);
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -94,7 +94,8 @@ function configureScope(callable $callback): void
  * is automatically removed once the operation finishes or throws.
  *
  * @param callable $callback The callback to be executed
- * @return mixed|void The callback's return value
+ *
+ * @return mixed|void The callback's return value, upon successful execution
  */
 function withScope(callable $callback)
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Sentry\State\Scope;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 
@@ -96,6 +97,10 @@ function configureScope(callable $callback): void
  * @param callable $callback The callback to be executed
  *
  * @return mixed|void The callback's return value, upon successful execution
+ *
+ * @phpstan-template T
+ * @phpstan-param callable(Scope): T $callback
+ * @phpstan-return T
  */
 function withScope(callable $callback)
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -94,10 +94,11 @@ function configureScope(callable $callback): void
  * is automatically removed once the operation finishes or throws.
  *
  * @param callable $callback The callback to be executed
+ * @return mixed|void The callback's return value
  */
-function withScope(callable $callback): void
+function withScope(callable $callback)
 {
-    SentrySdk::getCurrentHub()->withScope($callback);
+    return SentrySdk::getCurrentHub()->withScope($callback);
 }
 
 /**

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -206,6 +206,15 @@ final class FunctionsTest extends TestCase
         $this->assertTrue($callbackInvoked);
     }
 
+    public function testWithScopeWithCallback(): void
+    {
+        $callbackReturned = withScope(static function () use (&$callbackReturned): bool {
+            return true;
+        });
+
+        $this->assertTrue($callbackReturned);
+    }
+
     public function testConfigureScope(): void
     {
         $callbackInvoked = false;

--- a/tests/State/HubAdapterTest.php
+++ b/tests/State/HubAdapterTest.php
@@ -94,19 +94,6 @@ final class HubAdapterTest extends TestCase
 
     public function testWithScope(): void
     {
-        $callback = static function () {};
-
-        $hub = $this->createMock(HubInterface::class);
-        $hub->expects($this->once())
-            ->method('withScope')
-            ->with($callback);
-
-        SentrySdk::setCurrentHub($hub);
-        HubAdapter::getInstance()->withScope($callback);
-    }
-
-    public function testWithScopeWithReturnValue(): void
-    {
         $callback = static function () {
             return true;
         };
@@ -115,7 +102,7 @@ final class HubAdapterTest extends TestCase
         $hub->expects($this->once())
             ->method('withScope')
             ->with($callback)
-            ->willReturn(true);
+            ->willReturnCallback($callback);
 
         SentrySdk::setCurrentHub($hub);
         $value = HubAdapter::getInstance()->withScope($callback);

--- a/tests/State/HubAdapterTest.php
+++ b/tests/State/HubAdapterTest.php
@@ -105,6 +105,23 @@ final class HubAdapterTest extends TestCase
         HubAdapter::getInstance()->withScope($callback);
     }
 
+    public function testWithScopeWithReturnValue(): void
+    {
+        $callback = static function () {
+            return true;
+        };
+
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
+            ->method('withScope')
+            ->with($callback)
+            ->willReturn(true);
+
+        SentrySdk::setCurrentHub($hub);
+        $value = HubAdapter::getInstance()->withScope($callback);
+        $this->assertTrue($value);
+    }
+
     public function testConfigureScope(): void
     {
         $callback = static function () {};

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -155,6 +155,7 @@ final class HubTest extends TestCase
 
         $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
             $this->assertNotSame($scope1, $scope2);
+
             return true;
         });
 

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -136,42 +136,11 @@ final class HubTest extends TestCase
 
     public function testWithScope(): void
     {
-        $scope = new Scope();
-        $hub = new Hub($this->createMock(ClientInterface::class), $scope);
-        $callbackInvoked = false;
-
-        try {
-            $hub->withScope(function (Scope $scopeArg) use ($scope, &$callbackInvoked): void {
-                $this->assertNotSame($scope, $scopeArg);
-
-                $callbackInvoked = true;
-
-                // We throw to test that the scope is correctly popped form the
-                // stack regardless
-                throw new \RuntimeException();
-            });
-        } catch (\RuntimeException $exception) {
-            // Do nothing, we catch this exception to not make the test fail
-        }
-
-        $this->assertTrue($callbackInvoked);
-
-        $callbackInvoked = false;
-
-        $hub->configureScope(function (Scope $scopeArg) use (&$callbackInvoked, $scope): void {
-            $this->assertSame($scope, $scopeArg);
-
-            $callbackInvoked = true;
-        });
-
-        $this->assertTrue($callbackInvoked);
-    }
-
-    public function testWithScopeWithReturnValue(): void
-    {
         $scope1 = new Scope();
         $hub = new Hub($this->createMock(ClientInterface::class), $scope1);
+
         $returned = false;
+
         try {
             $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
                 $this->assertNotSame($scope1, $scope2);
@@ -183,15 +152,11 @@ final class HubTest extends TestCase
         }
 
         $this->assertFalse($returned);
-        $returned = false;
-        try {
-            $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
-                $this->assertNotSame($scope1, $scope2);
 
-                return true;
-            });
-        } catch (\RuntimeException $ignore) {
-        }
+        $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
+            $this->assertNotSame($scope1, $scope2);
+            return true;
+        });
 
         $this->assertTrue($returned);
     }

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -167,6 +167,33 @@ final class HubTest extends TestCase
         $this->assertTrue($callbackInvoked);
     }
 
+    public function testWithScopeWithReturnValue(): void
+    {
+        $scope1 = new Scope();
+        $hub = new Hub($this->createMock(ClientInterface::class), $scope1);
+        $returned = false;
+        try {
+            $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
+                $this->assertNotSame($scope1, $scope2);
+                throw new \RuntimeException();
+                return true;
+            });
+        } catch (\RuntimeException $ignore) {
+        }
+
+        $this->assertFalse($returned);
+        $returned = false;
+        try {
+            $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
+                $this->assertNotSame($scope1, $scope2);
+                return true;
+            });
+        } catch (\RuntimeException $ignore) {
+        }
+
+        $this->assertTrue($returned);
+    }
+
     public function testConfigureScope(): void
     {
         $scope = new Scope();

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -176,6 +176,7 @@ final class HubTest extends TestCase
             $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
                 $this->assertNotSame($scope1, $scope2);
                 throw new \RuntimeException();
+
                 return true;
             });
         } catch (\RuntimeException $ignore) {
@@ -186,6 +187,7 @@ final class HubTest extends TestCase
         try {
             $returned = $hub->withScope(function (Scope $scope2) use ($scope1): bool {
                 $this->assertNotSame($scope1, $scope2);
+
                 return true;
             });
         } catch (\RuntimeException $ignore) {


### PR DESCRIPTION
The `withScope` method is very useful to push local scope to error that happen during specific executions. But what if we rely on return values from the execution? It can be handled in a ugly way as below using current code.

```php
$success = false;

Sentry\withScope(function (Sentry\State\Scope $scope) use ($processor, $job, &$success) {
    $scope->setUser([
        'username' => $job->user->username,
    ]);
    $success = $processor->processJob($job);
});

if ($success) {
    // do whatever
}
```

The goal of this PR to simplify above as below:

```php
$success = Sentry\withScope(function (Sentry\State\Scope $scope) use ($processor, $job) {
    $scope->setUser([
        'username' => $job->user->username,
    ]);
    return $processor->processJob($job);
});
```

IMO this is cleaner and doesn't introduce any backwards incompatibility with existing code as well.