### PR TITLE
Add missing entries to the `.gitattributes` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,9 +16,14 @@
 /.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.php_cs.dist export-ignore
+/.php-cs-fixer.dist.php export-ignore
 /.travis.yml export-ignore
 /Makefile export-ignore
 /phpstan.neon export-ignore
+/phpstan-baseline.neon export-ignore
 /phpunit.xml.dist export-ignore
 /psalm.xml.dist export-ignore
+/psalm-baseline.xml export-ignore
+/codecov.yml export-ignore
+/.github export-ignore
+/phpbench.json export-ignore


### PR DESCRIPTION
Closes #1287 by adding the missing entries to the `.gitattributes` file so that the snapshot archive of the repo does not include unecessary files besides the source files