### PR TITLE
feat: Make tracing object fluent

### DIFF
--- a/src/Tracing/DynamicSamplingContext.php
+++ b/src/Tracing/DynamicSamplingContext.php
@@ -39,13 +39,15 @@ final class DynamicSamplingContext
      * @param string $key   the list member key
      * @param string $value the list member value
      */
-    public function set(string $key, string $value): void
+    public function set(string $key, string $value): self
     {
         if ($this->isFrozen) {
-            return;
+            return $this;
         }
 
         $this->entries[$key] = $value;
+
+        return $this;
     }
 
     /**
@@ -72,9 +74,11 @@ final class DynamicSamplingContext
     /**
      * Mark the dsc as frozen.
      */
-    public function freeze(): void
+    public function freeze(): self
     {
         $this->isFrozen = true;
+
+        return $this;
     }
 
     /**

--- a/src/Tracing/SamplingContext.php
+++ b/src/Tracing/SamplingContext.php
@@ -49,9 +49,11 @@ final class SamplingContext
     /**
      * Sets the sampling decision from the parent transaction, if any.
      */
-    public function setParentSampled(?bool $parentSampled): void
+    public function setParentSampled(?bool $parentSampled): self
     {
         $this->parentSampled = $parentSampled;
+
+        return $this;
     }
 
     /**
@@ -59,9 +61,11 @@ final class SamplingContext
      *
      * @param array<string, mixed>|null $additionalContext
      */
-    public function setAdditionalContext(?array $additionalContext): void
+    public function setAdditionalContext(?array $additionalContext): self
     {
         $this->additionalContext = $additionalContext;
+
+        return $this;
     }
 
     /**

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -111,9 +111,11 @@ class Span
      *
      * @param SpanId $spanId The ID
      */
-    public function setSpanId(SpanId $spanId): void
+    public function setSpanId(SpanId $spanId): self
     {
         $this->spanId = $spanId;
+
+        return $this;
     }
 
     /**
@@ -129,9 +131,11 @@ class Span
      *
      * @param TraceId $traceId The ID
      */
-    public function setTraceId(TraceId $traceId): void
+    public function setTraceId(TraceId $traceId): self
     {
         $this->traceId = $traceId;
+
+        return $this;
     }
 
     /**
@@ -147,9 +151,11 @@ class Span
      *
      * @param SpanId|null $parentSpanId The ID
      */
-    public function setParentSpanId(?SpanId $parentSpanId): void
+    public function setParentSpanId(?SpanId $parentSpanId): self
     {
         $this->parentSpanId = $parentSpanId;
+
+        return $this;
     }
 
     /**
@@ -165,9 +171,11 @@ class Span
      *
      * @param float $startTimestamp The timestamp
      */
-    public function setStartTimestamp(float $startTimestamp): void
+    public function setStartTimestamp(float $startTimestamp): self
     {
         $this->startTimestamp = $startTimestamp;
+
+        return $this;
     }
 
     /**
@@ -193,9 +201,11 @@ class Span
      *
      * @param string|null $description The description
      */
-    public function setDescription(?string $description): void
+    public function setDescription(?string $description): self
     {
         $this->description = $description;
+
+        return $this;
     }
 
     /**
@@ -211,9 +221,11 @@ class Span
      *
      * @param string|null $op The short code
      */
-    public function setOp(?string $op): void
+    public function setOp(?string $op): self
     {
         $this->op = $op;
+
+        return $this;
     }
 
     /**
@@ -229,9 +241,11 @@ class Span
      *
      * @param SpanStatus|null $status The status
      */
-    public function setStatus(?SpanStatus $status): void
+    public function setStatus(?SpanStatus $status): self
     {
         $this->status = $status;
+
+        return $this;
     }
 
     /**
@@ -239,7 +253,7 @@ class Span
      *
      * @param int $statusCode The HTTP status code
      */
-    public function setHttpStatus(int $statusCode): void
+    public function setHttpStatus(int $statusCode): self
     {
         $this->tags['http.status_code'] = (string) $statusCode;
 
@@ -248,6 +262,8 @@ class Span
         if ($status !== SpanStatus::unknownError()) {
             $this->status = $status;
         }
+
+        return $this;
     }
 
     /**
@@ -265,9 +281,11 @@ class Span
      *
      * @param array<string, string> $tags The tags
      */
