### PR TITLE
Swap order of Retry and Error http client plugins

### DIFF
--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -147,8 +147,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         $httpClientPlugins = [
             new HeaderSetPlugin(['User-Agent' => $this->sdkIdentifier . '/' . $this->sdkVersion]),
             new AuthenticationPlugin(new SentryAuthentication($options, $this->sdkIdentifier, $this->sdkVersion)),
-            new RetryPlugin(['retries' => $options->getSendAttempts()]),
             new ErrorPlugin(),
+            new RetryPlugin(['retries' => $options->getSendAttempts()]),
         ];
 
         if ($options->isCompressionEnabled()) {


### PR DESCRIPTION
The ErrorPlugin is responsible for filtering out requests that returned http
error codes. In the original order this filtering would happen only after a
failing request to the sentry endpoint was retried some number of times, as
configured by `getSendAttempts`.

This meant that when sentry rate limits the requests from this client the
requests would be retried before resulting in a ClientErrorException.

This patch reorders the ErrorPlugin and the RetryPlugin so the
ClientErrorException is thrown before the sdk attempts to retry the request.

Fixes #1204 

Some extra context: this only happens when you have `php-http/client-common`
version 1.x installed.