### PR TITLE
Optimize span constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ package.xml
 /vendor
 .idea
 .php_cs.cache
+.phpbench
 .phpunit.result.cache
 docs/_build
 tests/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,11 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "phpstan/extension-installer": true
+        }
     },
     "prefer-stable": true,
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "monolog/monolog": "^1.3|^2.0",
         "nikic/php-parser": "^4.10.3",
         "php-http/mock-client": "^1.3",
+        "phpbench/phpbench": "^1.2",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,4 @@
+{
+    "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+    "runner.bootstrap": "vendor/autoload.php"
+}

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,4 +1,6 @@
 {
     "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
-    "runner.bootstrap": "vendor/autoload.php"
+    "runner.bootstrap": "vendor/autoload.php",
+    "runner.retry_threshold": 2,
+    "runner.path": "tests/Benchmark"
 }

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -80,25 +80,17 @@ class Span
      */
     public function __construct(?SpanContext $context = null)
     {
-        $this->traceId = TraceId::generate();
-        $this->spanId = SpanId::generate();
-        $this->startTimestamp = microtime(true);
-
         if (null === $context) {
+            $this->traceId = TraceId::generate();
+            $this->spanId = SpanId::generate();
+            $this->startTimestamp = microtime(true);
+
             return;
         }
 
-        if (null !== $context->getTraceId()) {
-            $this->traceId = $context->getTraceId();
-        }
-
-        if (null !== $context->getSpanId()) {
-            $this->spanId = $context->getSpanId();
-        }
-
-        if (null !== $context->getStartTimestamp()) {
-            $this->startTimestamp = $context->getStartTimestamp();
-        }
+        $this->traceId = $context->getTraceId() ?? TraceId::generate();
+        $this->spanId = $context->getSpanId() ?? SpanId::generate();
+        $this->startTimestamp = $context->getStartTimestamp() ?? microtime(true);
 
         $this->parentSpanId = $context->getParentSpanId();
         $this->description = $context->getDescription();

--- a/tests/Benchmark/SpanBench.php
+++ b/tests/Benchmark/SpanBench.php
@@ -10,7 +10,7 @@ class SpanBench
 {
     /**
      * @Revs(10000)
-     * @Iterations(5)
+     * @Iterations(10)
      */
     public function benchConstructor(): void
     {

--- a/tests/Benchmark/SpanBench.php
+++ b/tests/Benchmark/SpanBench.php
@@ -11,10 +11,14 @@ class SpanBench
 {
     /** @var TransactionContext */
     private $context;
+    /** @var TransactionContext */
+    private $contextWithTimestamp;
 
     public function __construct()
     {
         $this->context = TransactionContext::fromSentryTrace('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-0');
+        $this->contextWithTimestamp = TransactionContext::fromSentryTrace('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-0');
+        $this->contextWithTimestamp->setStartTimestamp(microtime(true));
     }
 
     /**
@@ -33,5 +37,14 @@ class SpanBench
     public function benchConstructorWithInjectedContext(): void
     {
         $span = new Span($this->context);
+    }
+
+    /**
+     * @Revs(100000)
+     * @Iterations(10)
+     */
+    public function benchConstructorWithInjectedContextAndStartTimestamp(): void
+    {
+        $span = new Span($this->contextWithTimestamp);
     }
 }

--- a/tests/Benchmark/SpanBench.php
+++ b/tests/Benchmark/SpanBench.php
@@ -5,9 +5,18 @@ namespace Sentry\Tests\Benchmark;
 use PhpBench\Benchmark\Metadata\Annotations\Iterations;
 use PhpBench\Benchmark\Metadata\Annotations\Revs;
 use Sentry\Tracing\Span;
+use Sentry\Tracing\TransactionContext;
 
 class SpanBench
 {
+    /** @var TransactionContext */
+    private $context;
+
+    public function __construct()
+    {
+        $this->context = TransactionContext::fromSentryTrace('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-0');
+    }
+
     /**
      * @Revs(100000)
      * @Iterations(10)
@@ -15,5 +24,14 @@ class SpanBench
     public function benchConstructor(): void
     {
         $span = new Span();
+    }
+
+    /**
+     * @Revs(100000)
+     * @Iterations(10)
+     */
+    public function benchConstructorWithInjectedContext(): void
+    {
+        $span = new Span($this->context);
     }
 }

--- a/tests/Benchmark/SpanBench.php
+++ b/tests/Benchmark/SpanBench.php
@@ -9,7 +9,7 @@ use Sentry\Tracing\Span;
 class SpanBench
 {
     /**
-     * @Revs(10000)
+     * @Revs(100000)
      * @Iterations(10)
      */
     public function benchConstructor(): void

--- a/tests/Benchmark/SpanBench.php
+++ b/tests/Benchmark/SpanBench.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Sentry\Tests\Benchmark;
+
+use PhpBench\Benchmark\Metadata\Annotations\Iterations;
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use Sentry\Tracing\Span;
+
+class SpanBench
+{
+    /**
+     * @Revs(10000)
+     * @Iterations(5)
+     */
+    public function benchConstructor(): void
+    {
+        $span = new Span();
+    }
+}


### PR DESCRIPTION
This started as an investigation over #1273. I tried to run PHPBench over the `Span` constructor, and this is the result applying 5f94026:
![immagine](https://user-images.githubusercontent.com/6729988/148919150-e5ce2cd6-3a48-4871-96f0-4d62dd753b39.png)

Results seems promising, but the operation seems very small to obtain a consistent bench; @ocramius any suggestions? You can also try this branch if you want to check if there's an improvement on your profiled test suite.