### PR TITLE
fix: pin php-http/discovery to < 1.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "php-http/async-client-implementation": "^1.0",
         "php-http/client-common": "^1.5|^2.0",
-        "php-http/discovery": "^1.11",
+        "php-http/discovery": "^1.11, <1.15",
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
         "psr/http-factory": "^1.0",


### PR DESCRIPTION
From #1462, we decided it might be better to pin the dependency to a non-problematic version for the time being (php-http/discovery#213).