### PR TITLE
ref: Expose the ExceptionMechanism through the event hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ref: Enable the ModulesIntegration by default (#1415)
+ref: Expose the ExceptionMechanism through the event hint (#1416)
 
 ## 3.10.0 (2022-10-19)
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -248,7 +248,7 @@ final class Client implements ClientInterface
     {
         if (null !== $hint) {
             if (null !== $hint->exception && empty($event->getExceptions())) {
-                $this->addThrowableToEvent($event, $hint->exception);
+                $this->addThrowableToEvent($event, $hint->exception, $hint);
             }
 
             if (null !== $hint->stacktrace && null === $event->getStacktrace()) {
@@ -338,8 +338,9 @@ final class Client implements ClientInterface
      *
      * @param Event      $event     The event that will be enriched with the exception
      * @param \Throwable $exception The exception that will be processed and added to the event
+     * @param EventHint  $hint      Contains additional information about the event
      */
-    private function addThrowableToEvent(Event $event, \Throwable $exception): void
+    private function addThrowableToEvent(Event $event, \Throwable $exception, EventHint $hint): void
     {
         if ($exception instanceof \ErrorException && null === $event->getLevel()) {
             $event->setLevel(Severity::fromError($exception->getSeverity()));
@@ -351,7 +352,7 @@ final class Client implements ClientInterface
             $exceptions[] = new ExceptionDataBag(
                 $exception,
                 $this->stacktraceBuilder->buildFromException($exception),
-                new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true)
+                $hint->mechanism ?? new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true)
             );
         } while ($exception = $exception->getPrevious());
 

--- a/src/EventHint.php
+++ b/src/EventHint.php
@@ -17,6 +17,13 @@ final class EventHint
     public $exception;
 
     /**
+     * An object describing the mechanism of the original exception.
+     *
+     * @var ExceptionMechanism|null
+     */
+    public $mechanism;
+
+    /**
      * The stacktrace to set on the event.
      *
      * @var Stacktrace|null
@@ -43,11 +50,16 @@ final class EventHint
     {
         $hint = new self();
         $exception = $hintData['exception'] ?? null;
+        $mechanism = $hintData['mechanism'] ?? null;
         $stacktrace = $hintData['stacktrace'] ?? null;
         $extra = $hintData['extra'] ?? [];
 
         if (null !== $exception && !$exception instanceof \Throwable) {
             throw new \InvalidArgumentException(sprintf('The value of the "exception" field must be an instance of a class implementing the "%s" interface. Got: "%s".', \Throwable::class, get_debug_type($exception)));
+        }
+
+        if (null !== $mechanism && !$mechanism instanceof ExceptionMechanism) {
+            throw new \InvalidArgumentException(sprintf('The value of the "mechanism" field must be an instance of the "%s" class. Got: "%s".', ExceptionMechanism::class, get_debug_type($mechanism)));
         }
 
         if (null !== $stacktrace && !$stacktrace instanceof Stacktrace) {
@@ -59,6 +71,7 @@ final class EventHint
         }
 
         $hint->exception = $exception;
+        $hint->mechanism = $mechanism;
         $hint->stacktrace = $stacktrace;
         $hint->extra = $extra;
 

--- a/tests/EventHintTest.php
+++ b/tests/EventHintTest.php
@@ -6,6 +6,7 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\EventHint;
+use Sentry\ExceptionMechanism;
 use Sentry\Frame;
 use Sentry\Stacktrace;
 
@@ -14,17 +15,20 @@ final class EventHintTest extends TestCase
     public function testCreateFromArray(): void
     {
         $exception = new \Exception();
+        $mechanism = new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, false);
         $stacktrace = new Stacktrace([
             new Frame('function_1', 'path/to/file_1', 10),
         ]);
 
         $hint = EventHint::fromArray([
             'exception' => $exception,
+            'mechanism' => $mechanism,
             'stacktrace' => $stacktrace,
             'extra' => ['foo' => 'bar'],
         ]);
 
         $this->assertSame($exception, $hint->exception);
+        $this->assertSame($mechanism, $hint->mechanism);
         $this->assertSame($stacktrace, $hint->stacktrace);
         $this->assertSame(['foo' => 'bar'], $hint->extra);
     }
@@ -45,6 +49,11 @@ final class EventHintTest extends TestCase
         yield [
             ['exception' => 'foo'],
             'The value of the "exception" field must be an instance of a class implementing the "Throwable" interface. Got: "string".',
+        ];
+
+        yield [
+            ['mechanism' => 'foo'],
+            'The value of the "mechanism" field must be an instance of the "Sentry\\ExceptionMechanism" class. Got: "string".',
         ];
 
         yield [


### PR DESCRIPTION
This makes it possible to access the `handled` property when reporting errors to Sentry.
While this approach is definitely not the best solution, I didn't find a better way without breaking BC.

```
$hint = EventHint::fromArray([
    'exception' => $exception,
    'mechanism' => new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, false),
]);

captureEvent(Event::createEvent(), $hint);
```

Remaining ToDos

- [x] Add more tests 

Closes #1350 