### PR TITLE
Restrict the installable versions of `PHP-CS-Fixer` to workaround issue FriendsOfPHP/PHP-CS-Fixer#6238

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.19|^3.4",
+        "friendsofphp/php-cs-fixer": "^2.19|3.4.*",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.3|^2.0",
         "nikic/php-parser": "^4.10.3",


### PR DESCRIPTION
After the release of `PHP-CS-Fixer 3.5`, a [bug](https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/6238) was discovered that changes intersection types to union types, making our build to fail because it changes `Foo&PHPUnit\Framework\MockObject\MockObject` to `Foo|PHPUnit\Framework\MockObject\MockObject` in all tests. Restricting the installable version to an older one should be enough to workaround the problem while waiting for its resolution