### PR TITLE
chore: add issue templates/forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,50 @@
+name: 🐞 Bug Report
+description: Tell us about something that's not working the way we (probably) intend.
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: How do you use Sentry?
+      options:
+        - Sentry Saas (sentry.io)
+        - Self-hosted/on-premise
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which SDK version?
+      placeholder: ex. 3.7.0
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to Reproduce
+      description: How can we see what you're seeing? Specific is terrific.
+      placeholder: |-
+        1. What
+        2. you
+        3. did.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Result
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Result
+      description: Logs? Screenshots? Yes, please.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thanks 🙏
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support Request
+    url: https://sentry.io/support
+    about: Use our dedicated support channel for paid accounts.
+  

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,30 @@
+name: 💡 Feature Request
+description: Create a feature request for sentry-php SDK.
+labels: 'enhancement'
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a feature request! Please fill out this form as completely as possible.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: A clear and concise description of what you want and what your use case is.
+      placeholder: |-
+        I want to make whirled peas, but Sentry doesn't blend.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Solution Brainstorm
+      description: We know you have bright ideas to share ... share away, friend.
+      placeholder: |-
+        Add a blender to Sentry.
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |-
+        ## Thanks 🙏
+        Check our [triage docs](https://open.sentry.io/triage/) for what to expect next.


### PR DESCRIPTION
This PR adds [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms) to help us create better, more structured and easier to read issues on this repository.

It is also trying to align how we are using issues on other Sentry SDK repositories ([example on JS repo](https://github.com/getsentry/sentry-javascript/issues/new/choose)).