### PR TITLE
Feat: Allow passing an eventId as context

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -51,10 +51,13 @@
       <code>$record['level']</code>
       <code>$record['message']</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidArrayOffset occurrences="1">
+    <PossiblyInvalidArrayOffset occurrences="2">
+      <code>$record['context']['event_id']</code>
       <code>$record['context']['exception']</code>
     </PossiblyInvalidArrayOffset>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod occurrences="4">
+      <code>$record['context']</code>
+      <code>$record['context']</code>
       <code>$record['context']</code>
       <code>$record['context']</code>
     </PossiblyUndefinedMethod>

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -9,6 +9,7 @@ use Monolog\Logger;
 use Monolog\LogRecord;
 use Sentry\Event;
 use Sentry\EventHint;
+use Sentry\EventId;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 
@@ -52,7 +53,12 @@ final class Handler extends AbstractProcessingHandler
      */
     protected function doWrite($record): void
     {
-        $event = Event::createEvent();
+        $eventId = null;
+        if (isset($record['context']['event_id'])) {
+            $eventId = new EventId($record['context']['event_id']);
+        }
+
+        $event = Event::createEvent($eventId);
         $event->setLevel(self::getSeverityFromLevel($record['level']));
         $event->setMessage($record['message']);
         $event->setLogger(sprintf('monolog.%s', $record['channel']));

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Event;
 use Sentry\EventHint;
+use Sentry\EventId;
 use Sentry\Monolog\Handler;
 use Sentry\Severity;
 use Sentry\State\Hub;
@@ -307,6 +308,35 @@ final class HandlerTest extends TestCase
             [
                 'monolog.channel' => 'channel.foo',
                 'monolog.level' => Logger::getLevelName(Logger::WARNING),
+            ],
+        ];
+
+        $eventId = EventId::generate();
+        $event = Event::createEvent($eventId);
+        $event->setMessage('foo bar');
+        $event->setLogger('monolog.channel.foo');
+        $event->setLevel(Severity::warning());
+        $event->setContext('context', ['event_id' => (string) $eventId]);
+
+        yield 'Monolog\'s context eventId is filled and the event should have the same Id' => [
+            true,
+            RecordFactory::create(
+                'foo bar',
+                Logger::WARNING,
+                'channel.foo',
+                [
+                    'event_id' => (string) $eventId,
+                ],
+                []
+            ),
+            $event,
+            new EventHint(),
+            [
+                'monolog.channel' => 'channel.foo',
+                'monolog.level' => Logger::getLevelName(Logger::WARNING),
+                'monolog.context' => [
+                    'event_id' => (string) $eventId,
+                ],
             ],
         ];
 


### PR DESCRIPTION
Had to open a new PR because i couldn't change source branch in the original PR ( https://github.com/getsentry/sentry-php/pull/1388 ) 

We would like to pass an `eventId` as a parameter in the `$record` so that we can communicate the `eventId` to other handlers in the logger. 
