### PR TITLE
Remove memory addresses from anonymous class frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Bump minimum version of `guzzlehttp/psr7` package to avoid [`CVE-2022-24775`](https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh96) (#1305)
-- Remove memory addresses from stack trace frames with anonymous classes in PHP 8 (#1314)
+- Fix stripping of memory addresses from stacktrace frames of anonymous classes in PHP `>=7.4.2` (#1314)
 
 ## 3.4.0 (2022-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Bump minimum version of `guzzlehttp/psr7` package to avoid [`CVE-2022-24775`](https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh96) (#1305)
-- Remove memory addresses from stack trace frames with anonymous classes in PHP 8
+- Remove memory addresses from stack trace frames with anonymous classes in PHP 8 (#1314)
 
 ## 3.4.0 (2022-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bump minimum version of `guzzlehttp/psr7` package to avoid [`CVE-2022-24775`](https://github.com/guzzle/psr7/security/advisories/GHSA-q7rv-6hp3-vh96) (#1305)
+- Remove memory addresses from stack trace frames with anonymous classes in PHP 8
 
 ## 3.4.0 (2022-03-14)
 

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -76,7 +76,7 @@ final class FrameBuilder
             }
 
             $rawFunctionName = sprintf('%s::%s', $backtraceFrame['class'], $backtraceFrame['function']);
-            $functionName = sprintf('%s::%s', preg_replace('/(\$|0x)[a-fA-F0-9]+$/', '', $functionName), $backtraceFrame['function']);
+            $functionName = sprintf('%s::%s', preg_replace('/(?::\d+\$|0x)[a-fA-F0-9]+$/', '', $functionName), $backtraceFrame['function']);
         } elseif (isset($backtraceFrame['function'])) {
             $functionName = $backtraceFrame['function'];
         }

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -76,7 +76,7 @@ final class FrameBuilder
             }
 
             $rawFunctionName = sprintf('%s::%s', $backtraceFrame['class'], $backtraceFrame['function']);
-            $functionName = sprintf('%s::%s', preg_replace('/0x[a-fA-F0-9]+$/', '', $functionName), $backtraceFrame['function']);
+            $functionName = sprintf('%s::%s', preg_replace('/(\$|0x)[a-fA-F0-9]+$/', '', $functionName), $backtraceFrame['function']);
         } elseif (isset($backtraceFrame['function'])) {
             $functionName = $backtraceFrame['function'];
         }

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -203,7 +203,7 @@ final class StacktraceTest extends TestCase
             ],
         ];
 
-        yield 'Backtrace with frame containing memory address 0x format' => [
+        yield 'Backtrace with frame containing memory address in PHP <7.4.2 format' => [
             new Options([
                 'prefixes' => ['/path-prefix'],
             ]),
@@ -242,7 +242,7 @@ final class StacktraceTest extends TestCase
             ],
         ];
 
-        yield 'Backtrace with frame containing memory address $ format' => [
+        yield 'Backtrace with frame containing memory address in PHP >=7.4.2 format' => [
             new Options([
                 'prefixes' => ['/path-prefix'],
             ]),
@@ -269,12 +269,12 @@ final class StacktraceTest extends TestCase
                     0,
                 ],
                 [
-                    "class@anonymous\x00/path/to/app/consumer.php:12::messageCallback",
+                    "class@anonymous\x00/path/to/app/consumer.php::messageCallback",
                     Frame::INTERNAL_FRAME_FILENAME,
                     0,
                 ],
                 [
-                    "class@anonymous\x00/path/to/app/consumer.php:12::messageCallback",
+                    "class@anonymous\x00/path/to/app/consumer.php::messageCallback",
                     'path/to/file',
                     12,
                 ],

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -203,7 +203,7 @@ final class StacktraceTest extends TestCase
             ],
         ];
 
-        yield 'Backtrace with frame containing memory address' => [
+        yield 'Backtrace with frame containing memory address 0x format' => [
             new Options([
                 'prefixes' => ['/path-prefix'],
             ]),
@@ -236,6 +236,45 @@ final class StacktraceTest extends TestCase
                 ],
                 [
                     "class@anonymous\x00/path/to/app/consumer.php::messageCallback",
+                    'path/to/file',
+                    12,
+                ],
+            ],
+        ];
+
+        yield 'Backtrace with frame containing memory address $ format' => [
+            new Options([
+                'prefixes' => ['/path-prefix'],
+            ]),
+            [
+                'file' => 'path/to/file',
+                'line' => 12,
+                'backtrace' => [
+                    [
+                        'class' => "class@anonymous\x00/path/to/app/consumer.php:12$3e0a7",
+                        'function' => 'messageCallback',
+                        'type' => '->',
+                    ],
+                    [
+                        'class' => "class@anonymous\x00/path-prefix/path/to/app/consumer.php:12$3e0a7",
+                        'function' => 'messageCallback',
+                        'type' => '->',
+                    ],
+                ],
+            ],
+            [
+                [
+                    null,
+                    Frame::INTERNAL_FRAME_FILENAME,
+                    0,
+                ],
+                [
+                    "class@anonymous\x00/path/to/app/consumer.php:12::messageCallback",
+                    Frame::INTERNAL_FRAME_FILENAME,
+                    0,
+                ],
+                [
+                    "class@anonymous\x00/path/to/app/consumer.php:12::messageCallback",
                     'path/to/file',
                     12,
                 ],


### PR DESCRIPTION
Match the new `${addr}` syntax as well as the previous `0x{addr}` syntax when stripping out the memory address so that events can group correctly again.

For https://github.com/getsentry/sentry-php/issues/1314