### PR TITLE
ci: remove danger

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,9 +1,0 @@
-name: Danger
-
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, ready_for_review]
-
-jobs:
-  danger:
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2


### PR DESCRIPTION
Not helpful at all, we will write proper changelogs during the release flow moving forward.