### PR TITLE
Support http_connect_timeout and http_timeout options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bump minimum version of `guzzlehttp/psr7` package to avoid [`CVE-2022-24775`](https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh96) (#1305)
+- Add `http_connect_timeout` and `http_timeout` options to allow more explicit timeouts
 
 ## 3.4.0 (2022-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Bump minimum version of `guzzlehttp/psr7` package to avoid [`CVE-2022-24775`](https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh96) (#1305)
-- Add `http_connect_timeout` and `http_timeout` options to allow more explicit timeouts
+- Add `http_connect_timeout` and `http_timeout` client options (#1282)
 
 ## 3.4.0 (2022-03-14)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,7 +126,17 @@ parameters:
 			path: src/Options.php
 
 		-
+			message: "#^Method Sentry\\\\Options\\:\\:getHttpConnectTimeout\\(\\) should return int\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Method Sentry\\\\Options\\:\\:getHttpProxy\\(\\) should return string\\|null but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
+			message: "#^Method Sentry\\\\Options\\:\\:getHttpTimeout\\(\\) should return int\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -126,7 +126,7 @@ parameters:
 			path: src/Options.php
 
 		-
-			message: "#^Method Sentry\\\\Options\\:\\:getHttpConnectTimeout\\(\\) should return int\\|null but returns mixed\\.$#"
+			message: "#^Method Sentry\\\\Options\\:\\:getHttpConnectTimeout\\(\\) should return float but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
 
@@ -136,7 +136,7 @@ parameters:
 			path: src/Options.php
 
 		-
-			message: "#^Method Sentry\\\\Options\\:\\:getHttpTimeout\\(\\) should return int\\|null but returns mixed\\.$#"
+			message: "#^Method Sentry\\\\Options\\:\\:getHttpTimeout\\(\\) should return float but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
 

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -123,7 +123,10 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     {
         if (class_exists(SymfonyHttplugClient::class)) {
             $symfonyConfig = [
-                'max_duration' => $options->getHttpTimeout(),
+                /*
+                 * {@see https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts}
+                 */
+                'max_duration' => $options->getHttpConnectTimeout() + $options->getHttpTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -34,13 +34,13 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     /**
      * @var int The timeout of the request in seconds
      */
-    private const DEFAULT_HTTP_TIMEOUT = 5;
+    public const DEFAULT_HTTP_TIMEOUT = 5;
 
     /**
      * @var int The default number of seconds to wait while trying to connect
      *          to a server
      */
-    private const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
+    public const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
 
     /**
      * @var StreamFactoryInterface The PSR-17 stream factory
@@ -123,7 +123,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     {
         if (class_exists(SymfonyHttplugClient::class)) {
             $symfonyConfig = [
-                'max_duration' => self::DEFAULT_HTTP_TIMEOUT,
+                'max_duration' => $options->getHttpTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -135,8 +135,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(GuzzleHttpClient::class)) {
             $guzzleConfig = [
-                GuzzleHttpClientOptions::TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
-                GuzzleHttpClientOptions::CONNECT_TIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
+                GuzzleHttpClientOptions::TIMEOUT => $options->getHttpTimeout(),
+                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $options->getHttpConnectTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -148,8 +148,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(CurlHttpClient::class)) {
             $curlConfig = [
-                \CURLOPT_TIMEOUT => self::DEFAULT_HTTP_TIMEOUT,
-                \CURLOPT_CONNECTTIMEOUT => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
+                \CURLOPT_TIMEOUT => $options->getHttpTimeout(),
+                \CURLOPT_CONNECTTIMEOUT => $options->getHttpConnectTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -32,17 +32,6 @@ use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
 final class HttpClientFactory implements HttpClientFactoryInterface
 {
     /**
-     * @var int The timeout of the request in seconds
-     */
-    private const DEFAULT_HTTP_TIMEOUT = 5;
-
-    /**
-     * @var int The default number of seconds to wait while trying to connect
-     *          to a server
-     */
-    private const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
-
-    /**
      * @var StreamFactoryInterface The PSR-17 stream factory
      */
     private $streamFactory;
@@ -121,13 +110,10 @@ final class HttpClientFactory implements HttpClientFactoryInterface
      */
     private function resolveClient(Options $options)
     {
-        $httpTimeout = $options->getHttpTimeout() ?? self::DEFAULT_HTTP_TIMEOUT;
-        $httpConnectTimeout = $options->getHttpConnectTimeout() ?? self::DEFAULT_HTTP_CONNECT_TIMEOUT;
-
         if (class_exists(SymfonyHttplugClient::class)) {
             $symfonyConfig = [
-                'timeout' => $httpConnectTimeout,
-                'max_duration' => $httpTimeout,
+                'timeout' => $options->getHttpConnectTimeout(),
+                'max_duration' => $options->getHttpTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -139,8 +125,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(GuzzleHttpClient::class)) {
             $guzzleConfig = [
-                GuzzleHttpClientOptions::TIMEOUT => $httpTimeout,
-                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $httpConnectTimeout,
+                GuzzleHttpClientOptions::TIMEOUT => $options->getHttpTimeout(),
+                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $options->getHttpConnectTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -152,8 +138,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(CurlHttpClient::class)) {
             $curlConfig = [
-                \CURLOPT_TIMEOUT => $httpTimeout,
-                \CURLOPT_CONNECTTIMEOUT => $httpConnectTimeout,
+                \CURLOPT_TIMEOUT => $options->getHttpTimeout(),
+                \CURLOPT_CONNECTTIMEOUT => $options->getHttpConnectTimeout(),
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -126,7 +126,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 /*
                  * {@see https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts}
                  */
-                'max_duration' => $options->getHttpConnectTimeout() + $options->getHttpTimeout(),
+                'max_duration' => $options->getHttpConnectTimeout() ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT
+                    + $options->getHttpTimeout() ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -138,8 +139,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(GuzzleHttpClient::class)) {
             $guzzleConfig = [
-                GuzzleHttpClientOptions::TIMEOUT => $options->getHttpTimeout(),
-                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $options->getHttpConnectTimeout(),
+                GuzzleHttpClientOptions::TIMEOUT => $options->getHttpTimeout() ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
+                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $options->getHttpConnectTimeout() ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT,
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -151,8 +152,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(CurlHttpClient::class)) {
             $curlConfig = [
-                \CURLOPT_TIMEOUT => $options->getHttpTimeout(),
-                \CURLOPT_CONNECTTIMEOUT => $options->getHttpConnectTimeout(),
+                \CURLOPT_TIMEOUT => $options->getHttpTimeout() ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
+                \CURLOPT_CONNECTTIMEOUT => $options->getHttpConnectTimeout() ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT,
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -34,13 +34,13 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     /**
      * @var int The timeout of the request in seconds
      */
-    public const DEFAULT_HTTP_TIMEOUT = 5;
+    private const DEFAULT_HTTP_TIMEOUT = 5;
 
     /**
      * @var int The default number of seconds to wait while trying to connect
      *          to a server
      */
-    public const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
+    private const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
 
     /**
      * @var StreamFactoryInterface The PSR-17 stream factory

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -129,7 +129,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 /*
                  * {@see https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts}
                  */
-                'max_duration' => $httpConnectTimeout + $httpTimeout
+                'max_duration' => $httpConnectTimeout + $httpTimeout,
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -121,13 +121,15 @@ final class HttpClientFactory implements HttpClientFactoryInterface
      */
     private function resolveClient(Options $options)
     {
+        $httpTimeout = $options->getHttpTimeout() ?? self::DEFAULT_HTTP_TIMEOUT;
+        $httpConnectTimeout = $options->getHttpConnectTimeout() ?? self::DEFAULT_HTTP_CONNECT_TIMEOUT;
+
         if (class_exists(SymfonyHttplugClient::class)) {
             $symfonyConfig = [
                 /*
                  * {@see https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts}
                  */
-                'max_duration' => $options->getHttpConnectTimeout() ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT
-                    + $options->getHttpTimeout() ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
+                'max_duration' => $httpConnectTimeout + $httpTimeout
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -139,8 +141,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(GuzzleHttpClient::class)) {
             $guzzleConfig = [
-                GuzzleHttpClientOptions::TIMEOUT => $options->getHttpTimeout() ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
-                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $options->getHttpConnectTimeout() ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT,
+                GuzzleHttpClientOptions::TIMEOUT => $httpTimeout,
+                GuzzleHttpClientOptions::CONNECT_TIMEOUT => $httpConnectTimeout,
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -152,8 +154,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(CurlHttpClient::class)) {
             $curlConfig = [
-                \CURLOPT_TIMEOUT => $options->getHttpTimeout() ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
-                \CURLOPT_CONNECTTIMEOUT => $options->getHttpConnectTimeout() ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT,
+                \CURLOPT_TIMEOUT => $httpTimeout,
+                \CURLOPT_CONNECTTIMEOUT => $httpConnectTimeout,
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -126,10 +126,8 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
         if (class_exists(SymfonyHttplugClient::class)) {
             $symfonyConfig = [
-                /*
-                 * {@see https://symfony.com/doc/current/http_client.html#dealing-with-network-timeouts}
-                 */
-                'max_duration' => $httpConnectTimeout + $httpTimeout,
+                'timeout' => $httpConnectTimeout,
+                'max_duration' => $httpTimeout,
             ];
 
             if (null !== $options->getHttpProxy()) {

--- a/src/Options.php
+++ b/src/Options.php
@@ -695,7 +695,7 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds that http connections can take to connect.
+     * Sets the amount of time in seconds that http connections can take to connect.
      *
      * @param int $httpConnectTimeout The amount of time in seconds
      */
@@ -707,7 +707,7 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds to wait for the Sentry server to respond.
+     * Gets the maximum execution time for the request+response as a whole.
      */
     public function getHttpTimeout(): ?int
     {
@@ -715,7 +715,9 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds to wait for the Sentry server to respond.
+     * Sets the maximum execution time for the request+response as a whole. The
+     * value should also include the time for the connect phase, so it should be
+     * greater than the value set for the `http_connect_timeout` option.
      *
      * @param int $httpTimeout The amount of time in seconds
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Sentry\HttpClient\HttpClientFactory;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Symfony\Component\OptionsResolver\Options as SymfonyOptions;
@@ -708,7 +707,7 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds to wait for the Sentry server to respond
+     * Gets the amount of time in seconds to wait for the Sentry server to respond.
      */
     public function getHttpTimeout(): ?int
     {
@@ -716,7 +715,7 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds to wait for the Sentry server to respond
+     * Gets the amount of time in seconds to wait for the Sentry server to respond.
      *
      * @param int $httpTimeout The amount of time in seconds
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry;
 
 use Sentry\HttpClient\HttpClientFactory;
-use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Symfony\Component\OptionsResolver\Options as SymfonyOptions;
@@ -693,7 +692,7 @@ final class Options
      */
     public function getHttpConnectTimeout(): int
     {
-        return $this->options['http_connect_timeout'];
+        return $this->options['http_connect_timeout'] ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT;
     }
 
     /**
@@ -713,7 +712,7 @@ final class Options
      */
     public function getHttpTimeout(): int
     {
-        return $this->options['http_timeout'];
+        return $this->options['http_timeout'] ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT;
     }
 
     /**
@@ -771,8 +770,8 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
-            'http_connect_timeout' => HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT,
-            'http_timeout' => HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
+            'http_connect_timeout' => null,
+            'http_timeout' => null,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Sentry\HttpClient\HttpClientFactory;
+use Sentry\HttpClient\HttpClientFactoryInterface;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Symfony\Component\OptionsResolver\Options as SymfonyOptions;
@@ -687,6 +689,46 @@ final class Options
     }
 
     /**
+     * Gets the amount of time in seconds that http connections can take to connect.
+     */
+    public function getHttpConnectTimeout(): int
+    {
+        return $this->options['http_connect_timeout'];
+    }
+
+    /**
+     * Gets the amount of time in seconds that http connections can take to connect.
+     *
+     * @param int $httpConnectTimeout The amount of time in seconds.
+     */
+    public function setHttpConnectTimeout(int $httpConnectTimeout): void
+    {
+        $options = array_merge($this->options, ['http_connect_timeout' => $httpConnectTimeout]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
+     * Gets the amount of time in seconds to wait for the Sentry server to respond.
+     */
+    public function getHttpTimeout(): int
+    {
+        return $this->options['http_timeout'];
+    }
+
+    /**
+     * Gets the amount of time in seconds to wait for the Sentry server to respond.
+     *
+     * @param int $httpTimeout The amount of time in seconds.
+     */
+    public function setHttpTimeout(int $httpTimeout): void
+    {
+        $options = array_merge($this->options, ['http_timeout' => $httpTimeout]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -729,6 +771,8 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
+            'http_connect_timeout' => HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT,
+            'http_timeout' => HttpClientFactory::DEFAULT_HTTP_TIMEOUT,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -759,6 +803,8 @@ final class Options
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
+        $resolver->setAllowedTypes('http_connect_timeout', 'int');
+        $resolver->setAllowedTypes('http_timeout', 'int');
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -23,9 +23,21 @@ final class Options
     public const DEFAULT_MAX_BREADCRUMBS = 100;
 
     /**
+     * The default maximum execution time in seconds for the request+response
+     * as a whole.
+     */
+    public const DEFAULT_HTTP_TIMEOUT = 5;
+
+    /**
+     * The default maximum number of seconds to wait while trying to connect to a
+     * server.
+     */
+    public const DEFAULT_HTTP_CONNECT_TIMEOUT = 2;
+
+    /**
      * @var array<string, mixed> The configuration options
      */
-    private $options = [];
+    private $options;
 
     /**
      * @var OptionsResolver The options resolver
@@ -579,6 +591,48 @@ final class Options
     }
 
     /**
+     * Gets the maximum number of seconds to wait while trying to connect to a server.
+     */
+    public function getHttpConnectTimeout(): float
+    {
+        return $this->options['http_connect_timeout'];
+    }
+
+    /**
+     * Sets the maximum number of seconds to wait while trying to connect to a server.
+     *
+     * @param float $httpConnectTimeout The amount of time in seconds
+     */
+    public function setHttpConnectTimeout(float $httpConnectTimeout): void
+    {
+        $options = array_merge($this->options, ['http_connect_timeout' => $httpConnectTimeout]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
+     * Gets the maximum execution time for the request+response as a whole.
+     */
+    public function getHttpTimeout(): float
+    {
+        return $this->options['http_timeout'];
+    }
+
+    /**
+     * Sets the maximum execution time for the request+response as a whole. The
+     * value should also include the time for the connect phase, so it should be
+     * greater than the value set for the `http_connect_timeout` option.
+     *
+     * @param float $httpTimeout The amount of time in seconds
+     */
+    public function setHttpTimeout(float $httpTimeout): void
+    {
+        $options = array_merge($this->options, ['http_timeout' => $httpTimeout]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Gets whether the silenced errors should be captured or not.
      *
      * @return bool If true, errors silenced through the @ operator will be reported,
@@ -687,48 +741,6 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds that http connections can take to connect.
-     */
-    public function getHttpConnectTimeout(): ?int
-    {
-        return $this->options['http_connect_timeout'];
-    }
-
-    /**
-     * Sets the amount of time in seconds that http connections can take to connect.
-     *
-     * @param int $httpConnectTimeout The amount of time in seconds
-     */
-    public function setHttpConnectTimeout(int $httpConnectTimeout): void
-    {
-        $options = array_merge($this->options, ['http_connect_timeout' => $httpConnectTimeout]);
-
-        $this->options = $this->resolver->resolve($options);
-    }
-
-    /**
-     * Gets the maximum execution time for the request+response as a whole.
-     */
-    public function getHttpTimeout(): ?int
-    {
-        return $this->options['http_timeout'];
-    }
-
-    /**
-     * Sets the maximum execution time for the request+response as a whole. The
-     * value should also include the time for the connect phase, so it should be
-     * greater than the value set for the `http_connect_timeout` option.
-     *
-     * @param int $httpTimeout The amount of time in seconds
-     */
-    public function setHttpTimeout(int $httpTimeout): void
-    {
-        $options = array_merge($this->options, ['http_timeout' => $httpTimeout]);
-
-        $this->options = $this->resolver->resolve($options);
-    }
-
-    /**
      * Configures the options of the client.
      *
      * @param OptionsResolver $resolver The resolver for the options
@@ -768,11 +780,11 @@ final class Options
             'send_default_pii' => false,
             'max_value_length' => 1024,
             'http_proxy' => null,
+            'http_connect_timeout' => self::DEFAULT_HTTP_CONNECT_TIMEOUT,
+            'http_timeout' => self::DEFAULT_HTTP_TIMEOUT,
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
-            'http_connect_timeout' => null,
-            'http_timeout' => null,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -800,11 +812,11 @@ final class Options
         $resolver->setAllowedTypes('default_integrations', 'bool');
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
+        $resolver->setAllowedTypes('http_connect_timeout', ['int', 'float']);
+        $resolver->setAllowedTypes('http_timeout', ['int', 'float']);
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
-        $resolver->setAllowedTypes('http_connect_timeout', ['null', 'int']);
-        $resolver->setAllowedTypes('http_timeout', ['null', 'int']);
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -698,7 +698,7 @@ final class Options
     /**
      * Gets the amount of time in seconds that http connections can take to connect.
      *
-     * @param int $httpConnectTimeout The amount of time in seconds.
+     * @param int $httpConnectTimeout The amount of time in seconds
      */
     public function setHttpConnectTimeout(int $httpConnectTimeout): void
     {
@@ -708,7 +708,7 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds to wait for the Sentry server to respond.
+     * Gets the amount of time in seconds to wait for the Sentry server to respond
      */
     public function getHttpTimeout(): ?int
     {
@@ -716,9 +716,9 @@ final class Options
     }
 
     /**
-     * Gets the amount of time in seconds to wait for the Sentry server to respond.
+     * Gets the amount of time in seconds to wait for the Sentry server to respond
      *
-     * @param int $httpTimeout The amount of time in seconds.
+     * @param int $httpTimeout The amount of time in seconds
      */
     public function setHttpTimeout(int $httpTimeout): void
     {

--- a/src/Options.php
+++ b/src/Options.php
@@ -692,7 +692,7 @@ final class Options
      */
     public function getHttpConnectTimeout(): int
     {
-        return $this->options['http_connect_timeout'] ?? HttpClientFactory::DEFAULT_HTTP_CONNECT_TIMEOUT;
+        return $this->options['http_connect_timeout'];
     }
 
     /**
@@ -712,7 +712,7 @@ final class Options
      */
     public function getHttpTimeout(): int
     {
-        return $this->options['http_timeout'] ?? HttpClientFactory::DEFAULT_HTTP_TIMEOUT;
+        return $this->options['http_timeout'];
     }
 
     /**
@@ -802,8 +802,8 @@ final class Options
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
-        $resolver->setAllowedTypes('http_connect_timeout', 'int');
-        $resolver->setAllowedTypes('http_timeout', 'int');
+        $resolver->setAllowedTypes('http_connect_timeout', ['null', 'int']);
+        $resolver->setAllowedTypes('http_timeout', ['null', 'int']);
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));

--- a/src/Options.php
+++ b/src/Options.php
@@ -690,7 +690,7 @@ final class Options
     /**
      * Gets the amount of time in seconds that http connections can take to connect.
      */
-    public function getHttpConnectTimeout(): int
+    public function getHttpConnectTimeout(): ?int
     {
         return $this->options['http_connect_timeout'];
     }
@@ -710,7 +710,7 @@ final class Options
     /**
      * Gets the amount of time in seconds to wait for the Sentry server to respond.
      */
-    public function getHttpTimeout(): int
+    public function getHttpTimeout(): ?int
     {
         return $this->options['http_timeout'];
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -310,6 +310,24 @@ final class OptionsTest extends TestCase
             null,
             null,
         ];
+
+        yield [
+            'http_timeout',
+            100,
+            'getHttpTimeout',
+            'setHttpTimeout',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_connect_timeout',
+            150,
+            'getHttpConnectTimeout',
+            'setHttpConnectTimeout',
+            null,
+            null,
+        ];
     }
 
     /**

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -51,7 +51,7 @@ final class OptionsTest extends TestCase
 
         $options = new Options([$option => $value]);
 
-        $this->assertSame($value, $options->$getterMethod());
+        $this->assertEquals($value, $options->$getterMethod());
     }
 
     /**
@@ -81,7 +81,7 @@ final class OptionsTest extends TestCase
             $options->$setterMethod($value);
         }
 
-        $this->assertSame($value, $options->$getterMethod());
+        $this->assertEquals($value, $options->$getterMethod());
     }
 
     public function optionsDataProvider(): \Generator
@@ -294,6 +294,42 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'http_timeout',
+            1,
+            'getHttpTimeout',
+            'setHttpTimeout',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_timeout',
+            1.2,
+            'getHttpTimeout',
+            'setHttpTimeout',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_connect_timeout',
+            1,
+            'getHttpConnectTimeout',
+            'setHttpConnectTimeout',
+            null,
+            null,
+        ];
+
+        yield [
+            'http_connect_timeout',
+            1.2,
+            'getHttpConnectTimeout',
+            'setHttpConnectTimeout',
+            null,
+            null,
+        ];
+
+        yield [
             'capture_silenced_errors',
             true,
             'shouldCaptureSilencedErrors',
@@ -307,24 +343,6 @@ final class OptionsTest extends TestCase
             'small',
             'getMaxRequestBodySize',
             'setMaxRequestBodySize',
-            null,
-            null,
-        ];
-
-        yield [
-            'http_timeout',
-            100,
-            'getHttpTimeout',
-            'setHttpTimeout',
-            null,
-            null,
-        ];
-
-        yield [
-            'http_connect_timeout',
-            150,
-            'getHttpConnectTimeout',
-            'setHttpConnectTimeout',
             null,
             null,
         ];


### PR DESCRIPTION
I created this issue in the Symfony repo: https://github.com/getsentry/sentry-symfony/issues/592
This PR modifies the `HttpClientFactory` to allow configuration of the http (connect) timeout values.
If no option is set, it will use the default.

If I've missed the mark, feel free to reject - I'd just love to be able to do this in my app, if it's possible already please let me know, thanks!