### PR TITLE
add lordsimal/cakephp-sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ The following integrations are available and maintained by members of the Sentry
 - [ZendFramework](https://github.com/facile-it/sentry-module)
 - [Yii2](https://github.com/notamedia/yii2-sentry)
 - [Silverstripe](https://github.com/phptek/silverstripe-sentry)
-- [CakePHP](https://github.com/lordsimal/cakephp-sentry)
+- [CakePHP 3.0 - 4.3](https://github.com/Connehito/cake-sentry)
+- [CakePHP 4.4+](https://github.com/lordsimal/cakephp-sentry)
 - ... feel free to be famous, create a port to your favourite platform!
 
 ## 3rd party integrations using old SDK 2.x

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following integrations are available and maintained by members of the Sentry
 - [ZendFramework](https://github.com/facile-it/sentry-module)
 - [Yii2](https://github.com/notamedia/yii2-sentry)
 - [Silverstripe](https://github.com/phptek/silverstripe-sentry)
-- [CakePHP](https://github.com/Connehito/cake-sentry)
+- [CakePHP](https://github.com/lordsimal/cakephp-sentry)
 - ... feel free to be famous, create a port to your favourite platform!
 
 ## 3rd party integrations using old SDK 2.x


### PR DESCRIPTION
Connehito's plugin is still the recommended one for CakePHP 4.0 till 4.4 due to the fact that the new error logging behavior is only available since CakePHP 4.4
Connehito's plugin is still mentioned in the readme bellow, just in the SDK 2.x section.

Since the plugin author didn't respond to my PR I created my own package.

#skip-changelog