### PR TITLE
Add error handler integrations option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: Add `error_handler_integrations` option (#1439)
+
 ## 3.12.0 (2022-11-22)
 
 - feat: Add `before_send_transaction` option (#1424)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,6 +241,11 @@ parameters:
 			path: src/Options.php
 
 		-
+			message: "#^Method Sentry\\\\Options\\:\\:hasErrorHandlerIntegrations\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Method Sentry\\\\Options\\:\\:isCompressionEnabled\\(\\) should return bool but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -122,19 +122,19 @@ final class IntegrationRegistry
      */
     private function getDefaultIntegrations(Options $options): array
     {
-        if (!$options->hasDefaultIntegrations()) {
-            return [];
+        $integrations = [];
+
+        if ($options->hasDefaultIntegrations()) {
+            $integrations = [
+                new RequestIntegration(),
+                new TransactionIntegration(),
+                new FrameContextifierIntegration(),
+                new EnvironmentIntegration(),
+                new ModulesIntegration(),
+            ];
         }
 
-        $integrations = [
-            new RequestIntegration(),
-            new TransactionIntegration(),
-            new FrameContextifierIntegration(),
-            new EnvironmentIntegration(),
-            new ModulesIntegration(),
-        ];
-
-        if (null !== $options->getDsn()) {
+        if ($options->hasErrorHandlerIntegrations() && null !== $options->getDsn()) {
             array_unshift($integrations, new ExceptionListenerIntegration(), new ErrorListenerIntegration(), new FatalErrorListenerIntegration());
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -609,6 +609,28 @@ final class Options
     }
 
     /**
+     * Returns whether the error handler integrations are enabled or fallbacks
+     * to whether the default integrations are enabled when null.
+     */
+    public function hasErrorHandlerIntegrations(): bool
+    {
+        return $this->options['error_handler_integrations'] ?? $this->hasDefaultIntegrations();
+    }
+
+    /**
+     * Sets whether the error handler integrations are enabled.
+     *
+     * @param ?bool $enable Flag indicating whether the error handler integrations should be enabled, fallbacks
+     *                      to "default_integrations" when null
+     */
+    public function setErrorHandlerIntegrations(?bool $enable): void
+    {
+        $options = array_merge($this->options, ['error_handler_integrations' => $enable]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
+    /**
      * Gets the max length for values in the event payload.
      */
     public function getMaxValueLength(): int
@@ -811,6 +833,7 @@ final class Options
         $resolver->setDefaults([
             'integrations' => [],
             'default_integrations' => true,
+            'error_handler_integrations' => null,
             'send_attempts' => 0,
             'prefixes' => array_filter(explode(\PATH_SEPARATOR, get_include_path() ?: '')),
             'sample_rate' => 1,
@@ -874,6 +897,7 @@ final class Options
         $resolver->setAllowedTypes('integrations', ['Sentry\\Integration\\IntegrationInterface[]', 'callable']);
         $resolver->setAllowedTypes('send_default_pii', 'bool');
         $resolver->setAllowedTypes('default_integrations', 'bool');
+        $resolver->setAllowedTypes('error_handler_integrations', ['bool', 'null']);
         $resolver->setAllowedTypes('max_value_length', 'int');
         $resolver->setAllowedTypes('http_proxy', ['null', 'string']);
         $resolver->setAllowedTypes('http_connect_timeout', ['int', 'float']);

--- a/tests/Integration/IntegrationRegistryTest.php
+++ b/tests/Integration/IntegrationRegistryTest.php
@@ -298,6 +298,46 @@ final class IntegrationRegistryTest extends TestCase
                 ModulesIntegration::class => new ModulesIntegration(),
             ],
         ];
+
+        yield 'Default integrations and no error handler integrations' => [
+            new Options([
+                'dsn' => 'http://public@example.com/sentry/1',
+                'default_integrations' => true,
+                'error_handler_integrations' => false,
+            ]),
+            [
+                'The "Sentry\\Integration\\RequestIntegration" integration has been installed.',
+                'The "Sentry\\Integration\\TransactionIntegration" integration has been installed.',
+                'The "Sentry\\Integration\\FrameContextifierIntegration" integration has been installed.',
+                'The "Sentry\\Integration\\EnvironmentIntegration" integration has been installed.',
+                'The "Sentry\\Integration\\ModulesIntegration" integration has been installed.',
+            ],
+            [
+                RequestIntegration::class => new RequestIntegration(),
+                TransactionIntegration::class => new TransactionIntegration(),
+                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
+                EnvironmentIntegration::class => new EnvironmentIntegration(),
+                ModulesIntegration::class => new ModulesIntegration(),
+            ],
+        ];
+
+        yield 'No default integrations and error handler integrations' => [
+            new Options([
+                'dsn' => 'http://public@example.com/sentry/1',
+                'default_integrations' => false,
+                'error_handler_integrations' => true,
+            ]),
+            [
+                'The "Sentry\\Integration\\ExceptionListenerIntegration" integration has been installed.',
+                'The "Sentry\\Integration\\ErrorListenerIntegration" integration has been installed.',
+                'The "Sentry\\Integration\\FatalErrorListenerIntegration" integration has been installed.',
+            ],
+            [
+                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
+                ErrorListenerIntegration::class => new ErrorListenerIntegration(),
+                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
+            ],
+        ];
     }
 
     /**

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -364,6 +364,50 @@ final class OptionsTest extends TestCase
             null,
             null,
         ];
+
+        yield [
+            'default_integrations',
+            false,
+            'hasDefaultIntegrations',
+            'setDefaultIntegrations',
+            null,
+            null,
+        ];
+
+        yield [
+            'error_handler_integrations',
+            true,
+            'hasErrorHandlerIntegrations',
+            'setErrorHandlerIntegrations',
+            null,
+            null,
+        ];
+    }
+
+    /**
+     * @dataProvider errorHandlerIntegrationsOptionDataProvider
+     */
+    public function testErrorHandlerIntegrationsFallback(
+        bool $defaultIntegrationsValue,
+        ?bool $errorHandlerIntegrationsValue,
+        bool $expectedValue
+    ): void {
+        $options = new Options([
+            'default_integrations' => $defaultIntegrationsValue,
+            'error_handler_integrations' => $errorHandlerIntegrationsValue,
+        ]);
+
+        $this->assertEquals($expectedValue, $options->hasErrorHandlerIntegrations());
+    }
+
+    public function errorHandlerIntegrationsOptionDataProvider(): iterable
+    {
+        yield [true, null, true];
+        yield [true, false, false];
+        yield [true, true, true];
+        yield [false, null, false];
+        yield [false, false, false];
+        yield [false, true, true];
     }
 
     /**


### PR DESCRIPTION
Sometimes you might want to exclude the error handler integrations from the default ones in case you are using some other error handler implementation, eg a one provided by your framework (see https://github.com/getsentry/sentry-symfony/issues/421).

One problem that having multiple error handlers may cause is having duplicate events in Sentry for the same event.

This PR introduces a new `error_handler_integrations` option which can be used to skip enabling the error handler integrations without the need to disable all default ones. When set to `null`, which is the default value, it'll fallback to using the `default_integrations` option. This is done to preserve backward compatibility.