### PR TITLE
fix: Suppress errors on is_callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Suppress errors on is_callable (#1401)
+
 ## 3.9.0 (2022-10-05)
 
 - feat: Add tracePropagationTargets option (#1396)

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -100,7 +100,7 @@ abstract class AbstractSerializer
             }
 
             try {
-                if (\is_callable($value)) {
+                if (@\is_callable($value)) {
                     return $this->serializeCallable($value);
                 }
             } catch (\Throwable $exception) {


### PR DESCRIPTION
Reproduction case https://github.com/NotGeri/yii-test

The `is_callable` is triggering a warning in this case. As we already put it into a try/catch, I'm ok with suppressing eventual errors here as well.