### PR TITLE
ref: Add correct never option for max_request_body_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- ref: Add correct `never` option for `max_request_body_size` (#1397)
+  - Deprecate `max_request_body_size.none` in favour of `max_request_body_size.never`
+
 ## 3.9.0 (2022-10-05)
 
 - feat: Add tracePropagationTargets option (#1396)

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -42,9 +42,12 @@ final class RequestIntegration implements IntegrationInterface
     /**
      * This constant is a map of maximum allowed sizes for each value of the
      * `max_request_body_size` option.
+     *
+     * @deprecated The 'none' option is deprecated since version 3.10, to be removed in 4.0
      */
     private const MAX_REQUEST_BODY_SIZE_OPTION_TO_MAX_LENGTH_MAP = [
         'none' => 0,
+        'never' => 0,
         'small' => self::REQUEST_BODY_SMALL_MAX_CONTENT_LENGTH,
         'medium' => self::REQUEST_BODY_MEDIUM_MAX_CONTENT_LENGTH,
         'always' => -1,
@@ -269,7 +272,7 @@ final class RequestIntegration implements IntegrationInterface
             return false;
         }
 
-        if ('none' === $maxRequestBodySize) {
+        if ('none' === $maxRequestBodySize || 'never' === $maxRequestBodySize) {
             return false;
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -852,7 +852,7 @@ final class Options
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
 
-        $resolver->setAllowedValues('max_request_body_size', ['none', 'small', 'medium', 'always']);
+        $resolver->setAllowedValues('max_request_body_size', ['none', 'never', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));
         $resolver->setAllowedValues('class_serializers', \Closure::fromCallable([$this, 'validateClassSerializersOption']));

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -228,6 +228,25 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
+                'max_request_body_size' => 'never',
+            ],
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
+                ->withHeader('Content-Length', '3')
+                ->withBody(Utils::streamFor('foo')),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Content-Length' => ['3'],
+                ],
+            ],
+            null,
+            null,
+        ];
+
+        yield [
+            [
                 'max_request_body_size' => 'small',
             ],
             (new ServerRequest('POST', 'http://www.example.com/foo'))


### PR DESCRIPTION
According to our [docs](https://docs.sentry.io/platforms/php/configuration/options/#max-request-body-size), the correct config option is `never` instead of `none`.

This makes it a none BC breaking change.