### PR TITLE
feat: Add setSource to TransactionContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - feat: Expose a function to retrieve the URL of the CSP endpoint (#1378)
 - feat: Add support for Dynamic Sampling (#1360)
   - Add `segment` to `UserDataBag`
-  - Add `TransactionSource`, to set information about the transaction name
+  - Add `TransactionSource`, to set information about the transaction name via `TransactionContext::setSource()` (#1382)
   - Deprecate `TransactionContext::fromSentryTrace()` in favor of `TransactionContext::fromHeaders()`
 
 ## 3.8.1 (2022-09-21)

--- a/src/Tracing/TransactionContext.php
+++ b/src/Tracing/TransactionContext.php
@@ -97,6 +97,16 @@ final class TransactionContext extends SpanContext
     }
 
     /**
+     * Sets the transaction source.
+     *
+     * @param TransactionSource $transactionSource The transaction source
+     */
+    public function setSource(TransactionSource $transactionSource): void
+    {
+        $this->metadata->setSource($transactionSource);
+    }
+
+    /**
      * Returns a context populated with the data of the given header.
      *
      * @param string $header The sentry-trace header from the request

--- a/tests/Tracing/TransactionContextTest.php
+++ b/tests/Tracing/TransactionContextTest.php
@@ -10,6 +10,7 @@ use Sentry\Tracing\SpanId;
 use Sentry\Tracing\TraceId;
 use Sentry\Tracing\TransactionContext;
 use Sentry\Tracing\TransactionMetadata;
+use Sentry\Tracing\TransactionSource;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class TransactionContextTest extends TestCase
@@ -20,6 +21,7 @@ final class TransactionContextTest extends TestCase
     {
         $transactionContext = new TransactionContext();
         $transactionMetadata = new TransactionMetadata();
+        $transactionSource = TransactionSource::custom();
 
         $this->assertSame('<unlabeled transaction>', $transactionContext->getName());
         $this->assertNull($transactionContext->getParentSampled());
@@ -27,10 +29,12 @@ final class TransactionContextTest extends TestCase
         $transactionContext->setName('foo');
         $transactionContext->setParentSampled(true);
         $transactionContext->setMetadata($transactionMetadata);
+        $transactionContext->setSource($transactionSource);
 
         $this->assertSame('foo', $transactionContext->getName());
         $this->assertTrue($transactionContext->getParentSampled());
         $this->assertSame($transactionMetadata, $transactionContext->getMetadata());
+        $this->assertSame($transactionSource, $transactionContext->getMetadata()->getSource());
     }
 
     /**


### PR DESCRIPTION
The current API of setting the `TransactionSource` is pretty clunky...

```
$transactionContext->getMetadata()->setSource(TransactionSource::route());
```

... so I added a new setter.

```
$transactionContext->setSource(TransactionSource::route());
```

Do we need a getter as well? 