### PR TITLE
Minor cleanups

### DIFF
--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -177,8 +177,8 @@ final class ClientBuilder implements ClientBuilderInterface
     {
         $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUriFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
+            null,
+            null,
             $streamFactory,
             null,
             $this->sdkIdentifier,

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -54,16 +54,16 @@ final class HttpClientFactory implements HttpClientFactoryInterface
     /**
      * Constructor.
      *
-     * @param UriFactoryInterface           $uriFactory      The PSR-7 URI factory
-     * @param ResponseFactoryInterface      $responseFactory The PSR-7 response factory
+     * @param UriFactoryInterface|null      $uriFactory      The PSR-7 URI factory
+     * @param ResponseFactoryInterface|null $responseFactory The PSR-7 response factory
      * @param StreamFactoryInterface        $streamFactory   The PSR-17 stream factory
      * @param HttpAsyncClientInterface|null $httpClient      The HTTP client
      * @param string                        $sdkIdentifier   The SDK identifier
      * @param string                        $sdkVersion      The SDK version
      */
     public function __construct(
-        UriFactoryInterface $uriFactory,
-        ResponseFactoryInterface $responseFactory,
+        ?UriFactoryInterface $uriFactory,
+        ?ResponseFactoryInterface $responseFactory,
         StreamFactoryInterface $streamFactory,
         ?HttpAsyncClientInterface $httpClient,
         string $sdkIdentifier,

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -23,8 +23,8 @@ final class HttpClientFactoryTest extends TestCase
 
         $mockHttpClient = new HttpMockClient();
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
+            null,
+            null,
             $streamFactory,
             $mockHttpClient,
             'sentry.php.test',
@@ -67,8 +67,8 @@ final class HttpClientFactoryTest extends TestCase
     public function testCreateThrowsIfDsnOptionIsNotConfigured(): void
     {
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
+            null,
+            null,
             Psr17FactoryDiscovery::findStreamFactory(),
             null,
             'sentry.php.test',
@@ -84,8 +84,8 @@ final class HttpClientFactoryTest extends TestCase
     public function testCreateThrowsIfHttpProxyOptionIsUsedWithCustomHttpClient(): void
     {
         $httpClientFactory = new HttpClientFactory(
-            Psr17FactoryDiscovery::findUrlFactory(),
-            Psr17FactoryDiscovery::findResponseFactory(),
+            null,
+            null,
             Psr17FactoryDiscovery::findStreamFactory(),
             $this->createMock(HttpAsyncClientInterface::class),
             'sentry.php.test',

--- a/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
+++ b/tests/HttpClient/Plugin/GzipEncoderPluginTest.php
@@ -17,11 +17,13 @@ final class GzipEncoderPluginTest extends TestCase
 {
     public function testHandleRequest(): void
     {
-        $plugin = new GzipEncoderPlugin(Psr17FactoryDiscovery::findStreamFactory());
+        $streamFactory = Psr17FactoryDiscovery::findStreamFactory();
+
+        $plugin = new GzipEncoderPlugin($streamFactory);
         $expectedPromise = $this->createMock(PromiseInterface::class);
         $request = Psr17FactoryDiscovery::findRequestFactory()
             ->createRequest('POST', 'http://www.example.com')
-            ->withBody(Psr17FactoryDiscovery::findStreamFactory()->createStream('foo'));
+            ->withBody($streamFactory->createStream('foo'));
 
         $this->assertSame('foo', (string) $request->getBody());
         $this->assertSame($expectedPromise, $plugin->handleRequest(


### PR DESCRIPTION
Extracted from https://github.com/getsentry/sentry-php/pull/1418

`HttpClientFactory` doesn't use its 2 first arguments.

#skip-changelog