### PR TITLE
fix: Do not throw an TypeError on numeric HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Do not throw an TypeError on numeric HTTP headers (#1370)
+
 ## 3.8.0 (2022-09-05)
 
 - Add `Sentry\Monolog\BreadcrumbHandler`, a Monolog handler to allow registration of logs as breadcrumbs (#1199)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,6 +91,11 @@ parameters:
 			path: src/Integration/IgnoreErrorsIntegration.php
 
 		-
+			message: "#^Method Sentry\\\\Integration\\\\RequestIntegration\\:\\:sanitizeHeaders\\(\\) should return array\\<string, array\\<string\\>\\> but returns array\\<int\\|string, array\\<string\\>\\>\\.$#"
+			count: 1
+			path: src/Integration/RequestIntegration.php
+
+		-
 			message: "#^Property Sentry\\\\Integration\\\\RequestIntegration\\:\\:\\$options \\(array\\{pii_sanitize_headers\\: array\\<string\\>\\}\\) does not accept array\\.$#"
 			count: 1
 			path: src/Integration/RequestIntegration.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,11 +91,6 @@ parameters:
 			path: src/Integration/IgnoreErrorsIntegration.php
 
 		-
-			message: "#^Method Sentry\\\\Integration\\\\RequestIntegration\\:\\:sanitizeHeaders\\(\\) should return array\\<string, array\\<string\\>\\> but returns array\\<int\\|string, array\\<string\\>\\>\\.$#"
-			count: 1
-			path: src/Integration/RequestIntegration.php
-
-		-
 			message: "#^Property Sentry\\\\Integration\\\\RequestIntegration\\:\\:\\$options \\(array\\{pii_sanitize_headers\\: array\\<string\\>\\}\\) does not accept array\\.$#"
 			count: 1
 			path: src/Integration/RequestIntegration.php

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -169,13 +169,16 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * Removes headers containing potential PII.
      *
-     * @param array<string, string[]> $headers Array containing request headers
+     * @param array<mixed, string[]> $headers Array containing request headers
      *
      * @return array<string, string[]>
      */
     private function sanitizeHeaders(array $headers): array
     {
         foreach ($headers as $name => $values) {
+            // Cast the header name into a string, to avoid errors on numeric headers
+            $name = (string) $name;
+
             if (!\in_array(strtolower($name), $this->options['pii_sanitize_headers'], true)) {
                 continue;
             }

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -169,7 +169,7 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * Removes headers containing potential PII.
      *
-     * @param array<mixed, string[]> $headers Array containing request headers
+     * @param array<array-key, string[]> $headers Array containing request headers
      *
      * @return array<string, string[]>
      */

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -422,6 +422,22 @@ final class RequestIntegrationTest extends TestCase
             null,
             null,
         ];
+
+        yield [
+            [],
+            (new ServerRequest('GET', 'http://www.example.com/foo'))
+                ->withHeader('123', 'test'),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'GET',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    '123' => ['test'],
+                ],
+            ],
+            null,
+            null,
+        ];
     }
 
     private function createRequestFetcher(ServerRequestInterface $request): RequestFetcherInterface


### PR DESCRIPTION
Fixes #1369 

While I'm not entirely sure if numeric headers are in sync with the spec, we should definitely not throw an `TypeError` in this case.