### PR TITLE
Fix `Scope::getTransaction()` so that it returns also unsampled transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `Scope::getTransaction()` so that it returns also unsampled transactions (#1334)
+
 ## 3.6.1 (2022-06-27)
 
 - Set the `sentry-trace` header when using the tracing middleware (#1331)

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -408,12 +408,8 @@ final class Scope
      */
     public function getTransaction(): ?Transaction
     {
-        $span = $this->span;
-
-        if (null !== $span && null !== $span->getSpanRecorder() && !empty($span->getSpanRecorder()->getSpans())) {
-            // The first span in the recorder is considered to be a Transaction
-            /** @var Transaction */
-            return $span->getSpanRecorder()->getSpans()[0];
+        if (null !== $this->span) {
+            return $this->span->getTransaction();
         }
 
         return null;

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -7,7 +7,7 @@ namespace Sentry\Tracing;
 use Sentry\EventId;
 
 /**
- * This class stores all the information about a Span.
+ * This class stores all the information about a span.
  */
 class Span
 {
@@ -22,22 +22,22 @@ class Span
     protected $traceId;
 
     /**
-     * @var string|null Description of the Span
+     * @var string|null Description of the span
      */
     protected $description;
 
     /**
-     * @var string|null Operation of the Span
+     * @var string|null Operation of the span
      */
     protected $op;
 
     /**
-     * @var SpanStatus|null Completion status of the Span
+     * @var SpanStatus|null Completion status of the span
      */
     protected $status;
 
     /**
-     * @var SpanId|null ID of the parent Span
+     * @var SpanId|null ID of the parent span
      */
     protected $parentSpanId;
 
@@ -47,7 +47,7 @@ class Span
     protected $sampled;
 
     /**
-     * @var array<string, string> A List of tags associated to this Span
+     * @var array<string, string> A List of tags associated to this span
      */
     protected $tags = [];
 
@@ -67,9 +67,14 @@ class Span
     protected $endTimestamp;
 
     /**
-     * @var SpanRecorder|null Reference instance to the SpanRecorder
+     * @var SpanRecorder|null Reference instance to the {@see SpanRecorder}
      */
     protected $spanRecorder;
+
+    /**
+     * @var Transaction|null The transaction containing this span
+     */
+    protected $transaction;
 
     /**
      * Constructor.
@@ -390,6 +395,7 @@ class Span
         $context->setTraceId($this->traceId);
 
         $span = new self($context);
+        $span->transaction = $this->transaction;
         $span->spanRecorder = $this->spanRecorder;
 
         if (null != $span->spanRecorder) {
@@ -415,6 +421,14 @@ class Span
     public function detachSpanRecorder(): void
     {
         $this->spanRecorder = null;
+    }
+
+    /**
+     * Returns the transaction containing this span.
+     */
+    public function getTransaction(): ?Transaction
+    {
+        return $this->transaction;
     }
 
     /**

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -38,6 +38,7 @@ final class Transaction extends Span
 
         $this->hub = $hub ?? SentrySdk::getCurrentHub();
         $this->name = $context->getName();
+        $this->transaction = $this;
     }
 
     /**


### PR DESCRIPTION
Fixes #1333: `Scope::getTransaction()` was using the `SpanRecorder` to find the active transaction to return, but if the transaction is unsampled the recorder doesn't keep track of it and so `null` is returned. By adding a reference to the parent transaction inside each span, we can bypass the recorder and directly retrieve it, regardless of its sampling status. The original fix was implemented in getsentry/sentry-javascript#2952, and this is just a porting of it.