### PR TITLE
Decouple from "guzzlehttp/psr7" and "php-http/discovery", replace by "friendsofphp/well-known-implementations"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,11 @@
         "php": "^7.2|^8.0",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "friendsofphp/well-known-implementations": "^1",
         "guzzlehttp/promises": "^1.4",
-        "guzzlehttp/psr7": "^1.8.4|^2.1.1",
         "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
-        "php-http/discovery": "^1.11",
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-factory": "^1.0",
@@ -39,6 +38,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.19|3.4.*",
+        "guzzlehttp/psr7": "^1.8.4|^2.1.1",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.6|^2.0|^3.0",
         "nikic/php-parser": "^4.10.3",
@@ -89,6 +89,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "friendsofphp/well-known-implementations": false,
             "phpstan/extension-installer": true
         }
     },

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Http\Discovery\Psr17FactoryDiscovery;
+use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
 use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientFactory;
 use Sentry\Serializer\RepresentationSerializerInterface;
@@ -175,19 +175,19 @@ final class ClientBuilder implements ClientBuilderInterface
      */
     private function createDefaultTransportFactory(): DefaultTransportFactory
     {
-        $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+        $psr17Factory = new WellKnownPsr17Factory();
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUriFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
-            $streamFactory,
+            null,
+            null,
+            $psr17Factory,
             null,
             $this->sdkIdentifier,
             $this->sdkVersion
         );
 
         return new DefaultTransportFactory(
-            $streamFactory,
-            Psr17FactoryDiscovery::findRequestFactory(),
+            $psr17Factory,
+            $psr17Factory,
             $httpClientFactory,
             $this->logger
         );

--- a/src/Integration/RequestFetcher.php
+++ b/src/Integration/RequestFetcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Integration;
 
-use GuzzleHttp\Psr7\ServerRequest;
+use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -22,6 +22,6 @@ final class RequestFetcher implements RequestFetcherInterface
             return null;
         }
 
-        return ServerRequest::fromGlobals();
+        return (new WellKnownPsr17Factory())->createServerRequestFromGlobals();
     }
 }

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\HttpClient;
 
+use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
 use Http\Client\HttpAsyncClient as HttpAsyncClientInterface;
-use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Mock\Client as HttpMockClient;
 use PHPUnit\Framework\TestCase;
 use Sentry\HttpClient\HttpClientFactory;
@@ -19,13 +19,13 @@ final class HttpClientFactoryTest extends TestCase
      */
     public function testCreate(bool $isCompressionEnabled, string $expectedRequestBody): void
     {
-        $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+        $psr17Factory = new WellKnownPsr17Factory();
 
         $mockHttpClient = new HttpMockClient();
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
-            $streamFactory,
+            null,
+            null,
+            $psr17Factory,
             $mockHttpClient,
             'sentry.php.test',
             '1.2.3'
@@ -37,9 +37,9 @@ final class HttpClientFactoryTest extends TestCase
             'enable_compression' => $isCompressionEnabled,
         ]));
 
-        $request = Psr17FactoryDiscovery::findRequestFactory()
+        $request = $psr17Factory
             ->createRequest('POST', 'http://example.com/sentry/foo')
-            ->withBody($streamFactory->createStream('foo bar'));
+            ->withBody($psr17Factory->createStream('foo bar'));
 
         $httpClient->sendAsyncRequest($request);
 
@@ -67,9 +67,9 @@ final class HttpClientFactoryTest extends TestCase
     public function testCreateThrowsIfDsnOptionIsNotConfigured(): void
     {
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
-            Psr17FactoryDiscovery::findStreamFactory(),
+            null,
+            null,
+            new WellKnownPsr17Factory(),
             null,
             'sentry.php.test',
             '1.2.3'
@@ -84,9 +84,9 @@ final class HttpClientFactoryTest extends TestCase
     public function testCreateThrowsIfHttpProxyOptionIsUsedWithCustomHttpClient(): void
     {
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
-            Psr17FactoryDiscovery::findStreamFactory(),
+            null,
+            null,
+            new WellKnownPsr17Factory(),
             $this->createMock(HttpAsyncClientInterface::class),
             'sentry.php.test',
             '1.2.3'

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\HttpClient\Plugin;
 
-use Http\Discovery\Psr17FactoryDiscovery;
+use FriendsOfPHP\WellKnownImplementations\WellKnownPsr17Factory;
 use Http\Promise\Promise as PromiseInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -17,11 +17,12 @@ final class GzipEncoderPluginTest extends TestCase
 {
     public function testHandleRequest(): void
     {
-        $plugin = new GzipEncoderPlugin(Psr17FactoryDiscovery::findStreamFactory());
+        $psr17Factory = new WellKnownPsr17Factory();
+        $plugin = new GzipEncoderPlugin($psr17Factory);
         $expectedPromise = $this->createMock(PromiseInterface::class);
-        $request = Psr17FactoryDiscovery::findRequestFactory()
+        $request = $psr17Factory
             ->createRequest('POST', 'http://www.example.com')
-            ->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream('foo'));
+            ->withBody($psr17Factory->createStream('foo'));
 
         $this->assertSame('foo', (string) $request->getBody());
         $this->assertSame($expectedPromise, $plugin->handleRequest(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use Http\Discovery\ClassDiscovery;
-use Http\Discovery\Strategy\MockClientStrategy;
 use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\Tracing\Span;
@@ -11,8 +9,6 @@ use Sentry\Transport\RateLimiter;
 use Symfony\Bridge\PhpUnit\ClockMock;
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
-ClassDiscovery::appendStrategy(MockClientStrategy::class);
 
 // According to the Symfony documentation the proper way to register the mocked
 // functions for a certain class would be to configure the listener in the


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-php/discussions/1411 and https://github.com/FriendsOfPHP/well-known-implementations/issues/2

In this PR, I propose to rely on [FriendsOfPHP/well-known-implementations](https://github.com/FriendsOfPHP/well-known-implementations) to ensure a working out-of-the-box experience. This package is a composer-plugin that will install the most suited `async-http-implementation` depending on the existing dependencies of the projects that require sentry-php.

The package also provides a discovery mechanism that covers roughly the same purpose as `php-http/discovery`, but that plays well with the plugin part of the package.

The attached patch removes `php-http/discovery` from the mandatory dependencies, but also removes the dependency on `guzzlehttp/psr7`.