### PR TITLE
Fix nullability in getters and setters for traces_sample_rate in Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Allow `null` on `getTracesSampleRate` and `setTracesSampleRate` in `Options` class
+- fix: Allow `null` on `getTracesSampleRate` and `setTracesSampleRate` in `Options` class (#1441)
 
 ## 3.12.0 (2022-11-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Allow `null` on `getTracesSampleRate` and `setTracesSampleRate` in `Options` class
+
 ## 3.12.0 (2022-11-22)
 
 - feat: Add `before_send_transaction` option (#1424)

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -226,7 +226,7 @@ parameters:
 			path: src/Options.php
 
 		-
-			message: "#^Method Sentry\\\\Options\\:\\:getTracesSampleRate\\(\\) should return float but returns mixed\\.$#"
+			message: "#^Method Sentry\\\\Options\\:\\:getTracesSampleRate\\(\\) should return float\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -138,7 +138,7 @@ final class Options
      * Gets the sampling factor to apply to transaction. A value of 0 will deny
      * sending any transaction, and a value of 1 will send 100% of transaction.
      */
-    public function getTracesSampleRate(): float
+    public function getTracesSampleRate(): ?float
     {
         return $this->options['traces_sample_rate'];
     }
@@ -147,9 +147,9 @@ final class Options
      * Sets the sampling factor to apply to transactions. A value of 0 will deny
      * sending any transactions, and a value of 1 will send 100% of transactions.
      *
-     * @param float $sampleRate The sampling factor
+     * @param ?float $sampleRate The sampling factor
      */
-    public function setTracesSampleRate(float $sampleRate): void
+    public function setTracesSampleRate(?float $sampleRate): void
     {
         $options = array_merge($this->options, ['traces_sample_rate' => $sampleRate]);
 
@@ -163,7 +163,7 @@ final class Options
      */
     public function isTracingEnabled(): bool
     {
-        return null !== $this->options['traces_sample_rate'] || null !== $this->options['traces_sampler'];
+        return null !== $this->getTracesSampleRate() || null !== $this->getTracesSampler();
     }
 
     /**

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -239,7 +239,7 @@ final class Hub implements HubInterface
             } else {
                 $sampleRate = $this->getSampleRate(
                     $samplingContext->getParentSampled(),
-                    $options->getTracesSampleRate()
+                    $options->getTracesSampleRate() ?? 0
                 );
             }
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -123,6 +123,15 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'traces_sample_rate',
+            null,
+            'getTracesSampleRate',
+            'setTracesSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
             'traces_sampler',
             static function (): void {},
             'getTracesSampler',


### PR DESCRIPTION
In #1428 the default value for `traces_sample_rate` was set to `null`. When calling `getTracesSampleRate()` on a new `Options` instance, this results in a PHP runtime exception as this method has a `float` return type. Similarly, passing `null` to `setTracesSampleRate()` is not allowed.

This PR adjusts the parameter and return type for these methods to allow for `null`.

I've also slightly refactored `isTracingEnabled` to use functions for accessing configuration and added a test for getting/setting `null`.

#skip-changelog