### PR TITLE
Bump the minimum version of `guzzlehttp/psr7` to avoid `CVE-2022-24775`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Bump minimum version of `guzzlehttp/psr7` package to avoid [`CVE-2022-24775`](https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh96) (#1305)
+
 ## 3.4.0 (2022-03-14)
 
 - Update Guzzle tracing middleware to meet the [expected standard](https://develop.sentry.dev/sdk/features/#http-client-integrations) (#1234)

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "guzzlehttp/promises": "^1.4",
-        "guzzlehttp/psr7": "^1.7|^2.0",
+        "guzzlehttp/psr7": "^1.8.4|^2.1.1",
         "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",


### PR DESCRIPTION
Fixes #1300 by bumping the minimum supported version of `guzzlehttp/psr7`. Luckily the security issue was fixed for both version `1.x` and `2.x`, so we don't have to do any breaking release