### PR TITLE
chore(ci): add danger.yml to police CHANGELOG updates

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,9 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, ready_for_review]
+
+jobs:
+  danger:
+    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
This PR adds dangerJS bot to police our CHANGELOG.md entries on php repo.

Example: https://github.com/getsentry/sentry-wizard/pull/204#issuecomment-1288910711

 #skip-changelog