### PR TITLE
Expose a function to retrieve the URL of the CSP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Expose a function to retrieve the URL of the CSP endpoint (#1378)
+
 ## 3.8.1 (2022-09-21)
 
 - fix: Use constant for the SDK version (#1374)

--- a/src/Client.php
+++ b/src/Client.php
@@ -120,6 +120,30 @@ final class Client implements ClientInterface
     /**
      * {@inheritdoc}
      */
+    public function getCspReportUrl(): ?string
+    {
+        $dsn = $this->options->getDsn();
+
+        if (null === $dsn) {
+            return null;
+        }
+
+        $endpoint = $dsn->getCspReportEndpointUrl();
+        $query = array_filter([
+            'sentry_release' => $this->options->getRelease(),
+            'sentry_environment' => $this->options->getEnvironment(),
+        ]);
+
+        if (!empty($query)) {
+            $endpoint .= '&' . http_build_query($query, '', '&');
+        }
+
+        return $endpoint;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function captureMessage(string $message, ?Severity $level = null, ?Scope $scope = null, ?EventHint $hint = null): ?EventId
     {
         $event = Event::createEvent();

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -12,6 +12,7 @@ use Sentry\State\Scope;
  * This interface must be implemented by all Raven client classes.
  *
  * @method StacktraceBuilder getStacktraceBuilder() Returns the stacktrace builder of the client.
+ * @method string|null getCspReportUrl() Returns an URL for security policy reporting that's generated from the given DSN
  *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */

--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -197,6 +197,14 @@ final class Dsn implements \Stringable
     }
 
     /**
+     * Returns the URL of the API for the CSP report endpoint.
+     */
+    public function getCspReportEndpointUrl(): string
+    {
+        return $this->getBaseEndpointUrl() . '/security/?sentry_key=' . $this->publicKey;
+    }
+
+    /**
      * @see https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
      */
     public function __toString(): string

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -215,6 +215,44 @@ final class DsnTest extends TestCase
     }
 
     /**
+     * @dataProvider getCspReportEndpointUrlDataProvider
+     */
+    public function testGetCspReportEndpointUrl(string $value, string $expectedUrl): void
+    {
+        $dsn = Dsn::createFromString($value);
+
+        $this->assertSame($expectedUrl, $dsn->getCspReportEndpointUrl());
+    }
+
+    public function getCspReportEndpointUrlDataProvider(): \Generator
+    {
+        yield [
+            'http://public@example.com/sentry/1',
+            'http://example.com/sentry/api/1/security/?sentry_key=public',
+        ];
+
+        yield [
+            'http://public@example.com/1',
+            'http://example.com/api/1/security/?sentry_key=public',
+        ];
+
+        yield [
+            'http://public@example.com:8080/sentry/1',
+            'http://example.com:8080/sentry/api/1/security/?sentry_key=public',
+        ];
+
+        yield [
+            'https://public@example.com/sentry/1',
+            'https://example.com/sentry/api/1/security/?sentry_key=public',
+        ];
+
+        yield [
+            'https://public@example.com:4343/sentry/1',
+            'https://example.com:4343/sentry/api/1/security/?sentry_key=public',
+        ];
+    }
+
+    /**
      * @dataProvider toStringDataProvider
      */
     public function testToString(string $value): void


### PR DESCRIPTION
Fixes #1363. This is just a backport of what the Ruby SDK does, nothing more nothing less.