### PR TITLE
ref: Drop symfony/polyfill-uuid in favour of a standalone implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Drop symfony/polyfill-uuid in favour of a standalone implementation (#1346)
+
 ## 3.7.0 (2022-07-18)
 
 - Fix `Scope::getTransaction()` so that it returns also unsampled transactions (#1334)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-Drop symfony/polyfill-uuid in favour of a standalone implementation (#1346)
+- Drop symfony/polyfill-uuid in favour of a standalone implementation (#1346)
 
 ## 3.7.0 (2022-07-18)
 

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "psr/http-message-implementation": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/options-resolver": "^3.4.43|^4.4.30|^5.0.11|^6.0",
-        "symfony/polyfill-php80": "^1.17",
-        "symfony/polyfill-uuid": "^1.13.1"
+        "symfony/polyfill-php80": "^1.17"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19|3.4.*",

--- a/src/EventId.php
+++ b/src/EventId.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Sentry\Util\SentryUid;
+
 /**
  * This class represents an event ID.
  *
@@ -32,10 +34,12 @@ final class EventId implements \Stringable
 
     /**
      * Generates a new event ID.
+     *
+     * @copyright Matt Farina MIT License https://github.com/lootils/uuid/blob/master/LICENSE
      */
     public static function generate(): self
     {
-        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
+        return new self(SentryUid::generate());
     }
 
     public function __toString(): string

--- a/src/Tracing/SpanId.php
+++ b/src/Tracing/SpanId.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry\Tracing;
 
+use Sentry\Util\SentryUid;
+
 /**
  * This class represents an span ID.
  */
@@ -33,7 +35,7 @@ final class SpanId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(substr(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)), 0, 16));
+        return new self(substr(SentryUid::generate(), 0, 16));
     }
 
     /**

--- a/src/Tracing/TraceId.php
+++ b/src/Tracing/TraceId.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry\Tracing;
 
+use Sentry\Util\SentryUid;
+
 /**
  * This class represents an trace ID.
  */
