### PR TITLE
Fix sampling decision when parent is sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Sampling now correctly takes in account the parent sampling decision if available instead of always being `false` when tracing is disabled (#1407)
+
 ## 3.9.1 (2022-10-11)
 
 - fix: Suppress errors on is_callable (#1401)

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -222,7 +222,7 @@ final class Hub implements HubInterface
         $client = $this->getClient();
         $options = null !== $client ? $client->getOptions() : null;
 
-        if (null === $options || !$options->isTracingEnabled()) {
+        if (null === $options || (!$options->isTracingEnabled() && true !== $context->getParentSampled())) {
             $transaction->setSampled(false);
 
             return $transaction;


### PR DESCRIPTION
The current sampling decision always set the transaction to not sampled if sampling is disabled in the SDK not taking in account the parent sampling decision which is considered a bug.

This resolved that by also looking at the parent sampling decision when starting a transaction.

Fixes #1405.