### PR TITLE
Ability to set or remove single tag in the Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for `monolog/monolog:^3.0` (#1321)
+- Add `setTag` and `removeTag` public methods to `Event` for easier manipulation of tags (#1324)
 
 ## 3.5.0 (2022-05-19)
 

--- a/src/Event.php
+++ b/src/Event.php
@@ -490,6 +490,27 @@ final class Event
     }
 
     /**
+     * Sets or updates a tag in this event.
+     *
+     * @param string $key   The key that uniquely identifies the tag
+     * @param string $value The value
+     */
+    public function setTag(string $key, string $value): void
+    {
+        $this->tags[$key] = $value;
+    }
+
+    /**
+     * Removes a given tag from the event.
+     *
+     * @param string $key The key that uniquely identifies the tag
+     */
+    public function removeTag(string $key): void
+    {
+        unset($this->tags[$key]);
+    }
+
+    /**
      * Gets the user context.
      */
     public function getUser(): ?UserDataBag

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -101,4 +101,19 @@ final class EventTest extends TestCase
             ['environment', 'foo'],
         ];
     }
+
+    public function testSetAndRemoveTag(): void
+    {
+        $tagName = 'tag';
+        $tagValue = 'value';
+
+        $event = Event::createEvent();
+        $event->setTag($tagName, $tagValue);
+
+        $this->assertSame([$tagName => $tagValue], $event->getTags());
+
+        $event->removeTag($tagName);
+
+        $this->assertEmpty($event->getTags());
+    }
 }


### PR DESCRIPTION
For easier event processing instead of `getTags -> change -> setTags`.