### PR TITLE
feat: guzzle middleware add `sentry_trace`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.4",
         "guzzlehttp/psr7": "^1.7|^2.0",
-        "jean85/pretty-package-versions": "^1.5|^2.0.1",
+        "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
         "php-http/discovery": "^1.6.1",

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -41,6 +41,8 @@ final class GuzzleTracingMiddleware
                     return $responseOrException;
                 };
 
+                $request = $request->withHeader("sentry-trace",  $childSpan->toTraceparent());
+
                 return $handler($request, $options)->then($handlerPromiseCallback, $handlerPromiseCallback);
             };
         };


### PR DESCRIPTION
In the Guzzle middleware, add Sentry_Trace. The entire link can be connected in series in Sentry 