### PR TITLE
docs: Remove the need to add Changelogs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,6 @@ If you feel that you can fix or implement it yourself, please read on to learn h
 - Add tests for your changes to `tests/`.
 - Run tests and make sure all of them pass.
 - Submit a pull request, targeting the `develop` branch if you added any new features. For bug fixes of the current release, please target the `master` branch instead.
-- Make sure to update the `CHANGELOG.md` file below the `Unreleased` heading.
 
 We will review your pull request as soon as possible.
 Thank you for contributing!


### PR DESCRIPTION
We will write proper changelogs during the release flow moving forward.
There is no need that any contributors need to deal with any specific format.

#skip-changelog