### PR TITLE
ref: Use constant for the SDK version

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,7 +7,6 @@ statusProvider:
   name: github
 artifactProvider:
   name: none
-preReleaseCommand: ""
 targets:
   - name: github
   - name: registry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use constant for the SDK version (#1367)
+
 ## 3.8.1 (2022-09-21)
 
 - fix: Do not throw an TypeError on numeric HTTP headers (#1370)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -eux
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Please use the GitHub Action."
+    exit 1
+fi
+
+SCRIPT_DIR="$( dirname "$0" )"
+cd $SCRIPT_DIR/..
+
+OLD_VERSION="${1}"
+NEW_VERSION="${2}"
+
+echo "Current version: $OLD_VERSION"
+echo "Bumping version: $NEW_VERSION"
+
+function replace() {
+    ! grep "$2" $3
+    perl -i -pe "s/$1/$2/g" $3
+    grep "$2" $3  # verify that replacement was successful
+}
+
+replace "SDK_VERSION = '[0-9.]+'" "SDK_VERSION = '$NEW_VERSION'" ./src/Client.php

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry;
 
 use GuzzleHttp\Promise\PromiseInterface;
-use Jean85\PrettyVersions;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sentry\Integration\IntegrationInterface;
@@ -32,6 +31,11 @@ final class Client implements ClientInterface
      * The identifier of the SDK.
      */
     public const SDK_IDENTIFIER = 'sentry.php';
+
+    /**
+     * The version of the SDK.
+     */
+    public const SDK_VERSION = '3.8.0';
 
     /**
      * @var Options The client options
@@ -102,7 +106,7 @@ final class Client implements ClientInterface
         $this->representationSerializer = $representationSerializer ?? new RepresentationSerializer($this->options);
         $this->stacktraceBuilder = new StacktraceBuilder($options, $this->representationSerializer);
         $this->sdkIdentifier = $sdkIdentifier ?? self::SDK_IDENTIFIER;
-        $this->sdkVersion = $sdkVersion ?? PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
+        $this->sdkVersion = $sdkVersion ?? self::SDK_VERSION;
     }
 
     /**

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry;
 
 use Http\Discovery\Psr17FactoryDiscovery;
-use Jean85\PrettyVersions;
 use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientFactory;
 use Sentry\Serializer\RepresentationSerializerInterface;
@@ -59,7 +58,7 @@ final class ClientBuilder implements ClientBuilderInterface
     /**
      * @var string The SDK version of the Client
      */
-    private $sdkVersion;
+    private $sdkVersion = Client::SDK_VERSION;
 
     /**
      * Class constructor.
@@ -69,7 +68,6 @@ final class ClientBuilder implements ClientBuilderInterface
     public function __construct(Options $options = null)
     {
         $this->options = $options ?? new Options();
-        $this->sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
     }
 
     /**

--- a/src/Event.php
+++ b/src/Event.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Jean85\PrettyVersions;
 use Sentry\Context\OsContext;
 use Sentry\Context\RuntimeContext;
 use Sentry\Tracing\Span;
@@ -153,7 +152,7 @@ final class Event
     /**
      * @var string The Sentry SDK version
      */
-    private $sdkVersion;
+    private $sdkVersion = Client::SDK_VERSION;
 
     /**
      * @var EventType The type of the Event
@@ -164,7 +163,6 @@ final class Event
     {
         $this->id = $eventId ?? EventId::generate();
         $this->timestamp = microtime(true);
-        $this->sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
         $this->type = $eventType;
     }
 

--- a/tests/ClientBuilderTest.php
+++ b/tests/ClientBuilderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\Tests;
 
-use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\Client;
 use Sentry\ClientBuilder;
@@ -38,14 +37,13 @@ final class ClientBuilderTest extends TestCase
     public function testClientBuilderFallbacksToDefaultSdkIdentifierAndVersion(): void
     {
         $callbackCalled = false;
-        $expectedVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
 
         $options = new Options();
-        $options->setBeforeSendCallback(function (Event $event) use ($expectedVersion, &$callbackCalled) {
+        $options->setBeforeSendCallback(function (Event $event) use (&$callbackCalled) {
             $callbackCalled = true;
 
             $this->assertSame(Client::SDK_IDENTIFIER, $event->getSdkIdentifier());
-            $this->assertSame($expectedVersion, $event->getSdkVersion());
+            $this->assertSame(Client::SDK_VERSION, $event->getSdkVersion());
 
             return null;
         });

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\Serializer;
 
-use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
+use Sentry\Client;
 use Sentry\Context\OsContext;
 use Sentry\Context\RuntimeContext;
 use Sentry\Event;
@@ -65,7 +65,7 @@ final class PayloadSerializerTest extends TestCase
     {
         ClockMock::withClockMock(1597790835);
 
-        $sdkVersion = PrettyVersions::getVersion('sentry/sentry')->getPrettyVersion();
+        $sdkVersion = Client::SDK_VERSION;
 
         yield [
             Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd')),


### PR DESCRIPTION
As master is currently [failing](https://github.com/getsentry/sentry-php/actions/runs/3096549882/jobs/5012498359), I decided to promote this to a bugfix.

That might be a bit awkward when merging it back into `develop`, but I think we can make it work.