### PR TITLE
Support PHP 8.1 for sentry-php 2.x 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.3",

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -149,7 +149,8 @@ class Context implements \ArrayAccess, \JsonSerializable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset): mixed
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
         return $this->data[$offset];
     }

--- a/src/Context/Context.php
+++ b/src/Context/Context.php
@@ -149,7 +149,7 @@ class Context implements \ArrayAccess, \JsonSerializable, \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->data[$offset];
     }

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -243,7 +243,7 @@ class Stacktrace implements \JsonSerializable
      *
      * @return Frame[]
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Stacktrace.php
+++ b/src/Stacktrace.php
@@ -243,7 +243,8 @@ class Stacktrace implements \JsonSerializable
      *
      * @return Frame[]
      */
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->toArray();
     }


### PR DESCRIPTION
We can't update to sentry-php 3.x, because of this issue: https://github.com/getsentry/sentry-symfony/issues/421.

With this change we can still use Sentry and upgrade to the latest PHP 8.1. 🙂 

Fixes:

```
Fatal error:  During inheritance of ArrayAccess: Uncaught ErrorException: Return type of Sentry\Context\Context::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/sentry/sentry/src/Context/Context.php:152
```

(follow-up from https://github.com/getsentry/sentry-php/pull/1247)