### PR TITLE
fix: Only include the transaction name to the DSC if it has good quality

### DIFF
--- a/src/Tracing/DynamicSamplingContext.php
+++ b/src/Tracing/DynamicSamplingContext.php
@@ -149,7 +149,11 @@ final class DynamicSamplingContext
         $samplingContext = new self();
         $samplingContext->set('trace_id', (string) $transaction->getTraceId());
         $samplingContext->set('sample_rate', (string) $transaction->getMetaData()->getSamplingRate());
-        $samplingContext->set('transaction', $transaction->getName());
+
+        // Only include the transaction name if it has good quality
+        if ($transaction->getMetadata()->getSource() !== TransactionSource::url()) {
+            $samplingContext->set('transaction', $transaction->getName());
+        }
 
         $client = $hub->getClient();
 

--- a/tests/Tracing/DynamicSamplingContextTest.php
+++ b/tests/Tracing/DynamicSamplingContextTest.php
@@ -12,6 +12,7 @@ use Sentry\State\Scope;
 use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 use Sentry\UserDataBag;
 
 final class DynamicSamplingContextTest extends TestCase
@@ -110,6 +111,21 @@ final class DynamicSamplingContextTest extends TestCase
         $this->assertSame('test', $samplingContext->get('environment'));
         $this->assertSame('my_segment', $samplingContext->get('user_segment'));
         $this->assertTrue($samplingContext->isFrozen());
+    }
+
+    public function testFromTransactionSourceUrl(): void
+    {
+        $hub = new Hub();
+
+        $transactionContext = new TransactionContext();
+        $transactionContext->setName('/foo/bar/123');
+        $transactionContext->setSource(TransactionSource::url());
+
+        $transaction = new Transaction($transactionContext, $hub);
+
+        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $hub);
+
+        $this->assertNull($samplingContext->get('transaction'));
     }
 
     /**


### PR DESCRIPTION
The transaction should only be included in the DSC, if the quality is good, meaning, not a raw URL (`TransactionSource::url()`).

https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#payloads