### PR TITLE
Bump minor to include fix for composer #9816

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.4",
         "guzzlehttp/psr7": "^1.7|^2.0",
-        "jean85/pretty-package-versions": "^1.5|^2.0.1",
+        "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
         "php-http/discovery": "^1.6.1",


### PR DESCRIPTION
Didn't run the tests yet. Hoping that CI will catch any boo boo's.

Composer https://github.com/composer/composer/releases/tag/2.0.14 introduced a breaking change to something that `pretty-package-versions` depends on. They fixed it in their `2.0.4` release. See:

https://github.com/Jean85/pretty-package-versions/pull/39