### PR TITLE
bug: Set sentry-trace header when using tracing middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Set the `sentry-trace` header when using the tracing middleware (#1331)
+
 ## 3.6.0 (2022-06-10)
 
 - Add support for `monolog/monolog:^3.0` (#1321)

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -34,7 +34,7 @@ final class GuzzleTracingMiddleware
 
                 $childSpan = $span->startChild($spanContext);
 
-                $request->withHeader('sentry-trace', $childSpan->toTraceparent());
+                $request = $request->withHeader('sentry-trace', $childSpan->toTraceparent());
 
                 $handlerPromiseCallback = static function ($responseOrException) use ($hub, $request, $childSpan) {
                     // We finish the span (which means setting the span end timestamp) first to ensure the measured time

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -104,7 +104,8 @@ final class GuzzleTracingMiddlewareTest extends TestCase
         $hub->setSpan($transaction);
 
         $middleware = GuzzleTracingMiddleware::trace($hub);
-        $function = $middleware(static function () use ($expectedPromiseResult): PromiseInterface {
+        $function = $middleware(function (Request $request) use ($expectedPromiseResult): PromiseInterface {
+            $this->assertNotEmpty($request->getHeader('sentry-trace'));
             if ($expectedPromiseResult instanceof \Throwable) {
                 return new RejectedPromise($expectedPromiseResult);
             }


### PR DESCRIPTION
According to [PSR-7](https://www.php-fig.org/psr/psr-7/), `withHeader` operates in the following manner:
```
Return an instance with the provided value replacing the specified header.
[...]
This method MUST be implemented in such a way as to retain the
immutability of the message, and MUST return an instance that has the
new and/or updated header and value.
```
(see: https://www.php-fig.org/psr/psr-7/)

Due to this, we must set `$request` to the modified request object (from the return value of
withHeader) in order to actually send the sentry-trace header.