@@ -33,7 +35,7 @@ final class TraceId implements \Stringable
      */
     public static function generate(): self
     {
-        return new self(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
+        return new self(SentryUid::generate());
     }
 
     public function __toString(): string

--- a/src/Util/SentryUid.php
+++ b/src/Util/SentryUid.php
@@ -17,7 +17,7 @@ final class SentryUid
     public static function generate(): string
     {
         if (function_exists('uuid_create')) {
-            return str_replace('-', '', uuid_create(UUID_TYPE_RANDOM));
+            return strtolower(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
         }
 
         $uuid = bin2hex(random_bytes(16));

--- a/src/Util/SentryUid.php
+++ b/src/Util/SentryUid.php
@@ -16,7 +16,7 @@ final class SentryUid
      */
     public static function generate(): string
     {
-        if (function_exists('uuid_create')) {
+        if (\function_exists('uuid_create')) {
             return strtolower(str_replace('-', '', uuid_create(UUID_TYPE_RANDOM)));
         }
 

--- a/src/Util/SentryUid.php
+++ b/src/Util/SentryUid.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Util;
+
+/**
+ * @internal
+ */
+final class SentryUid
+{
+    /**
+     * Generate a random "Sentry UID", a UUID version 4 without dashes.
+     *
+     * @copyright Fabien Potencier MIT License https://github.com/symfony/polyfill/blob/main/LICENSE
+     */
+    public static function generate(): string
+    {
+        $uuid = bin2hex(random_bytes(16));
+
+        return sprintf('%08s%04s4%03s%04x%012s',
+            // 32 bits for "time_low"
+            substr($uuid, 0, 8),
+            // 16 bits for "time_mid"
+            substr($uuid, 8, 4),
+            // 16 bits for "time_hi_and_version",
+            // four most significant bits holds version number 4
+            substr($uuid, 13, 3),
+            // 16 bits:
+            // * 8 bits for "clk_seq_hi_res",
+            // * 8 bits for "clk_seq_low",
+            // two most significant bits holds zero and one for variant DCE1.1
+            hexdec(substr($uuid, 16, 4)) & 0x3FFF | 0x8000,
+            // 48 bits for "node"
+            substr($uuid, 20, 12)
+        );
+    }
+}

--- a/src/Util/SentryUid.php
+++ b/src/Util/SentryUid.php
@@ -18,25 +18,25 @@ final class SentryUid
     {
         if (function_exists('uuid_create')) {
             return str_replace('-', '', uuid_create(UUID_TYPE_RANDOM));
-        } else {
-            $uuid = bin2hex(random_bytes(16));
-
-            return sprintf('%08s%04s4%03s%04x%012s',
-                // 32 bits for "time_low"
-                substr($uuid, 0, 8),
-                // 16 bits for "time_mid"
-                substr($uuid, 8, 4),
-                // 16 bits for "time_hi_and_version",
-                // four most significant bits holds version number 4
-                substr($uuid, 13, 3),
-                // 16 bits:
-                // * 8 bits for "clk_seq_hi_res",
-                // * 8 bits for "clk_seq_low",
-                // two most significant bits holds zero and one for variant DCE1.1
-                hexdec(substr($uuid, 16, 4)) & 0x3FFF | 0x8000,
-                // 48 bits for "node"
-                substr($uuid, 20, 12)
-            );
         }
+
+        $uuid = bin2hex(random_bytes(16));
+
+        return sprintf('%08s%04s4%03s%04x%012s',
+            // 32 bits for "time_low"
+            substr($uuid, 0, 8),
+            // 16 bits for "time_mid"
+            substr($uuid, 8, 4),
+            // 16 bits for "time_hi_and_version",
+            // four most significant bits holds version number 4
+            substr($uuid, 13, 3),
+            // 16 bits:
+            // * 8 bits for "clk_seq_hi_res",
+            // * 8 bits for "clk_seq_low",
+            // two most significant bits holds zero and one for variant DCE1.1
+            hexdec(substr($uuid, 16, 4)) & 0x3FFF | 0x8000,
+            // 48 bits for "node"
+            substr($uuid, 20, 12)
+        );
     }
 }

--- a/src/Util/SentryUid.php
+++ b/src/Util/SentryUid.php
@@ -16,23 +16,27 @@ final class SentryUid
      */
     public static function generate(): string
     {
-        $uuid = bin2hex(random_bytes(16));
+        if (function_exists('uuid_create')) {
+            return str_replace('-', '', uuid_create(UUID_TYPE_RANDOM));
+        } else {
+            $uuid = bin2hex(random_bytes(16));
 
-        return sprintf('%08s%04s4%03s%04x%012s',
-            // 32 bits for "time_low"
-            substr($uuid, 0, 8),
-            // 16 bits for "time_mid"
-            substr($uuid, 8, 4),
-            // 16 bits for "time_hi_and_version",
-            // four most significant bits holds version number 4
-            substr($uuid, 13, 3),
-            // 16 bits:
-            // * 8 bits for "clk_seq_hi_res",
-            // * 8 bits for "clk_seq_low",
-            // two most significant bits holds zero and one for variant DCE1.1
-            hexdec(substr($uuid, 16, 4)) & 0x3FFF | 0x8000,
-            // 48 bits for "node"
-            substr($uuid, 20, 12)
-        );
+            return sprintf('%08s%04s4%03s%04x%012s',
+                // 32 bits for "time_low"
+                substr($uuid, 0, 8),
+                // 16 bits for "time_mid"
+                substr($uuid, 8, 4),
+                // 16 bits for "time_hi_and_version",
+                // four most significant bits holds version number 4
+                substr($uuid, 13, 3),
+                // 16 bits:
+                // * 8 bits for "clk_seq_hi_res",
+                // * 8 bits for "clk_seq_low",
+                // two most significant bits holds zero and one for variant DCE1.1
+                hexdec(substr($uuid, 16, 4)) & 0x3FFF | 0x8000,
+                // 48 bits for "node"
+                substr($uuid, 20, 12)
+            );
+        }
     }
 }

--- a/tests/Util/SentryUidTest.php
+++ b/tests/Util/SentryUidTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Util\SentryUid;
+
+final class SentryUidTest extends TestCase
+{
+    public function testGenerate(): void
+    {
+        $result = SentryUid::generate();
+        $pattern = '/^[0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}$/';
+        $match = (bool) preg_match($pattern, $result);
+        $this->assertTrue($match);
+    }
+}


### PR DESCRIPTION
As we only use one single method of `symfony/polyfill-uuid`, I'm in favor of removing this as a dependency and implementing the method directly in the SDK.

The code is based on [symfony/polyfill-uuid](https://github.com/symfony/polyfill/blob/d45b58e9f527e408fb28c4b6431b7284f8c168ff/src/Uuid/Uuid.php#L356), hence the `@copyright` annotation.