### PR TITLE
fix: Set `traces_sample_rate` to `null` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Set `traces_sample_rate` to `null` by default
+
 ## 3.11.0 (2022-10-25)
 
 - fix: Only include the transaction name to the DSC if it has good quality (#1410)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Set `traces_sample_rate` to `null` by default
+- fix: Set `traces_sample_rate` to `null` by default (#1428)
 
 ## 3.11.0 (2022-10-25)
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -163,7 +163,7 @@ final class Options
      */
     public function isTracingEnabled(): bool
     {
-        return 0 != $this->options['traces_sample_rate'] || null !== $this->options['traces_sampler'];
+        return null !== $this->options['traces_sample_rate'] || null !== $this->options['traces_sampler'];
     }
 
     /**
@@ -788,7 +788,7 @@ final class Options
             'send_attempts' => 0,
             'prefixes' => array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: '')),
             'sample_rate' => 1,
-            'traces_sample_rate' => 0,
+            'traces_sample_rate' => null,
             'traces_sampler' => null,
             'attach_stacktrace' => false,
             'context_lines' => 5,
@@ -823,7 +823,7 @@ final class Options
         $resolver->setAllowedTypes('send_attempts', 'int');
         $resolver->setAllowedTypes('prefixes', 'string[]');
         $resolver->setAllowedTypes('sample_rate', ['int', 'float']);
-        $resolver->setAllowedTypes('traces_sample_rate', ['int', 'float']);
+        $resolver->setAllowedTypes('traces_sample_rate', ['null', 'int', 'float']);
         $resolver->setAllowedTypes('traces_sampler', ['null', 'callable']);
         $resolver->setAllowedTypes('attach_stacktrace', 'bool');
         $resolver->setAllowedTypes('context_lines', ['null', 'int']);

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -222,7 +222,7 @@ final class Hub implements HubInterface
         $client = $this->getClient();
         $options = null !== $client ? $client->getOptions() : null;
 
-        if (null === $options || (!$options->isTracingEnabled() && true !== $context->getParentSampled())) {
+        if (null === $options || !$options->isTracingEnabled()) {
             $transaction->setSampled(false);
 
             return $transaction;

--- a/tests/Tracing/TransactionTest.php
+++ b/tests/Tracing/TransactionTest.php
@@ -90,7 +90,7 @@ final class TransactionTest extends TestCase
     /**
      * @dataProvider parentTransactionContextDataProvider
      */
-    public function testTransactionIsSampledCorrectlyWhenTracingIsDisabledInOptions(TransactionContext $context, bool $expectedSampled): void
+    public function testTransactionIsSampledCorrectlyWhenTracingIsSetToZeroInOptions(TransactionContext $context, bool $expectedSampled): void
     {
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->once())
@@ -122,6 +122,49 @@ final class TransactionTest extends TestCase
         yield [
             TransactionContext::fromHeaders('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-1', ''),
             true,
+        ];
+
+        yield [
+            TransactionContext::fromHeaders('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-0', ''),
+            false,
+        ];
+    }
+
+    /**
+     * @dataProvider parentTransactionContextDataProviderDisabled
+     */
+    public function testTransactionIsNotSampledWhenTracingIsDisabledInOptions(TransactionContext $context, bool $expectedSampled): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getOptions')
+            ->willReturn(
+                new Options([
+                    'traces_sampler' => null,
+                    'traces_sample_rate' => null,
+                ])
+            );
+
+        $transaction = (new Hub($client))->startTransaction($context);
+
+        $this->assertSame($expectedSampled, $transaction->getSampled());
+    }
+
+    public function parentTransactionContextDataProviderDisabled(): Generator
+    {
+        yield [
+            new TransactionContext(TransactionContext::DEFAULT_NAME, true),
+            false,
+        ];
+
+        yield [
+            new TransactionContext(TransactionContext::DEFAULT_NAME, false),
+            false,
+        ];
+
+        yield [
+            TransactionContext::fromHeaders('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-1', ''),
+            false,
         ];
 
         yield [


### PR DESCRIPTION
The new default value for `traces_sample_rate` is now `null`.

If neither `traces_sample_rate: 0` nor a `traces_sampler` is set in the options, we do not enable tracing.

Closes https://github.com/getsentry/sentry-php/issues/1427