### PR TITLE
Cancel in progress ci runs when there is a new commit pushed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,11 @@ on:
       - master
       - develop
       - release/**
-
+# Cancel in progress workflows on pull_requests.
+# https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 jobs:
   tests:
     name: Tests


### PR DESCRIPTION
Cancel in progress CI runs when a new commit is pushed to the PR. This should save some CI minutes (and concurrency)