### PR TITLE
Support handling of the server rate limits

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -175,7 +175,7 @@ final class Event
      */
     public static function createEvent(?EventId $eventId = null): self
     {
-        return new self($eventId, EventType::default());
+        return new self($eventId, EventType::event());
     }
 
     /**

--- a/src/EventType.php
+++ b/src/EventType.php
@@ -35,6 +35,11 @@ final class EventType implements \Stringable
         return self::getInstance('default');
     }
 
+    public static function event(): self
+    {
+        return self::getInstance('event');
+    }
+
     /**
      * Creates an instance of this enum for the "transaction" value.
      */

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -105,7 +105,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
             new HeaderSetPlugin(['User-Agent' => $this->sdkIdentifier . '/' . $this->sdkVersion]),
             new AuthenticationPlugin(new SentryAuthentication($options, $this->sdkIdentifier, $this->sdkVersion)),
             new RetryPlugin(['retries' => $options->getSendAttempts()]),
-            new ErrorPlugin(),
+            new ErrorPlugin(['only_server_exception' => true]),
         ];
 
         if ($options->isCompressionEnabled()) {

--- a/src/Transport/RateLimiter.php
+++ b/src/Transport/RateLimiter.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Transport;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Sentry\Event;
+use Sentry\EventType;
+use Sentry\Response;
+use Sentry\ResponseStatus;
+
+final class RateLimiter
+{
+    /**
+     * The name of the header to look at to know the rate limits for the events
+     * categories supported by the server.
+     */
+    private const RATE_LIMITS_HEADER = 'X-Sentry-Rate-Limits';
+
+    /**
+     * The name of the header to look at to know after how many seconds the HTTP
+     * request should be retried.
+     */
+    private const RETRY_AFTER_HEADER = 'Retry-After';
+
+    /**
+     * The number of seconds after which an HTTP request can be retried.
+     */
+    private const DEFAULT_RETRY_AFTER_DELAY_SECONDS = 60;
+
+    /**
+     * @var LoggerInterface An instance of a PSR-3 compatible logger
+     */
+    private $logger;
+
+    /**
+     * @var array<string, int> The map of time instants for each event category after
+     *                         which an HTTP request can be retried
+     */
+    private $rateLimits = [];
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function handleResponse(Event $event, ResponseInterface $response): Response
+    {
+        $sendResponse = new Response(ResponseStatus::createFromHttpStatusCode($response->getStatusCode()), $event);
+
+        if ($this->handleRateLimit($response)) {
+            $eventType = $event->getType();
+            $disabledUntil = $this->getDisabledUntil($eventType);
+
+            \assert(null !== $disabledUntil);
+
+            $this->logger->warning(
+                sprintf('Rate limited exceeded for requests of type "%s", backing off until "%s".', (string) $eventType, gmdate(\DATE_ATOM, $disabledUntil)),
+                ['event' => $event]
+            );
+        }
+
+        return $sendResponse;
+    }
+
+    public function isRateLimited(EventType $eventType): bool
+    {
+        $disabledUntil = $this->getDisabledUntil($eventType);
+
+        return null !== $disabledUntil && $disabledUntil > time();
+    }
+
+    private function getDisabledUntil(EventType $eventType): ?int
+    {
+        $category = (string) $eventType;
+
+        if ($eventType === EventType::event()) {
+            $category = 'error';
+        }
+
+        $allDeadline = $this->rateLimits['all'] ?? null;
+        $categoryDeadline = $this->rateLimits[$category] ?? null;
+
+        if (null === $allDeadline && null === $categoryDeadline) {
+            return null;
+        }
+
+        if ($categoryDeadline > $allDeadline) {
+            return $categoryDeadline;
+        }
+
+        return $allDeadline;
+    }
+
+    private function handleRateLimit(ResponseInterface $response): bool
+    {
+        $now = time();
+
+        if ($response->hasHeader(self::RATE_LIMITS_HEADER)) {
+            foreach (explode(',', $response->getHeaderLine(self::RATE_LIMITS_HEADER)) as $limit) {
+                $parameters = explode(':', $limit, 3);
+                $parameters = array_splice($parameters, 0, 2);
+                $delay = ctype_digit($parameters[0]) ? (int) $parameters[0] : self::DEFAULT_RETRY_AFTER_DELAY_SECONDS;
+
+                foreach (explode(';', $parameters[1]) as $category) {
+                    $this->rateLimits[$category ?: 'all'] = $now + $delay;
+                }
+            }
+
+            return true;
+        }
+
+        if ($response->hasHeader(self::RETRY_AFTER_HEADER)) {
+            $delay = $this->parseRetryAfterHeader($now, $response->getHeaderLine(self::RETRY_AFTER_HEADER));
+
+            $this->rateLimits['all'] = $now + $delay;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function parseRetryAfterHeader(int $currentTime, string $header): int
+    {
+        if (1 === preg_match('/^\d+$/', $header)) {
+            return (int) $header;
+        }
+
+        $headerDate = \DateTimeImmutable::createFromFormat(\DateTimeImmutable::RFC1123, $header);
+
+        if (false !== $headerDate && $headerDate->getTimestamp() >= $currentTime) {
+            return $headerDate->getTimestamp() - $currentTime;
+        }
+
+        return self::DEFAULT_RETRY_AFTER_DELAY_SECONDS;
+    }
+}

--- a/tests/Transport/RateLimiterTest.php
+++ b/tests/Transport/RateLimiterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Transport;
+
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Sentry\Event;
+use Sentry\EventType;
+use Sentry\ResponseStatus;
+use Sentry\Transport\RateLimiter;
+use Symfony\Bridge\PhpUnit\ClockMock;
+
+/**
+ * @group time-sensitive
+ */
+final class RateLimiterTest extends TestCase
+{
+    /**
+     * @var LoggerInterface&MockObject
+     */
+    private $logger;
+
+    /**
+     * @var RateLimiter
+     */
+    private $rateLimiter;
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->rateLimiter = new RateLimiter($this->logger);
+    }
+
+    /**
+     * @dataProvider handleResponseDataProvider
+     */
+    public function testHandleResponse(Event $event, ResponseInterface $response, ResponseStatus $responseStatus): void
+    {
+        ClockMock::withClockMock(1644105600);
+
+        $this->logger->expects($responseStatus === ResponseStatus::success() ? $this->never() : $this->once())
+            ->method('warning')
+            ->with('Rate limited exceeded for requests of type "event", backing off until "2022-02-06T00:01:00+00:00".', ['event' => $event]);
+
+        $transportResponse = $this->rateLimiter->handleResponse($event, $response);
+
+        $this->assertSame($responseStatus, $transportResponse->getStatus());
+        $this->assertSame($event, $transportResponse->getEvent());
+    }
+
+    public function handleResponseDataProvider(): \Generator
+    {
+        yield 'Rate limits headers missing' => [
+            Event::createEvent(),
+            new Response(),
+            ResponseStatus::success(),
+        ];
+
+        yield 'Back-off using X-Sentry-Rate-Limits header with single category' => [
+            Event::createEvent(),
+            new Response(429, ['X-Sentry-Rate-Limits' => '60:error:org']),
+            ResponseStatus::rateLimit(),
+        ];
+
+        yield 'Back-off using X-Sentry-Rate-Limits header with multiple categories' => [
+            Event::createEvent(),
+            new Response(429, ['X-Sentry-Rate-Limits' => '60:error;transaction:org']),
+            ResponseStatus::rateLimit(),
+        ];
+
+        yield 'Back-off using X-Sentry-Rate-Limits header with missing categories should lock them all' => [
+            Event::createEvent(),
+            new Response(429, ['X-Sentry-Rate-Limits' => '60::org']),
+            ResponseStatus::rateLimit(),
+        ];
+
+        yield 'Back-off using Retry-After header with number-based value' => [
+            Event::createEvent(),
+            new Response(429, ['Retry-After' => '60']),
+            ResponseStatus::rateLimit(),
+        ];
+
+        yield 'Back-off using Retry-After header with date-based value' => [
+            Event::createEvent(),
+            new Response(429, ['Retry-After' => 'Sun, 02 February 2022 00:01:00 GMT']),
+            ResponseStatus::rateLimit(),
+        ];
+    }
+
+    public function testIsRateLimited(): void
+    {
+        // Events should not be rate-limited at all
+        ClockMock::withClockMock(1644105600);
+
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::event()));
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+
+        // Events should be rate-limited for 60 seconds, but transactions should
+        // still be allowed to be sent
+        $this->rateLimiter->handleResponse(Event::createEvent(), new Response(429, ['X-Sentry-Rate-Limits' => '60:error:org']));
+
+        $this->assertTrue($this->rateLimiter->isRateLimited(EventType::event()));
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+
+        // Events should not be rate-limited anymore once the deadline expired
+        ClockMock::withClockMock(1644105660);
+
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::event()));
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+
+        // Both events and transactions should be rate-limited if all categories
+        // are
+        $this->rateLimiter->handleResponse(Event::createTransaction(), new Response(429, ['X-Sentry-Rate-Limits' => '60:all:org']));
+
+        $this->assertTrue($this->rateLimiter->isRateLimited(EventType::event()));
+        $this->assertTrue($this->rateLimiter->isRateLimited(EventType::transaction()));
+
+        // Both events and transactions should not be rate-limited anymore once
+        // the deadline expired
+        ClockMock::withClockMock(1644105720);
+
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::event()));
+        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,6 +7,7 @@ use Http\Discovery\Strategy\MockClientStrategy;
 use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\Tracing\Span;
+use Sentry\Transport\RateLimiter;
 use Symfony\Bridge\PhpUnit\ClockMock;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -27,3 +28,4 @@ ClassDiscovery::appendStrategy(MockClientStrategy::class);
 ClockMock::register(Event::class);
 ClockMock::register(Breadcrumb::class);
 ClockMock::register(Span::class);
+ClockMock::register(RateLimiter::class);


### PR DESCRIPTION
As per title, this PR adds support for handling the rate limits when sending events to the Sentry server. There are obvious limitations of this implementation due to the fact that the status of the rate limits does not persist across handling multiple server requests, but at least within the lifecycle of a single request issues like keeping flooding the server should now be avoided