### PR TITLE
fix: set php-http/discovery to allow false

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -89,6 +89,7 @@
         "sort-packages": true,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
+            "php-http/discovery": false,
             "phpstan/extension-installer": true
         }
     },


### PR DESCRIPTION
The last minor release of [php-http/discovery](https://github.com/php-http/discovery) contains some questionable changes that fail CI. Disabling the plugin for now.

See https://github.com/php-http/discovery/issues/213
