### PR TITLE
Allow a formatted message with empty params to be sent to Sentry

### DIFF
--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -155,13 +155,13 @@ final class PayloadSerializer implements PayloadSerializerInterface
         }
 
         if (null !== $event->getMessage()) {
-            if (empty($event->getMessageParams())) {
+            if (empty($event->getMessageParams()) && is_null($event->getMessageFormatted())) {
                 $result['message'] = $event->getMessage();
             } else {
                 $result['message'] = [
                     'message' => $event->getMessage(),
                     'params' => $event->getMessageParams(),
-                    'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
+                    'formatted' => $event->getMessageFormatted() ?? (empty($event->getMessageParams()) ? $event->getMessage() : vsprintf($event->getMessage(), $event->getMessageParams())),
                 ];
             }
         }

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -155,7 +155,7 @@ final class PayloadSerializer implements PayloadSerializerInterface
         }
 
         if (null !== $event->getMessage()) {
-            if (empty($event->getMessageParams()) && is_null($event->getMessageFormatted())) {
+            if (empty($event->getMessageParams()) && null === $event->getMessageFormatted()) {
                 $result['message'] = $event->getMessage();
             } else {
                 $result['message'] = [


### PR DESCRIPTION
Currently the PayloadSerializer logic will only send the formatted message to Sentry if the message params are not empty.

However, I would like to have the option to send both the uninterpolated message (which is used to group events into issues) and the formatted message (which is displayed in the Sentry UI) without params to Sentry.

Example use cases for this capability would be that I want to reduce the size of event payloads, or if I simply don't want the message params to be rendered in the Sentry UI.

I'm not aware of any reason for the SDK to have such logic restricting which components of the message are sent to Sentry.