### PR TITLE
feat: Add tracePropagationTargets option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 3.9.0 (2022-10-04)
 
+- feat: Add tracePropagationTargets option (#1396)
 - feat: Expose a function to retrieve the URL of the CSP endpoint (#1378)
 - feat: Add support for Dynamic Sampling (#1360)
   - Add `segment` to `UserDataBag`

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,6 +216,11 @@ parameters:
 			path: src/Options.php
 
 		-
+			message: "#^Method Sentry\\\\Options\\:\\:getTracePropagationTargets\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Method Sentry\\\\Options\\:\\:getTracesSampleRate\\(\\) should return float but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
@@ -336,12 +341,12 @@ parameters:
 			path: src/UserDataBag.php
 
 		-
-			message: "#^Parameter \\#1 \\$username of method Sentry\\\\UserDataBag\\:\\:setUsername\\(\\) expects string\\|null, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$segment of method Sentry\\\\UserDataBag\\:\\:setSegment\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/UserDataBag.php
 
 		-
-			message: "#^Parameter \\#1 \\$segment of method Sentry\\\\UserDataBag\\:\\:setSegment\\(\\) expects string\\|null, mixed given\\.$#"
+			message: "#^Parameter \\#1 \\$username of method Sentry\\\\UserDataBag\\:\\:setUsername\\(\\) expects string\\|null, mixed given\\.$#"
 			count: 1
 			path: src/UserDataBag.php
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -397,6 +397,28 @@ final class Options
     }
 
     /**
+     * Gets an allow list of trace propagation targets.
+     *
+     * @return string[]
+     */
+    public function getTracePropagationTargets(): array
+    {
+        return $this->options['trace_propagation_targets'];
+    }
+
+    /**
+     * Set an allow list of trace propagation targets.
+     *
+     * @param string[] $tracePropagationTargets Trace propagation targets
+     */
+    public function setTracePropagationTargets(array $tracePropagationTargets): void
+    {
+        $options = array_merge($this->options, ['trace_propagation_targets' => $tracePropagationTargets]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Gets a list of default tags for events.
      *
      * @return array<string, string>
@@ -779,6 +801,7 @@ final class Options
             'before_send' => static function (Event $event): Event {
                 return $event;
             },
+            'trace_propagation_targets' => [],
             'tags' => [],
             'error_types' => null,
             'max_breadcrumbs' => self::DEFAULT_MAX_BREADCRUMBS,
@@ -813,6 +836,7 @@ final class Options
         $resolver->setAllowedTypes('dsn', ['null', 'string', 'bool', Dsn::class]);
         $resolver->setAllowedTypes('server_name', 'string');
         $resolver->setAllowedTypes('before_send', ['callable']);
+        $resolver->setAllowedTypes('trace_propagation_targets', 'string[]');
         $resolver->setAllowedTypes('tags', 'string[]');
         $resolver->setAllowedTypes('error_types', ['null', 'int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -22,6 +22,7 @@ final class GuzzleTracingMiddleware
         return static function (callable $handler) use ($hub): Closure {
             return static function (RequestInterface $request, array $options) use ($hub, $handler) {
                 $hub = $hub ?? SentrySdk::getCurrentHub();
+                $client = $hub->getClient();
                 $span = $hub->getSpan();
 
                 if (null === $span) {
@@ -35,8 +36,17 @@ final class GuzzleTracingMiddleware
                 $childSpan = $span->startChild($spanContext);
 
                 $request = $request
-                    ->withHeader('sentry-trace', $childSpan->toTraceparent())
-                    ->withHeader('baggage', $childSpan->toBaggage());
+                    ->withHeader('sentry-trace', $childSpan->toTraceparent());
+
+                // Check if the request destination is allow listed in the trace_propagation_targets option.
+                if (null !== $client) {
+                    $sdkOptions = $client->getOptions();
+
+                    if (\in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())) {
+                        $request = $request
+                            ->withHeader('baggage', $childSpan->toBaggage());
+                    }
+                }
 
                 $handlerPromiseCallback = static function ($responseOrException) use ($hub, $request, $childSpan) {
                     // We finish the span (which means setting the span end timestamp) first to ensure the measured time

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -249,6 +249,15 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'trace_propagation_targets',
+            ['www.example.com'],
+            'getTracePropagationTargets',
+            'setTracePropagationTargets',
+            null,
+            null,
+        ];
+
+        yield [
             'before_breadcrumb',
             static function (): void {},
             'getBeforeBreadcrumbCallback',

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -61,9 +61,14 @@ final class GuzzleTracingMiddlewareTest extends TestCase
     public function testTrace(Request $request, $expectedPromiseResult, array $expectedBreadcrumbData): void
     {
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->exactly(3))
+        $client->expects($this->exactly(4))
             ->method('getOptions')
-            ->willReturn(new Options(['traces_sample_rate' => 1]));
+            ->willReturn(new Options([
+                'traces_sample_rate' => 1,
+                'trace_propagation_targets' => [
+                    'www.example.com',
+                ],
+            ]));
 
         $hub = new Hub($client);
 


### PR DESCRIPTION
To not break people's usage of the `GuzzleTracingMiddleware`, I only check for `tracePropagationTargets` when applying the `baggage` header.

Also nothing fancy here, a simple array with an allow-list of hosts.

Closes #1395 & #1361