### PR TITLE
ci: Fix phpunit deprecations

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="true"
-         colors="true"
-         bootstrap="tests/bootstrap.php"
-         cacheResult="false"
-         beStrictAboutOutputDuringTests="true"
+<phpunit
+    backupGlobals="true"
+    colors="true"
+    bootstrap="tests/bootstrap.php"
+    cacheResult="false"
+    beStrictAboutOutputDuringTests="true"
 >
     <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0"/>
     </php>
 
     <testsuites>
@@ -18,23 +17,11 @@
         </testsuite>
     </testsuites>
 
-    <coverage>
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
-    </coverage>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
     <listeners>
-        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
     </listeners>
 
     <extensions>
-        <extension class="Sentry\Tests\SentrySdkExtension" />
+        <extension class="Sentry\Tests\SentrySdkExtension"/>
     </extensions>
 </phpunit>


### PR DESCRIPTION
This fixes 

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 21:
  - Element 'coverage': This element is not expected.

  Test results may not be as expected.
```

and 

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 27:
  - Element 'filter': This element is not expected.

  Test results may not be as expected.
```