### PR TITLE
Feat: Allow passing an eventId as context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Suppress errors on is_callable (#1401)
+
 ## 3.9.0 (2022-10-05)
 
 - feat: Add tracePropagationTargets option (#1396)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.9.1 (2022-10-11)
+
 - fix: Suppress errors on is_callable (#1401)
 
 ## 3.9.0 (2022-10-05)

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ final class Client implements ClientInterface
     /**
      * The version of the SDK.
      */
-    public const SDK_VERSION = '3.9.0';
+    public const SDK_VERSION = '3.9.1';
 
     /**
      * @var Options The client options

--- a/src/Client.php
+++ b/src/Client.php
@@ -35,7 +35,7 @@ final class Client implements ClientInterface
     /**
      * The version of the SDK.
      */
-    public const SDK_VERSION = '3.8.1';
+    public const SDK_VERSION = '3.9.0';
 
     /**
      * @var Options The client options

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -100,7 +100,7 @@ abstract class AbstractSerializer
             }
 
             try {
-                if (\is_callable($value)) {
+                if (@\is_callable($value)) {
                     return $this->serializeCallable($value);
                 }
             } catch (\Throwable $exception) {


### PR DESCRIPTION
We would like to pass an `eventId` as a parameter in the `$record` so that we can communicate the `eventId` to other handlers in the logger. 
