### PR TITLE
fix: Use array_replace to preserve request body keys

### DIFF
--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -215,7 +215,7 @@ final class RequestIntegration implements IntegrationInterface
         }
 
         $requestData = $request->getParsedBody();
-        $requestData = array_merge(
+        $requestData = array_replace(
             $this->parseUploadedFiles($request->getUploadedFiles()),
             \is_array($requestData) ? $requestData : []
         );

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -405,6 +405,31 @@ final class RequestIntegrationTest extends TestCase
             ],
             (new ServerRequest('POST', 'http://www.example.com/foo'))
                 ->withHeader('Content-Type', 'application/json')
+                ->withHeader('Content-Length', '23')
+                ->withBody(Utils::streamFor('{"1":"foo","bar":"baz"}')),
+            [
+                'url' => 'http://www.example.com/foo',
+                'method' => 'POST',
+                'headers' => [
+                    'Host' => ['www.example.com'],
+                    'Content-Type' => ['application/json'],
+                    'Content-Length' => ['23'],
+                ],
+                'data' => [
+                    '1' => 'foo',
+                    'bar' => 'baz',
+                ],
+            ],
+            null,
+            null,
+        ];
+
+        yield [
+            [
+                'max_request_body_size' => 'always',
+            ],
+            (new ServerRequest('POST', 'http://www.example.com/foo'))
+                ->withHeader('Content-Type', 'application/json')
                 ->withHeader('Content-Length', '13')
                 ->withBody(Utils::streamFor('{"foo":"bar"}')),
             [


### PR DESCRIPTION
Looks like there is a different behavior with `nyholm/psr7` compared to `guzzlehttp/psr7`, hence we get different results in our Laravel SDK then in the PHP SDK.

```curl
POST / HTTP/1.1
Content-Type: application/json; charset=utf-8
Content-Length: 23

{"1":"foo","bar":"baz"}
```

```php
// Nyholm\Psr7\ServerRequest
$request->getParsedBody();

[
  1 => "foo"
  "bar" => "baz"
]
```

```php
// GuzzleHttp\Psr7\ServerRequest
$request->getParsedBody();

[]
```

Opted to preserve the keys by using `array_replace`.

Closes #1469 