-    public function setTags(array $tags): void
+    public function setTags(array $tags): self
     {
         $this->tags = array_merge($this->tags, $tags);
+
+        return $this;
     }
 
     /**
@@ -291,9 +309,11 @@ class Span
      *
      * @param bool $sampled Whether to sample or not this span
      */
-    public function setSampled(?bool $sampled): void
+    public function setSampled(?bool $sampled): self
     {
         $this->sampled = $sampled;
+
+        return $this;
     }
 
     /**
@@ -312,9 +332,11 @@ class Span
      *
      * @param array<string, mixed> $data The data
      */
-    public function setData(array $data): void
+    public function setData(array $data): self
     {
         $this->data = array_merge($this->data, $data);
+
+        return $this;
     }
 
     /**

--- a/src/Tracing/SpanContext.php
+++ b/src/Tracing/SpanContext.php
@@ -71,9 +71,11 @@ class SpanContext
         return $this->description;
     }
 
-    public function setDescription(?string $description): void
+    public function setDescription(?string $description): self
     {
         $this->description = $description;
+
+        return $this;
     }
 
     public function getOp(): ?string
@@ -81,9 +83,11 @@ class SpanContext
         return $this->op;
     }
 
-    public function setOp(?string $op): void
+    public function setOp(?string $op): self
     {
         $this->op = $op;
+
+        return $this;
     }
 
     public function getStatus(): ?SpanStatus
@@ -91,9 +95,11 @@ class SpanContext
         return $this->status;
     }
 
-    public function setStatus(?SpanStatus $status): void
+    public function setStatus(?SpanStatus $status): self
     {
         $this->status = $status;
+
+        return $this;
     }
 
     public function getParentSpanId(): ?SpanId
@@ -101,9 +107,11 @@ class SpanContext
         return $this->parentSpanId;
     }
 
-    public function setParentSpanId(?SpanId $parentSpanId): void
+    public function setParentSpanId(?SpanId $parentSpanId): self
     {
         $this->parentSpanId = $parentSpanId;
+
+        return $this;
     }
 
     public function getSampled(): ?bool
@@ -111,9 +119,11 @@ class SpanContext
         return $this->sampled;
     }
 
-    public function setSampled(?bool $sampled): void
+    public function setSampled(?bool $sampled): self
     {
         $this->sampled = $sampled;
+
+        return $this;
     }
 
     public function getSpanId(): ?SpanId
@@ -121,9 +131,11 @@ class SpanContext
         return $this->spanId;
     }
 
-    public function setSpanId(?SpanId $spanId): void
+    public function setSpanId(?SpanId $spanId): self
     {
         $this->spanId = $spanId;
+
+        return $this;
     }
 
     public function getTraceId(): ?TraceId
@@ -131,9 +143,11 @@ class SpanContext
         return $this->traceId;
     }
 
-    public function setTraceId(?TraceId $traceId): void
+    public function setTraceId(?TraceId $traceId): self
     {
         $this->traceId = $traceId;
+
+        return $this;
     }
 
     /**
@@ -147,9 +161,11 @@ class SpanContext
     /**
      * @param array<string, string> $tags
      */
-    public function setTags(array $tags): void
+    public function setTags(array $tags): self
     {
         $this->tags = $tags;
+
+        return $this;
     }
 
     /**
@@ -163,9 +179,11 @@ class SpanContext
     /**
      * @param array<string, mixed> $data
      */
-    public function setData(array $data): void
+    public function setData(array $data): self
     {
         $this->data = $data;
+
+        return $this;
     }
 
     public function getStartTimestamp(): ?float
@@ -173,9 +191,11 @@ class SpanContext
         return $this->startTimestamp;
     }
 
-    public function setStartTimestamp(?float $startTimestamp): void
+    public function setStartTimestamp(?float $startTimestamp): self
     {
         $this->startTimestamp = $startTimestamp;
+
+        return $this;
     }
 
     public function getEndTimestamp(): ?float
@@ -183,9 +203,11 @@ class SpanContext
         return $this->endTimestamp;
     }
 
-    public function setEndTimestamp(?float $endTimestamp): void
+    public function setEndTimestamp(?float $endTimestamp): self
     {
         $this->endTimestamp = $endTimestamp;
+
+        return $this;
     }
 
     /**

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -65,9 +65,11 @@ final class Transaction extends Span
      *
      * @param string $name The name
      */
