### PR TITLE
Add `use_local_relay` option

### DIFF
--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -117,6 +117,18 @@ final class Dsn implements \Stringable
     }
 
     /**
+     * Overwrite parts of the DSN to point to a local Relay instance.
+     *
+     * @return void
+     */
+    public function useLocalRelay(): void
+    {
+        $this->scheme = 'http';
+        $this->host = 'localhost';
+        $this->port = 3000;
+    }
+
+    /**
      * Gets the protocol to be used to access the resource.
      */
     public function getScheme(): string

--- a/src/Options.php
+++ b/src/Options.php
@@ -795,6 +795,7 @@ final class Options
             'capture_silenced_errors' => false,
             'max_request_body_size' => 'medium',
             'class_serializers' => [],
+            'use_local_relay' => false,
         ]);
 
         $resolver->setAllowedTypes('send_attempts', 'int');
@@ -827,6 +828,7 @@ final class Options
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
+        $resolver->setAllowedTypes('use_local_relay', 'bool');
 
         $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
@@ -908,7 +910,13 @@ final class Options
                 return null;
         }
 
-        return Dsn::createFromString($value);
+        $dsn = Dsn::createFromString($value);
+
+        if ($options['use_local_relay']) {
+            $dsn->useLocalRelay();
+        }
+
+        return $dsn;
     }
 
     /**

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -441,6 +441,31 @@ final class OptionsTest extends TestCase
     }
 
     /**
+     * @dataProvider dsnOptionInteractionWithLocalRelayDataProvider
+     */
+    public function testDsnInteractionWithLocalRelayOption($value, ?Dsn $expectedDsnAsObject, bool $useLocalRelay): void
+    {
+        $options = new Options(['dsn' => $value, 'use_local_relay' => $useLocalRelay]);
+
+        $this->assertEquals($expectedDsnAsObject, $options->getDsn());
+    }
+
+    public function dsnOptionInteractionWithLocalRelayDataProvider(): \Generator
+    {
+        yield [
+            'https://public:secret@example.com/sentry/1',
+            Dsn::createFromString('https://public:secret@example.com/sentry/1'),
+            false,
+        ];
+
+        yield [
+            'https://public:secret@example.com/sentry/1',
+            Dsn::createFromString('http://public:secret@localhost:3000/sentry/1'),
+            true,
+        ];
+    }
+
+    /**
      * @dataProvider excludedPathProviders
      */
     public function testExcludedAppPathsPathRegressionWithFileName(string $value, string $expected): void


### PR DESCRIPTION
Relates to #1313.

This adds a `use_local_relay` option to the SDK option you can supply like:

```php
Sentry\init([
    'dsn' => 'https://fa516ddb2fb44c44a2c4c9ce2638af99@o12345.ingest.sentry.io/1234',
    'use_local_relay' => true,
]);
```

Internally this will result in the DSN used by the SDK to look like:

```
http://fa516ddb2fb44c44a2c4c9ce2638af99@localhost:3000/1234
```

(changing the scheme to `http`, the host to `localhost` and the port to `3000`)

If relay is deployed elsewhere in the infrastructure the user can simply modify their own DSN to make the needed adjustments instead of us adding options for custom scheme, host and port when relay is used (hence the `local` in the option name). This is just a convenience option for when you deploy Relay next to your application.

This might need to be enhanced later to still supply the original scheme/domain/port to let Relay now where to relay to, but this is not supported by Relay yet so I've not added this here at this time.