### PR TITLE
Fix PHPStan errors after update to latest version

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/Dsn.php
 
 		-
+			message: "#^Offset 'host'\\|'path'\\|'scheme'\\|'user' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
+			count: 1
+			path: src/Dsn.php
+
+		-
 			message: "#^Offset 'path' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 4
 			path: src/Dsn.php

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -166,7 +166,7 @@ final class FrameBuilder
         $reflectionFunction = null;
 
         try {
-            if (isset($backtraceFrame['class'], $backtraceFrame['function'])) {
+            if (isset($backtraceFrame['class'])) {
                 if (method_exists($backtraceFrame['class'], $backtraceFrame['function'])) {
                     $reflectionFunction = new \ReflectionMethod($backtraceFrame['class'], $backtraceFrame['function']);
                 } elseif (isset($backtraceFrame['type']) && '::' === $backtraceFrame['type']) {


### PR DESCRIPTION
After the recent release of PHPStan `1.7`, something changed and new errors started getting reported. One was easily solved, the other one instead is due to a known limitation of the tool and so I decided to ignore it.