### PR TITLE
expose transport exceptions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -159,6 +159,10 @@ final class Client implements ClientInterface
                 return $event->getId();
             }
         } catch (\Throwable $exception) {
+            $this->logger->error(
+                sprintf('Failed to send the event to Sentry. Reason: "%s".', $exception->getMessage()),
+                ['exception' => $exception, 'event' => $event]
+            );
         }
 
         return null;


### PR DESCRIPTION

Send transport exceptions to logger, instead of ignoring, thus allowing for the problem to be noticed and handled.

Currently an exception thrown on line 155 gets swallowed by the "catch" block and causes Sentry events to be **discarded silently** (e.g. in case of unsuccessful HTTP requests).

https://github.com/getsentry/sentry-php/blob/5b611e3f09035f5ad5edf494443e3236bd5ea482/src/Client.php#L153-L162

This happens when `HttpTransport->send()` [returns a `RejectedPromise`](https://github.com/getsentry/sentry-php/blob/5b611e3f09035f5ad5edf494443e3236bd5ea482/src/Transport/HttpTransport.php#L143) .  Line 155 becomes: 

```php
$response = RejectedPromise->wait()
```

which  [throws a](https://github.com/guzzle/promises/blob/fe752aedc9fd8fcca3fe7ad05d419d32998a06da/src/RejectedPromise.php#L64) `RejectionException`.