-    public function setName(string $name): void
+    public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**

--- a/src/Tracing/TransactionContext.php
+++ b/src/Tracing/TransactionContext.php
@@ -55,9 +55,11 @@ final class TransactionContext extends SpanContext
      *
      * @param string $name The name
      */
-    public function setName(string $name): void
+    public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -73,9 +75,11 @@ final class TransactionContext extends SpanContext
      *
      * @param bool|null $parentSampled The decision
      */
-    public function setParentSampled(?bool $parentSampled): void
+    public function setParentSampled(?bool $parentSampled): self
     {
         $this->parentSampled = $parentSampled;
+
+        return $this;
     }
 
     /**
@@ -91,9 +95,11 @@ final class TransactionContext extends SpanContext
      *
      * @param TransactionMetadata $metadata The transaction metadata
      */
-    public function setMetadata(TransactionMetadata $metadata): void
+    public function setMetadata(TransactionMetadata $metadata): self
     {
         $this->metadata = $metadata;
+
+        return $this;
     }
 
     /**

--- a/src/Tracing/TransactionMetadata.php
+++ b/src/Tracing/TransactionMetadata.php
@@ -49,9 +49,11 @@ final class TransactionMetadata
     /**
      * @param float|int|null $samplingRate
      */
-    public function setSamplingRate($samplingRate): void
+    public function setSamplingRate($samplingRate): self
     {
         $this->samplingRate = $samplingRate;
+
+        return $this;
     }
 
     public function getDynamicSamplingContext(): ?DynamicSamplingContext
@@ -59,9 +61,11 @@ final class TransactionMetadata
         return $this->dynamicSamplingContext;
     }
 
-    public function setDynamicSamplingContext(?DynamicSamplingContext $dynamicSamplingContext): void
+    public function setDynamicSamplingContext(?DynamicSamplingContext $dynamicSamplingContext): self
     {
         $this->dynamicSamplingContext = $dynamicSamplingContext;
+
+        return $this;
     }
 
     public function getSource(): ?TransactionSource
@@ -69,8 +73,10 @@ final class TransactionMetadata
         return $this->source;
     }
 
-    public function setSource(?TransactionSource $source): void
+    public function setSource(?TransactionSource $source): self
     {
         $this->source = $source;
+
+        return $this;
     }
 }


### PR DESCRIPTION
This could make writing tracing code easier and more readable depending on your preference.

The upside is that this unlocks a fluent way of writing. I don't think there are any actual downsides (apart from BC).

I believe this is a backward incompatible change, especially `Span` is not a final class so I don't think we can make this change in 3.x but maybe this is a good start for 4.x and allows us to make the tracing code simpeler/shorter to use. Possibly we could already convert the final classes but not a 100% sure if that is also a BC.

If we think this is acceptable and a good change I would propose that going forward (possibly starting with 4.x) to make all future APIs fluent where it makes sense.

---

A small example partly taken from the laravel codebase:

Before:

```php
$context = TransactionContext::fromHeaders($sentryTraceHeader, $baggageHeader);
$context->setOp('http.server');
$context->setData([
    'url' => '/' . ltrim($request->path(), '/'),
    'method' => strtoupper($request->method()),
]);
$context->setStartTimestamp($requestStartTime);

$bootstrapSpan = $this->addAppBootstrapSpan($request);

$appContextStart = new SpanContext();
$appContextStart->setOp('laravel.handle');
$appContextStart->setStartTimestamp($bootstrapSpan ? $bootstrapSpan->getEndTimestamp() : microtime(true));

$this->transaction->startChild($appContextStart);
```

After:

```php
$context = TransactionContext::fromHeaders($sentryTraceHeader, $baggageHeader)
    ->setStartTimestamp($requestStartTime)
    ->setOp('http.server')
    ->setData([
        'url' => '/' . ltrim($request->path(), '/'),
        'method' => strtoupper($request->method()),
    ]);

$bootstrapSpan = $this->addAppBootstrapSpan($request);

$appContextStart = (new SpanContext)
    ->setStartTimestamp($bootstrapSpan ? $bootstrapSpan->getEndTimestamp() : microtime(true))
    ->setOp('laravel.handle');
```