### PR TITLE
Update release 3.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## Unreleased
 
-- Use constant for the SDK version (#1367)
-
 ## 3.8.1 (2022-09-21)
 
+- fix: Use constant for the SDK version (#1367)
 - fix: Do not throw an TypeError on numeric HTTP headers (#1370)
 
 ## 3.8.0 (2022-09-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 3.8.1 (2022-09-21)
 
-- fix: Use constant for the SDK version (#1367)
+- fix: Use constant for the SDK version (#1374)
 - fix: Do not throw an TypeError on numeric HTTP headers (#1370)
 
 ## 3.8.0 (2022-09-05)


### PR DESCRIPTION
Due to failing tests on master and a `-0.01%` decrease in our coverage, I had to pull in a feature from 3.9 and add some tests.
The release didn't go out yet, so this only updates the CHANGELOG.md.