### PR TITLE
Handle autoloaders that throws while serializing a possible callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Optimize `Span` constructor and add benchmarks (#1274)
+- Handle autoloader that throws an exception while trying to serialize a possible callable (#1276)
 
 ## 3.3.5 (2021-12-27)
 

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -99,8 +99,11 @@ abstract class AbstractSerializer
                 return $this->serializeValue($value);
             }
 
-            if (\is_callable($value)) {
-                return $this->serializeCallable($value);
+            try {
+                if (\is_callable($value)) {
+                    return $this->serializeCallable($value);
+                }
+            } catch (\Throwable $e) {
             }
 
             if (\is_array($value)) {

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -103,7 +103,8 @@ abstract class AbstractSerializer
                 if (\is_callable($value)) {
                     return $this->serializeCallable($value);
                 }
-            } catch (\Throwable $e) {
+            } catch (\Throwable $exception) {
+                // Do nothing on purpose
             }
 
             if (\is_array($value)) {

--- a/tests/phpt/serialize_broken_class.phpt
+++ b/tests/phpt/serialize_broken_class.phpt
@@ -25,7 +25,7 @@ require $vendor . '/vendor/autoload.php';
 function testSerialization($value) {
     $serializer = new Serializer(new Options());
 
-    echo $serializer->serialize($value);
+    echo json_encode($serializer->serialize($value));
 }
 
 testSerialization(BrokenClass::class . '::brokenMethod');
@@ -34,5 +34,5 @@ testSerialization([BrokenClass::class, 'brokenMethod']);
 
 ?>
 --EXPECT--
-Sentry\Tests\Fixtures\code\BrokenClass::brokenMethod {serialization error}
-{serialization error}
+"Sentry\\Tests\\Fixtures\\code\\BrokenClass::brokenMethod {serialization error}"
+["Sentry\\Tests\\Fixtures\\code\\BrokenClass","brokenMethod"]

--- a/tests/phpt/serialize_callable_that_makes_autoloader_throw.phpt
+++ b/tests/phpt/serialize_callable_that_makes_autoloader_throw.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test that serializing a pseudo-callable that doesn't exist (like an array of 2 strings) doesn't brake,
+Test that serializing a pseudo-callable that doesn't exist (like an array of 2 strings) doesn't brake
 when inside an application with an autoloader that throws, like Yii or Magento (see #1112)
 --FILE--
 <?php

--- a/tests/phpt/serialize_callable_that_makes_autoloader_throw.phpt
+++ b/tests/phpt/serialize_callable_that_makes_autoloader_throw.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Test that serializing a pseudo-callable that doesn't exist (like an array of 2 strings) doesn't brake,
+when inside an application with an autoloader that throws, like Yii or Magento (see #1112)
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use Sentry\Options;
+use Sentry\Serializer\Serializer;
+use Sentry\Tests\Fixtures\code\BrokenClass;
+
+$vendor = __DIR__;
+
+while (!file_exists($vendor . '/vendor')) {
+    $vendor = dirname($vendor);
+}
+
+require $vendor . '/vendor/autoload.php';
+
+function testSerialization() {
+    $serializer = new Serializer(new Options());
+
+    echo json_encode($serializer->serialize(['FakeClass', 'fakeMethod']));
+}
+
+testSerialization();
+echo PHP_EOL;
+$brokenAutoloader = function (string $classname): void {
+    throw new \RuntimeException('Autoloader throws while loading ' . $classname);
+};
+spl_autoload_register($brokenAutoloader, true, true);
+
+testSerialization();
+
+?>
+--EXPECT--
+["FakeClass","fakeMethod"]
+["FakeClass","fakeMethod"]

--- a/tests/phpt/serialize_callable_that_makes_autoloader_throw.phpt
+++ b/tests/phpt/serialize_callable_that_makes_autoloader_throw.phpt
@@ -31,10 +31,14 @@ echo PHP_EOL;
 $brokenAutoloader = function (string $classname): void {
     throw new \RuntimeException('Autoloader throws while loading ' . $classname);
 };
+
 spl_autoload_register($brokenAutoloader, true, true);
 
-testSerialization();
-
+try {
+    testSerialization();
+} finally {
+    spl_autoload_unregister($brokenAutoloader);
+}
 ?>
 --EXPECT--
 ["FakeClass","fakeMethod"]


### PR DESCRIPTION
Fixes #1112

While trying to fix that ticket, I got an improvement in the serialization of a broken class, a PHPT test already present in our test suite.