### PR TITLE
Update PHPStan, Psalm and PHP-CS-Fixer to the latest versions

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
 
       - name: Install dependencies
         run: composer update --no-progress --no-interaction --prefer-dist

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 package.xml
 /vendor
 .idea
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 docs/_build
 tests/clover.xml

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,19 +1,15 @@
 <?php
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
     ->setRules([
-        '@PSR2' => true,
+        '@PHP71Migration' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        'array_syntax' => ['syntax' => 'short'],
         'concat_space' => ['spacing' => 'one'],
         'ordered_imports' => [
             'imports_order' => ['class', 'function', 'const'],
         ],
         'declare_strict_types' => true,
-        'psr0' => true,
-        'psr4' => true,
-        'random_api_migration' => true,
         'yoda_style' => true,
         'self_accessor' => false,
         'phpdoc_no_useless_inheritdoc' => false,

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "nikic/php-parser": "^4.10.3",
         "php-http/mock-client": "^1.3",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "^0.12",
-        "phpstan/phpstan-phpunit": "^0.12",
+        "phpstan/phpstan": "^1.3",
+        "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^8.5.14|^9.4",
         "symfony/phpunit-bridge": "^5.2|^6.0",
         "vimeo/psalm": "^4.2"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.4",
+        "friendsofphp/php-cs-fixer": "^2.19|^3.4",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.3|^2.0",
         "nikic/php-parser": "^4.10.3",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^8.5.14|^9.4",
         "symfony/phpunit-bridge": "^5.2|^6.0",
-        "vimeo/psalm": "^4.2"
+        "vimeo/psalm": "^4.17"
     },
     "suggest": {
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.17",
+        "friendsofphp/php-cs-fixer": "^3.4",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.3|^2.0",
         "nikic/php-parser": "^4.10.3",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Constructor of class Sentry\\\\Client has an unused parameter \\$serializer\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
 			message: "#^Method Sentry\\\\Client\\:\\:getIntegration\\(\\) should return T of Sentry\\\\Integration\\\\IntegrationInterface\\|null but returns T of Sentry\\\\Integration\\\\IntegrationInterface\\|null\\.$#"
 			count: 1
 			path: src/Client.php
@@ -29,6 +34,11 @@ parameters:
 			message: "#^Offset 'user' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 1
 			path: src/Dsn.php
+
+		-
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\ErrorHandler\\:\\:cleanBacktraceFromErrorHandlerFrames\\(\\) expects array\\<int, array\\{function\\?\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
+			count: 1
+			path: src/ErrorHandler.php
 
 		-
 			message: "#^Result of && is always false\\.$#"
@@ -66,7 +76,162 @@ parameters:
 			path: src/HttpClient/HttpClientFactory.php
 
 		-
+			message: "#^Property Sentry\\\\Integration\\\\IgnoreErrorsIntegration\\:\\:\\$options \\(array\\{ignore_exceptions\\: array\\<int, class\\-string\\<Throwable\\>\\>, ignore_tags\\: array\\<string, string\\>\\}\\) does not accept array\\.$#"
+			count: 1
+			path: src/Integration/IgnoreErrorsIntegration.php
+
+		-
+			message: "#^Property Sentry\\\\Integration\\\\RequestIntegration\\:\\:\\$options \\(array\\{pii_sanitize_headers\\: array\\<string\\>\\}\\) does not accept array\\.$#"
+			count: 1
+			path: src/Integration/RequestIntegration.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getBeforeBreadcrumbCallback\\(\\) should return callable\\(Sentry\\\\Breadcrumb\\)\\: Sentry\\\\Breadcrumb\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getBeforeSendCallback\\(\\) should return callable\\(Sentry\\\\Event, Sentry\\\\EventHint\\|null\\)\\: Sentry\\\\Event\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getClassSerializers\\(\\) should return array\\<string, callable\\(\\)\\: mixed\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getContextLines\\(\\) should return int\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getDsn\\(\\) should return Sentry\\\\Dsn\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getEnvironment\\(\\) should return string\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getErrorTypes\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getHttpProxy\\(\\) should return string\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getInAppExcludedPaths\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getInAppIncludedPaths\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getIntegrations\\(\\) should return array\\<Sentry\\\\Integration\\\\IntegrationInterface\\>\\|\\(callable\\(array\\<Sentry\\\\Integration\\\\IntegrationInterface\\>\\)\\: array\\<Sentry\\\\Integration\\\\IntegrationInterface\\>\\) but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getLogger\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getMaxBreadcrumbs\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getMaxRequestBodySize\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getMaxValueLength\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getPrefixes\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getRelease\\(\\) should return string\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getSampleRate\\(\\) should return float but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getSendAttempts\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getServerName\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getTags\\(\\) should return array\\<string, string\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getTracesSampleRate\\(\\) should return float but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getTracesSampler\\(\\) should return \\(callable\\(\\)\\: mixed\\)\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:hasDefaultIntegrations\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:isCompressionEnabled\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:shouldAttachStacktrace\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:shouldCaptureSilencedErrors\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:shouldSendDefaultPii\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: src/Serializer/AbstractSerializer.php
+
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
 			count: 1
 			path: src/Serializer/AbstractSerializer.php
 
@@ -74,6 +239,11 @@ parameters:
 			message: "#^Method Sentry\\\\Serializer\\\\PayloadSerializer\\:\\:serializeAsEvent\\(\\) should return string but returns string\\|false\\.$#"
 			count: 1
 			path: src/Serializer/PayloadSerializer.php
+
+		-
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\?\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
+			count: 1
+			path: src/StacktraceBuilder.php
 
 		-
 			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureException\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
@@ -124,6 +294,26 @@ parameters:
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Tracing/SpanContext.php
+
+		-
+			message: "#^Parameter \\#1 \\$email of method Sentry\\\\UserDataBag\\:\\:setEmail\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/UserDataBag.php
+
+		-
+			message: "#^Parameter \\#1 \\$id of method Sentry\\\\UserDataBag\\:\\:setId\\(\\) expects int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/UserDataBag.php
+
+		-
+			message: "#^Parameter \\#1 \\$ipAddress of method Sentry\\\\UserDataBag\\:\\:setIpAddress\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/UserDataBag.php
+
+		-
+			message: "#^Parameter \\#1 \\$username of method Sentry\\\\UserDataBag\\:\\:setUsername\\(\\) expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/UserDataBag.php
 
 		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureException\\(\\) invoked with 2 parameters, 1 required\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,22 +11,22 @@ parameters:
 			path: src/ClientInterface.php
 
 		-
-			message: "#^Offset 'host' does not exist on array\\(\\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string, 'scheme' \\=\\> 'http'\\|'https'\\)\\.$#"
+			message: "#^Offset 'host' does not exist on array\\{host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string, scheme\\: 'http'\\|'https'\\}\\.$#"
 			count: 1
 			path: src/Dsn.php
 
 		-
-			message: "#^Offset 'path' does not exist on array\\(\\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string, 'scheme' \\=\\> 'http'\\|'https'\\)\\.$#"
+			message: "#^Offset 'path' does not exist on array\\{host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string, scheme\\: 'http'\\|'https'\\}\\.$#"
 			count: 4
 			path: src/Dsn.php
 
 		-
-			message: "#^Offset 'scheme' does not exist on array\\(\\?'scheme' \\=\\> string, \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\.$#"
+			message: "#^Offset 'scheme' does not exist on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 1
 			path: src/Dsn.php
 
 		-
-			message: "#^Offset 'user' does not exist on array\\('scheme' \\=\\> 'http'\\|'https', \\?'host' \\=\\> string, \\?'port' \\=\\> int, \\?'user' \\=\\> string, \\?'pass' \\=\\> string, \\?'path' \\=\\> string, \\?'query' \\=\\> string, \\?'fragment' \\=\\> string\\)\\.$#"
+			message: "#^Offset 'user' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 1
 			path: src/Dsn.php
 
@@ -56,9 +56,24 @@ parameters:
 			path: src/HttpClient/HttpClientFactory.php
 
 		-
+			message: "#^Constructor of class Sentry\\\\HttpClient\\\\HttpClientFactory has an unused parameter \\$responseFactory\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
+			message: "#^Constructor of class Sentry\\\\HttpClient\\\\HttpClientFactory has an unused parameter \\$uriFactory\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
 			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
 			count: 1
 			path: src/Serializer/AbstractSerializer.php
+
+		-
+			message: "#^Method Sentry\\\\Serializer\\\\PayloadSerializer\\:\\:serializeAsEvent\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Serializer/PayloadSerializer.php
 
 		-
 			message: "#^Method Sentry\\\\ClientInterface\\:\\:captureException\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
@@ -104,6 +119,11 @@ parameters:
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
 			count: 3
 			path: src/State/HubInterface.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: src/Tracing/SpanContext.php
 
 		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureException\\(\\) invoked with 2 parameters, 1 required\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,6 +11,11 @@ parameters:
 			path: src/Client.php
 
 		-
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, args\\?\\: array\\}\\>, array\\<int, array\\> given\\.$#"
+			count: 1
+			path: src/Client.php
+
+		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
 			count: 3
 			path: src/ClientInterface.php
@@ -36,7 +41,7 @@ parameters:
 			path: src/Dsn.php
 
 		-
-			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\ErrorHandler\\:\\:cleanBacktraceFromErrorHandlerFrames\\(\\) expects array\\<int, array\\{function\\?\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\ErrorHandler\\:\\:cleanBacktraceFromErrorHandlerFrames\\(\\) expects array\\<int, array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
 			count: 1
 			path: src/ErrorHandler.php
 
@@ -236,12 +241,12 @@ parameters:
 			path: src/Serializer/AbstractSerializer.php
 
 		-
-			message: "#^Method Sentry\\\\Serializer\\\\PayloadSerializer\\:\\:serializeAsEvent\\(\\) should return string but returns string\\|false\\.$#"
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
 			count: 1
-			path: src/Serializer/PayloadSerializer.php
+			path: src/StacktraceBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\?\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
+			message: "#^Parameter \\#3 \\$backtraceFrame of method Sentry\\\\FrameBuilder\\:\\:buildFromBacktraceFrame\\(\\) expects array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}, array\\{\\} given\\.$#"
 			count: 1
 			path: src/StacktraceBuilder.php
 
@@ -314,6 +319,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$username of method Sentry\\\\UserDataBag\\:\\:setUsername\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/UserDataBag.php
+
+		-
+			message: "#^Method Sentry\\\\Util\\\\JSON\\:\\:encode\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: src/Util/JSON.php
 
 		-
 			message: "#^Method Sentry\\\\State\\\\HubInterface\\:\\:captureException\\(\\) invoked with 2 parameters, 1 required\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11,11 +11,6 @@ parameters:
 			path: src/Client.php
 
 		-
-			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, args\\?\\: array\\}\\>, array\\<int, array\\> given\\.$#"
-			count: 1
-			path: src/Client.php
-
-		-
 			message: "#^PHPDoc tag @param references unknown parameter\\: \\$hint$#"
 			count: 3
 			path: src/ClientInterface.php
@@ -41,7 +36,7 @@ parameters:
 			path: src/Dsn.php
 
 		-
-			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\ErrorHandler\\:\\:cleanBacktraceFromErrorHandlerFrames\\(\\) expects array\\<int, array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\ErrorHandler\\:\\:cleanBacktraceFromErrorHandlerFrames\\(\\) expects array\\<int, array\\{function\\?\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
 			count: 1
 			path: src/ErrorHandler.php
 
@@ -241,12 +236,7 @@ parameters:
 			path: src/Serializer/AbstractSerializer.php
 
 		-
-			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
-			count: 1
-			path: src/StacktraceBuilder.php
-
-		-
-			message: "#^Parameter \\#3 \\$backtraceFrame of method Sentry\\\\FrameBuilder\\:\\:buildFromBacktraceFrame\\(\\) expects array\\{function\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}, array\\{\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$backtrace of method Sentry\\\\StacktraceBuilder\\:\\:buildFromBacktrace\\(\\) expects array\\<int, array\\{function\\?\\: string, line\\?\\: int, file\\?\\: string, class\\?\\: class\\-string, type\\?\\: string, args\\?\\: array\\}\\>, array\\<int, array\\<string, mixed\\>\\> given\\.$#"
 			count: 1
 			path: src/StacktraceBuilder.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,6 @@ parameters:
     level: 8
     paths:
         - src
-    excludes_analyse:
+    excludePaths:
         - tests/resources
         - tests/Fixtures

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,7 @@ includes:
 parameters:
     tipsOfTheDay: false
     treatPhpDocTypesAsCertain: false
-    level: 8
+    level: 9
     paths:
         - src
     excludePaths:

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.17.0@6f4707aa41c9174353a6434bba3fc8840f981d9c">
+  <file src="src/Dsn.php">
+    <PossiblyUndefinedArrayOffset occurrences="4">
+      <code>$parsedDsn['host']</code>
+      <code>$parsedDsn['path']</code>
+      <code>$parsedDsn['scheme']</code>
+      <code>$parsedDsn['user']</code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="src/HttpClient/HttpClientFactory.php">
+    <UndefinedClass occurrences="4">
+      <code>GuzzleHttpClientOptions</code>
+      <code>GuzzleHttpClientOptions</code>
+      <code>GuzzleHttpClientOptions</code>
+      <code>SymfonyHttpClient</code>
+    </UndefinedClass>
+  </file>
+  <file src="src/Integration/IntegrationRegistry.php">
+    <PossiblyInvalidArgument occurrences="2">
+      <code>$userIntegration</code>
+      <code>$userIntegrations</code>
+    </PossiblyInvalidArgument>
+  </file>
+  <file src="src/Serializer/PayloadSerializer.php">
+    <FalsableReturnStatement occurrences="1">
+      <code>JSON::encode($result)</code>
+    </FalsableReturnStatement>
+    <InvalidFalsableReturnType occurrences="1">
+      <code>string</code>
+    </InvalidFalsableReturnType>
+    <PossiblyFalseArgument occurrences="2">
+      <code>$envelopeHeader</code>
+      <code>$itemHeader</code>
+    </PossiblyFalseArgument>
+  </file>
+  <file src="src/Serializer/RepresentationSerializer.php">
+    <InvalidReturnStatement occurrences="1">
+      <code>$value</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType occurrences="1">
+      <code>representationSerialize</code>
+    </InvalidReturnType>
+  </file>
+  <file src="src/State/Hub.php">
+    <TooManyArguments occurrences="3">
+      <code>captureException</code>
+      <code>captureLastError</code>
+      <code>captureMessage</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/State/HubAdapter.php">
+    <TooManyArguments occurrences="4">
+      <code>captureException</code>
+      <code>captureLastError</code>
+      <code>captureMessage</code>
+      <code>startTransaction</code>
+    </TooManyArguments>
+  </file>
+  <file src="src/Tracing/SpanContext.php">
+    <UnsafeInstantiation occurrences="1">
+      <code>new static()</code>
+    </UnsafeInstantiation>
+  </file>
+  <file src="src/functions.php">
+    <TooManyArguments occurrences="4">
+      <code>captureException</code>
+      <code>captureLastError</code>
+      <code>captureMessage</code>
+      <code>startTransaction</code>
+    </TooManyArguments>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -5,6 +5,7 @@
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
     memoizeMethodCallResults="true"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Client.php
+++ b/src/Client.php
@@ -96,10 +96,6 @@ final class Client implements ClientInterface
         ?RepresentationSerializerInterface $representationSerializer = null,
         ?LoggerInterface $logger = null
     ) {
-        if ($serializer !== null) {
-            @trigger_error('The $serializer argument is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
-        }
-
         $this->options = $options;
         $this->transport = $transport;
         $this->logger = $logger ?? new NullLogger();

--- a/src/Client.php
+++ b/src/Client.php
@@ -12,7 +12,6 @@ use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\IntegrationRegistry;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\Serializer\RepresentationSerializerInterface;
-use Sentry\Serializer\Serializer;
 use Sentry\Serializer\SerializerInterface;
 use Sentry\State\Scope;
 use Sentry\Transport\TransportInterface;

--- a/src/Client.php
+++ b/src/Client.php
@@ -57,11 +57,6 @@ final class Client implements ClientInterface
     private $integrations;
 
     /**
-     * @var SerializerInterface The serializer of the client
-     */
-    private $serializer;
-
-    /**
      * @var RepresentationSerializerInterface The representation serializer of the client
      */
     private $representationSerializer;
@@ -101,11 +96,14 @@ final class Client implements ClientInterface
         ?RepresentationSerializerInterface $representationSerializer = null,
         ?LoggerInterface $logger = null
     ) {
+        if ($serializer !== null) {
+            @trigger_error('The $serializer argument is deprecated since version 3.3 and will be removed in 4.0.', E_USER_DEPRECATED);
+        }
+
         $this->options = $options;
         $this->transport = $transport;
         $this->logger = $logger ?? new NullLogger();
         $this->integrations = IntegrationRegistry::getInstance()->setupIntegrations($options, $this->logger);
-        $this->serializer = $serializer ?? new Serializer($this->options);
         $this->representationSerializer = $representationSerializer ?? new RepresentationSerializer($this->options);
         $this->stacktraceBuilder = new StacktraceBuilder($options, $this->representationSerializer);
         $this->sdkIdentifier = $sdkIdentifier ?? self::SDK_IDENTIFIER;

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -9,7 +9,6 @@ use Jean85\PrettyVersions;
 use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientFactory;
 use Sentry\Serializer\RepresentationSerializerInterface;
-use Sentry\Serializer\Serializer;
 use Sentry\Serializer\SerializerInterface;
 use Sentry\Transport\DefaultTransportFactory;
 use Sentry\Transport\TransportFactoryInterface;

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Http\Client\HttpAsyncClient;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Jean85\PrettyVersions;
 use Psr\Log\LoggerInterface;
@@ -37,11 +36,6 @@ final class ClientBuilder implements ClientBuilderInterface
      * @var TransportInterface|null The transport
      */
     private $transport;
-
-    /**
-     * @var HttpAsyncClient|null The HTTP client
-     */
-    private $httpClient;
 
     /**
      * @var SerializerInterface|null The serializer to be injected in the client
@@ -84,7 +78,7 @@ final class ClientBuilder implements ClientBuilderInterface
      */
     public static function create(array $options = []): ClientBuilderInterface
     {
-        return new static(new Options($options));
+        return new self(new Options($options));
     }
 
     /**
@@ -189,7 +183,7 @@ final class ClientBuilder implements ClientBuilderInterface
             Psr17FactoryDiscovery::findUrlFactory(),
             Psr17FactoryDiscovery::findResponseFactory(),
             $streamFactory,
-            $this->httpClient,
+            null,
             $this->sdkIdentifier,
             $this->sdkVersion
         );

--- a/src/Context/OsContext.php
+++ b/src/Context/OsContext.php
@@ -41,7 +41,7 @@ final class OsContext
      */
     public function __construct(string $name, ?string $version = null, ?string $build = null, ?string $kernelVersion = null)
     {
-        if (0 === \strlen(trim($name))) {
+        if ('' === trim($name)) {
             throw new \InvalidArgumentException('The $name argument cannot be an empty string.');
         }
 
@@ -66,7 +66,7 @@ final class OsContext
      */
     public function setName(string $name): void
     {
-        if (0 === \strlen(trim($name))) {
+        if ('' === trim($name)) {
             throw new \InvalidArgumentException('The $name argument cannot be an empty string.');
         }
 

--- a/src/Context/RuntimeContext.php
+++ b/src/Context/RuntimeContext.php
@@ -29,7 +29,7 @@ final class RuntimeContext
      */
     public function __construct(string $name, ?string $version = null)
     {
-        if (0 === \strlen(trim($name))) {
+        if ('' === trim($name)) {
             throw new \InvalidArgumentException('The $name argument cannot be an empty string.');
         }
 
@@ -52,7 +52,7 @@ final class RuntimeContext
      */
     public function setName(string $name): void
     {
-        if (0 === \strlen(trim($name))) {
+        if ('' === trim($name)) {
             throw new \InvalidArgumentException('The $name argument cannot be an empty string.');
         }
 

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -92,12 +92,10 @@ final class Dsn implements \Stringable
             throw new \InvalidArgumentException(sprintf('The "%s" DSN must contain a valid secret key.', $value));
         }
 
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
         if (!\in_array($parsedDsn['scheme'], ['http', 'https'], true)) {
             throw new \InvalidArgumentException(sprintf('The scheme of the "%s" DSN must be either "http" or "https".', $value));
         }
 
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
         $segmentPaths = explode('/', $parsedDsn['path']);
         $projectId = array_pop($segmentPaths);
 
@@ -112,7 +110,6 @@ final class Dsn implements \Stringable
             $path = substr($parsedDsn['path'], 0, $lastSlashPosition);
         }
 
-        /** @psalm-suppress PossiblyUndefinedArrayOffset */
         return new self(
             $parsedDsn['scheme'],
             $parsedDsn['host'],

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -12,6 +12,8 @@ use Sentry\Exception\SilencedErrorException;
  * error types and relays them to all configured listeners. Registering this
  * error handler more than once is not supported and will lead to nasty
  * problems. The code is based on the Symfony ErrorHandler component.
+ *
+ * @psalm-import-type StacktraceFrame from FrameBuilder
  */
 final class ErrorHandler
 {
@@ -379,11 +381,13 @@ final class ErrorHandler
      * Cleans and returns the backtrace without the first frames that belong to
      * this error handler.
      *
-     * @param array<int, mixed> $backtrace The backtrace to clear
-     * @param string            $file      The filename the backtrace was raised in
-     * @param int               $line      The line number the backtrace was raised at
+     * @param array<int, array<string, mixed>> $backtrace The backtrace to clear
+     * @param string                           $file      The filename the backtrace was raised in
+     * @param int                              $line      The line number the backtrace was raised at
      *
      * @return array<int, mixed>
+     *
+     * @psalm-param list<StacktraceFrame> $backtrace
      */
     private function cleanBacktraceFromErrorHandlerFrames(array $backtrace, string $file, int $line): array
     {

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -93,7 +93,7 @@ final class ErrorHandler
     private static $reservedMemory;
 
     /**
-     * @var array<string, string> List of error levels and their description
+     * @var string[] List of error levels and their description
      */
     private const ERROR_LEVELS_DESCRIPTION = [
         \E_DEPRECATED => 'Deprecated',

--- a/src/Event.php
+++ b/src/Event.php
@@ -71,7 +71,7 @@ final class Event
     private $messageFormatted;
 
     /**
-     * @var mixed[] The parameters to use to format the message
+     * @var string[] The parameters to use to format the message
      */
     private $messageParams = [];
 
@@ -376,7 +376,7 @@ final class Event
      * Sets the error message.
      *
      * @param string      $message   The message
-     * @param mixed[]     $params    The parameters to use to format the message
+     * @param string[]    $params    The parameters to use to format the message
      * @param string|null $formatted The formatted message
      */
     public function setMessage(string $message, array $params = [], ?string $formatted = null): void

--- a/src/EventId.php
+++ b/src/EventId.php
@@ -35,7 +35,7 @@ final class EventId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
+        return new self(str_replace('-', '', uuid_create(\UUID_TYPE_RANDOM)));
     }
 
     public function __toString(): string

--- a/src/EventId.php
+++ b/src/EventId.php
@@ -35,7 +35,7 @@ final class EventId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(str_replace('-', '', uuid_create(\UUID_TYPE_RANDOM)));
+        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
     }
 
     public function __toString(): string

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -67,7 +67,7 @@ final class Frame
 
     /**
      * @var array<string, mixed> A mapping of variables which were available within
-     *                    this frame (usually context-locals)
+     *                           this frame (usually context-locals)
      */
     private $vars = [];
 

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -11,9 +11,9 @@ use Sentry\Serializer\RepresentationSerializerInterface;
  *
  * @internal
  *
- * @phpstan-type StacktraceFrame array{
- *     function?: callable-string,
- *     line?: integer,
+ * @psalm-type StacktraceFrame array{
+ *     function?: string,
+ *     line?: int,
  *     file?: string,
  *     class?: class-string,
  *     type?: string,
@@ -51,7 +51,7 @@ final class FrameBuilder
      * @param int                  $line           The line at which the frame originated
      * @param array<string, mixed> $backtraceFrame The raw frame
      *
-     * @phpstan-param StacktraceFrame $backtraceFrame
+     * @psalm-param StacktraceFrame $backtraceFrame
      */
     public function buildFromBacktraceFrame(string $file, int $line, array $backtraceFrame): Frame
     {
@@ -155,7 +155,7 @@ final class FrameBuilder
      *
      * @return array<string, mixed>
      *
-     * @phpstan-param StacktraceFrame $backtraceFrame
+     * @psalm-param StacktraceFrame $backtraceFrame
      */
     private function getFunctionArguments(array $backtraceFrame): array
     {

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -12,7 +12,7 @@ use Sentry\Serializer\RepresentationSerializerInterface;
  * @internal
  *
  * @psalm-type StacktraceFrame array{
- *     function?: string,
+ *     function: string,
  *     line?: int,
  *     file?: string,
  *     class?: class-string,
@@ -174,7 +174,7 @@ final class FrameBuilder
                 } else {
                     $reflectionFunction = new \ReflectionMethod($backtraceFrame['class'], '__call');
                 }
-            } elseif (isset($backtraceFrame['function']) && !\in_array($backtraceFrame['function'], ['{closure}', '__lambda_func'], true) && \function_exists($backtraceFrame['function'])) {
+            } elseif (!\in_array($backtraceFrame['function'], ['{closure}', '__lambda_func'], true) && \function_exists($backtraceFrame['function'])) {
                 $reflectionFunction = new \ReflectionFunction($backtraceFrame['function']);
             }
         } catch (\ReflectionException $e) {

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -12,7 +12,7 @@ use Sentry\Serializer\RepresentationSerializerInterface;
  * @internal
  *
  * @psalm-type StacktraceFrame array{
- *     function: string,
+ *     function?: string,
  *     line?: int,
  *     file?: string,
  *     class?: class-string,

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -10,6 +10,15 @@ use Sentry\Serializer\RepresentationSerializerInterface;
  * This class builds a {@see Frame} object out of a backtrace's raw frame.
  *
  * @internal
+ *
+ * @phpstan-type StacktraceFrame array{
+ *     function?: callable-string,
+ *     line?: integer,
+ *     file?: string,
+ *     class?: class-string,
+ *     type?: string,
+ *     args?: mixed[]
+ * }
  */
 final class FrameBuilder
 {
@@ -42,14 +51,7 @@ final class FrameBuilder
      * @param int                  $line           The line at which the frame originated
      * @param array<string, mixed> $backtraceFrame The raw frame
      *
-     * @psalm-param array{
-     *     function?: callable-string,
-     *     line?: integer,
-     *     file?: string,
-     *     class?: class-string,
-     *     type?: string,
-     *     args?: array
-     * } $backtraceFrame
+     * @phpstan-param StacktraceFrame $backtraceFrame
      */
     public function buildFromBacktraceFrame(string $file, int $line, array $backtraceFrame): Frame
     {
@@ -153,14 +155,7 @@ final class FrameBuilder
      *
      * @return array<string, mixed>
      *
-     * @throws \ReflectionException
-     *
-     * @psalm-param array{
-     *     function?: callable-string,
-     *     class?: class-string,
-     *     type?: string,
-     *     args?: array
-     * } $backtraceFrame
+     * @phpstan-param StacktraceFrame $backtraceFrame
      */
     private function getFunctionArguments(array $backtraceFrame): array
     {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -42,16 +42,6 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     private const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
 
     /**
-     * @var UriFactoryInterface The PSR-7 URI factory
-     */
-    private $uriFactory;
-
-    /**
-     * @var ResponseFactoryInterface The PSR-7 response factory
-     */
-    private $responseFactory;
-
-    /**
      * @var StreamFactoryInterface The PSR-17 stream factory
      */
     private $streamFactory;
@@ -89,8 +79,6 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         string $sdkIdentifier,
         string $sdkVersion
     ) {
-        $this->uriFactory = $uriFactory;
-        $this->responseFactory = $responseFactory;
         $this->streamFactory = $streamFactory;
         $this->httpClient = $httpClient;
         $this->sdkIdentifier = $sdkIdentifier;

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -110,23 +110,19 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                     $symfonyConfig['proxy'] = $options->getHttpProxy();
                 }
 
-                /** @psalm-suppress UndefinedClass */
                 $httpClient = new SymfonyHttplugClient(
                     SymfonyHttpClient::create($symfonyConfig)
                 );
             } elseif (class_exists(GuzzleHttpClient::class)) {
-                /** @psalm-suppress UndefinedClass */
                 $guzzleConfig = [
                     GuzzleHttpClientOptions::TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
                     GuzzleHttpClientOptions::CONNECT_TIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
                 ];
 
                 if (null !== $options->getHttpProxy()) {
-                    /** @psalm-suppress UndefinedClass */
                     $guzzleConfig[GuzzleHttpClientOptions::PROXY] = $options->getHttpProxy();
                 }
 
-                /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $httpClient = GuzzleHttpClient::createWithConfig($guzzleConfig);
             } elseif (class_exists(CurlHttpClient::class)) {
                 $curlConfig = [
@@ -138,7 +134,6 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                     $curlConfig[\CURLOPT_PROXY] = $options->getHttpProxy();
                 }
 
-                /** @psalm-suppress InvalidPropertyAssignmentValue */
                 $httpClient = new CurlHttpClient(null, null, $curlConfig);
             } elseif (null !== $options->getHttpProxy()) {
                 throw new \RuntimeException('The "http_proxy" option requires either the "php-http/curl-client" or the "php-http/guzzle6-adapter" package to be installed.');

--- a/src/Integration/IgnoreErrorsIntegration.php
+++ b/src/Integration/IgnoreErrorsIntegration.php
@@ -14,11 +14,18 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * to a series of options that must match with its data.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
+ *
+ * @psalm-type IntegrationOptions array{
+ *     ignore_exceptions: list<class-string<\Throwable>>,
+ *     ignore_tags: array<string, string>
+ * }
  */
 final class IgnoreErrorsIntegration implements IntegrationInterface
 {
     /**
      * @var array<string, mixed> The options
+     *
+     * @psalm-var IntegrationOptions
      */
     private $options;
 
@@ -29,7 +36,7 @@ final class IgnoreErrorsIntegration implements IntegrationInterface
      * @param array<string, mixed> $options The options
      *
      * @psalm-param array{
-     *     ignore_exceptions?: list<class-string<\Throwable>>
+     *     ignore_exceptions?: list<class-string<\Throwable>>,
      *     ignore_tags?: array<string, string>
      * } $options
      */
@@ -69,6 +76,8 @@ final class IgnoreErrorsIntegration implements IntegrationInterface
      *
      * @param Event                $event   The event to check
      * @param array<string, mixed> $options The options of the integration
+     *
+     * @psalm-param IntegrationOptions $options
      */
     private function shouldDropEvent(Event $event, array $options): bool
     {
@@ -89,6 +98,8 @@ final class IgnoreErrorsIntegration implements IntegrationInterface
      *
      * @param Event                $event   The event instance
      * @param array<string, mixed> $options The options of the integration
+     *
+     * @psalm-param IntegrationOptions $options
      */
     private function isIgnoredException(Event $event, array $options): bool
     {
@@ -113,6 +124,8 @@ final class IgnoreErrorsIntegration implements IntegrationInterface
      *
      * @param Event                $event   The event instance
      * @param array<string, mixed> $options The options of the integration
+     *
+     * @psalm-param IntegrationOptions $options
      */
     private function isIgnoredTag(Event $event, array $options): bool
     {

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -86,7 +86,6 @@ final class IntegrationRegistry
         $userIntegrations = $options->getIntegrations();
 
         if (\is_array($userIntegrations)) {
-            /** @psalm-suppress PossiblyInvalidArgument */
             $userIntegrationsClasses = array_map('get_class', $userIntegrations);
             $pickedIntegrationsClasses = [];
 
@@ -100,7 +99,6 @@ final class IntegrationRegistry
             }
 
             foreach ($userIntegrations as $userIntegration) {
-                /** @psalm-suppress PossiblyInvalidArgument */
                 $integrationClassName = \get_class($userIntegration);
 
                 if (!isset($pickedIntegrationsClasses[$integrationClassName])) {

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -69,6 +69,10 @@ final class RequestIntegration implements IntegrationInterface
 
     /**
      * @var array<string, mixed> The options
+     *
+     * @psalm-var array{
+     *     pii_sanitize_headers: string[]
+     * }
      */
     private $options;
 

--- a/src/Integration/TransactionIntegration.php
+++ b/src/Integration/TransactionIntegration.php
@@ -36,7 +36,7 @@ final class TransactionIntegration implements IntegrationInterface
                 return $event;
             }
 
-            if (isset($hint->extra['transaction'])) {
+            if (isset($hint->extra['transaction']) && \is_string($hint->extra['transaction'])) {
                 $event->setTransaction($hint->extra['transaction']);
             } elseif (isset($_SERVER['PATH_INFO'])) {
                 $event->setTransaction($_SERVER['PATH_INFO']);

--- a/src/Serializer/RepresentationSerializer.php
+++ b/src/Serializer/RepresentationSerializer.php
@@ -12,9 +12,6 @@ class RepresentationSerializer extends AbstractSerializer implements Representat
 {
     /**
      * {@inheritdoc}
-     *
-     * @psalm-suppress InvalidReturnType
-     * @psalm-suppress InvalidReturnStatement
      */
     public function representationSerialize($value)
     {

--- a/src/StacktraceBuilder.php
+++ b/src/StacktraceBuilder.php
@@ -11,6 +11,8 @@ use Sentry\Serializer\RepresentationSerializerInterface;
  * or from a backtrace.
  *
  * @internal
+ *
+ * @psalm-import-type StacktraceFrame from FrameBuilder
  */
 final class StacktraceBuilder
 {
@@ -47,10 +49,7 @@ final class StacktraceBuilder
      * @param string                           $file      The file where the backtrace originated from
      * @param int                              $line      The line from which the backtrace originated from
      *
-     * @phpstan-param list<array{
-     *     line?: integer,
-     *     file?: string,
-     * }> $backtrace
+     * @psalm-param list<StacktraceFrame> $backtrace
      */
     public function buildFromBacktrace(array $backtrace, string $file, int $line): Stacktrace
     {

--- a/src/StacktraceBuilder.php
+++ b/src/StacktraceBuilder.php
@@ -15,11 +15,6 @@ use Sentry\Serializer\RepresentationSerializerInterface;
 final class StacktraceBuilder
 {
     /**
-     * @var Options The SDK client options
-     */
-    private $options;
-
-    /**
      * @var FrameBuilder An instance of the builder of {@see Frame} objects
      */
     private $frameBuilder;
@@ -32,7 +27,6 @@ final class StacktraceBuilder
      */
     public function __construct(Options $options, RepresentationSerializerInterface $representationSerializer)
     {
-        $this->options = $options;
         $this->frameBuilder = new FrameBuilder($options, $representationSerializer);
     }
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -121,7 +121,6 @@ final class Hub implements HubInterface
         $client = $this->getClient();
 
         if (null !== $client) {
-            /** @psalm-suppress TooManyArguments */
             return $this->lastEventId = $client->captureMessage($message, $level, $this->getScope(), $hint);
         }
 
@@ -136,7 +135,6 @@ final class Hub implements HubInterface
         $client = $this->getClient();
 
         if (null !== $client) {
-            /** @psalm-suppress TooManyArguments */
             return $this->lastEventId = $client->captureException($exception, $this->getScope(), $hint);
         }
 
@@ -165,7 +163,6 @@ final class Hub implements HubInterface
         $client = $this->getClient();
 
         if (null !== $client) {
-            /** @psalm-suppress TooManyArguments */
             return $this->lastEventId = $client->captureLastError($this->getScope(), $hint);
         }
 
@@ -267,9 +264,6 @@ final class Hub implements HubInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @psalm-suppress MoreSpecificReturnType
-     * @psalm-suppress LessSpecificReturnStatement
      */
     public function getTransaction(): ?Transaction
     {

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -108,7 +108,6 @@ final class HubAdapter implements HubInterface
      */
     public function captureMessage(string $message, ?Severity $level = null, ?EventHint $hint = null): ?EventId
     {
-        /** @psalm-suppress TooManyArguments */
         return SentrySdk::getCurrentHub()->captureMessage($message, $level, $hint);
     }
 
@@ -117,7 +116,6 @@ final class HubAdapter implements HubInterface
      */
     public function captureException(\Throwable $exception, ?EventHint $hint = null): ?EventId
     {
-        /** @psalm-suppress TooManyArguments */
         return SentrySdk::getCurrentHub()->captureException($exception, $hint);
     }
 
@@ -134,7 +132,6 @@ final class HubAdapter implements HubInterface
      */
     public function captureLastError(?EventHint $hint = null): ?EventId
     {
-        /** @psalm-suppress TooManyArguments */
         return SentrySdk::getCurrentHub()->captureLastError($hint);
     }
 
@@ -161,7 +158,6 @@ final class HubAdapter implements HubInterface
      */
     public function startTransaction(TransactionContext $context, array $customSamplingContext = []): Transaction
     {
-        /** @psalm-suppress TooManyArguments */
         return SentrySdk::getCurrentHub()->startTransaction($context, $customSamplingContext);
     }
 

--- a/src/Tracing/SpanContext.php
+++ b/src/Tracing/SpanContext.php
@@ -201,7 +201,6 @@ class SpanContext
     {
         @trigger_error(sprintf('The %s() method is deprecated since version 3.1 and will be removed in 4.0. Use TransactionContext::fromSentryTrace() instead.', __METHOD__), \E_USER_DEPRECATED);
 
-        /** @phpstan-ignore-next-line */ /** @psalm-suppress UnsafeInstantiation */
         $context = new static();
 
         if (!preg_match(self::TRACEPARENT_HEADER_REGEX, $header, $matches)) {

--- a/src/Tracing/SpanId.php
+++ b/src/Tracing/SpanId.php
@@ -33,7 +33,7 @@ final class SpanId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(substr(str_replace('-', '', uuid_create(\UUID_TYPE_RANDOM)), 0, 16));
+        return new self(substr(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)), 0, 16));
     }
 
     /**

--- a/src/Tracing/SpanId.php
+++ b/src/Tracing/SpanId.php
@@ -33,7 +33,7 @@ final class SpanId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(substr(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)), 0, 16));
+        return new self(substr(str_replace('-', '', uuid_create(\UUID_TYPE_RANDOM)), 0, 16));
     }
 
     /**

--- a/src/Tracing/TraceId.php
+++ b/src/Tracing/TraceId.php
@@ -33,7 +33,7 @@ final class TraceId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(str_replace('-', '', uuid_create(\UUID_TYPE_RANDOM)));
+        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
     }
 
     public function __toString(): string

--- a/src/Tracing/TraceId.php
+++ b/src/Tracing/TraceId.php
@@ -33,7 +33,7 @@ final class TraceId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
+        return new self(str_replace('-', '', uuid_create(\UUID_TYPE_RANDOM)));
     }
 
     public function __toString(): string

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -22,11 +22,9 @@ final class JSON
      * @param int   $options  Bitmask consisting of JSON_* constants
      * @param int   $maxDepth The maximum depth allowed for serializing $data
      *
-     * @return false|string
-     *
      * @throws JsonException If the encoding failed
      */
-    public static function encode($data, int $options = 0, int $maxDepth = 512)
+    public static function encode($data, int $options = 0, int $maxDepth = 512): string
     {
         if ($maxDepth < 1) {
             throw new \InvalidArgumentException('The $maxDepth argument must be an integer greater than 0.');

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -22,12 +22,16 @@ final class JSON
      * @param int   $options  Bitmask consisting of JSON_* constants
      * @param int   $maxDepth The maximum depth allowed for serializing $data
      *
-     * @return mixed
+     * @return false|string
      *
      * @throws JsonException If the encoding failed
      */
     public static function encode($data, int $options = 0, int $maxDepth = 512)
     {
+        if ($maxDepth < 1) {
+            throw new \InvalidArgumentException('The $maxDepth argument must be an integer greater than 0.');
+        }
+
         $options |= \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE;
 
         $encodedData = json_encode($data, $options, $maxDepth);

--- a/src/functions.php
+++ b/src/functions.php
@@ -28,7 +28,6 @@ function init(array $options = []): void
  */
 function captureMessage(string $message, ?Severity $level = null, ?EventHint $hint = null): ?EventId
 {
-    /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->captureMessage($message, $level, $hint);
 }
 
@@ -40,7 +39,6 @@ function captureMessage(string $message, ?Severity $level = null, ?EventHint $hi
  */
 function captureException(\Throwable $exception, ?EventHint $hint = null): ?EventId
 {
-    /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->captureException($exception, $hint);
 }
 
@@ -62,7 +60,6 @@ function captureEvent(Event $event, ?EventHint $hint = null): ?EventId
  */
 function captureLastError(?EventHint $hint = null): ?EventId
 {
-    /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->captureLastError($hint);
 }
 
@@ -120,6 +117,5 @@ function withScope(callable $callback): void
  */
 function startTransaction(TransactionContext $context, array $customSamplingContext = []): Transaction
 {
-    /** @psalm-suppress TooManyArguments */
     return SentrySdk::getCurrentHub()->startTransaction($context, $customSamplingContext);
 }

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -113,6 +113,23 @@ final class JSONTest extends TestCase
         JSON::encode($resource);
     }
 
+    /**
+     * @dataProvider encodeThrowsExceptionIfMaxDepthArgumentIsInvalidDataProvider
+     */
+    public function testEncodeThrowsExceptionIfMaxDepthArgumentIsInvalid(int $maxDepth): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The $maxDepth argument must be an integer greater than 0.');
+
+        JSON::encode('foo', 0, $maxDepth);
+    }
+
+    public function encodeThrowsExceptionIfMaxDepthArgumentIsInvalidDataProvider(): \Generator
+    {
+        yield [0];
+        yield [-1];
+    }
+
     public function testEncodeRespectsOptionsArgument(): void
     {
         $this->assertSame('{}', JSON::encode([], \JSON_FORCE_OBJECT));


### PR DESCRIPTION
As per title, I've updated the development tools to their latest version, taking the occasion to remove all Psalm error suppressions annotations and introducing the baseline instead. I've also updated the level of PHPStan to 9, which is the maximum level available at the moment of writing.