### PR TITLE
feat: Add support for profiling

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,9 +12,5 @@ parameters:
         - tests/Fixtures
     dynamicConstantNames:
         - Monolog\Logger::API
-    stubFiles:
-        - stubs/ExcimerLog.stub
-        - stubs/ExcimerLogEntry.stub
-        - stubs/ExcimerProfiler.stub
-        - stubs/ExcimerTimer.stub
-        - stubs/globals.stub
+    bootstrapFiles:
+        - stubs/autoload.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,3 +12,9 @@ parameters:
         - tests/Fixtures
     dynamicConstantNames:
         - Monolog\Logger::API
+    stubFiles:
+        - stubs/ExcimerLog.stub
+        - stubs/ExcimerLogEntry.stub
+        - stubs/ExcimerProfiler.stub
+        - stubs/ExcimerTimer.stub
+        - stubs/globals.stub

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.27.0@faf106e717c37b8c81721845dba9de3d8deed8ff">
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
   <file src="src/Dsn.php">
     <PossiblyUndefinedArrayOffset occurrences="4">
       <code>$parsedDsn['host']</code>
@@ -58,6 +58,12 @@
       <code>$record['context']</code>
       <code>$record['context']</code>
     </PossiblyUndefinedMethod>
+  </file>
+  <file src="src/Profiling/Profile.php">
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1">
+      <code>SentryProfile|null</code>
+    </MoreSpecificReturnType>
   </file>
   <file src="src/Serializer/RepresentationSerializer.php">
     <InvalidReturnStatement occurrences="1">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -64,4 +64,12 @@
             </errorLevel>
         </UndefinedClass>
     </issueHandlers>
+
+    <stubs>
+        <file name="stubs/ExcimerLog.stub" />
+        <file name="stubs/ExcimerLogEntry.stub" />
+        <file name="stubs/ExcimerProfiler.stub" />
+        <file name="stubs/ExcimerTimer.stub" />
+        <file name="stubs/globals.stub" />
+    </stubs>
 </psalm>

--- a/src/Context/OsContext.php
+++ b/src/Context/OsContext.php
@@ -32,15 +32,26 @@ final class OsContext
     private $kernelVersion;
 
     /**
+     * @var string|null
+     */
+    private $machineType;
+
+    /**
      * Constructor.
      *
      * @param string      $name          The name of the operating system
      * @param string|null $version       The version of the operating system
      * @param string|null $build         The internal build revision of the operating system
      * @param string|null $kernelVersion An independent kernel version string
+     * @param string|null $machineType   The machine type
      */
-    public function __construct(string $name, ?string $version = null, ?string $build = null, ?string $kernelVersion = null)
-    {
+    public function __construct(
+        string $name,
+        ?string $version = null,
+        ?string $build = null,
+        ?string $kernelVersion = null,
+        ?string $machineType = null
+    ) {
         if ('' === trim($name)) {
             throw new \InvalidArgumentException('The $name argument cannot be an empty string.');
         }
@@ -49,6 +60,7 @@ final class OsContext
         $this->version = $version;
         $this->build = $build;
         $this->kernelVersion = $kernelVersion;
+        $this->machineType = $machineType;
     }
 
     /**
@@ -125,5 +137,18 @@ final class OsContext
     public function setKernelVersion(?string $kernelVersion): void
     {
         $this->kernelVersion = $kernelVersion;
+    }
+
+    public function getMachineType(): ?string
+    {
+        return $this->machineType;
+    }
+
+    /**
+     * @param string|null $machineType The machine type
+     */
+    public function setMachineType(?string $machineType): void
+    {
+        $this->machineType = $machineType;
     }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -6,6 +6,7 @@ namespace Sentry;
 
 use Sentry\Context\OsContext;
 use Sentry\Context\RuntimeContext;
+use Sentry\Profiling\Profile;
 use Sentry\Tracing\Span;
 
 /**
@@ -166,6 +167,11 @@ final class Event
      * @var EventType The type of the Event
      */
     private $type;
+
+    /**
+     * @var Profile|null The profile data
+     */
+    private $profile;
 
     private function __construct(?EventId $eventId, EventType $eventType)
     {
@@ -746,5 +752,15 @@ final class Event
     public function setSpans(array $spans): void
     {
         $this->spans = $spans;
+    }
+
+    public function setProfile(?Profile $profile): void
+    {
+        $this->profile = $profile;
+    }
+
+    public function getProfile(): ?Profile
+    {
+        return $this->profile;
     }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -763,4 +763,15 @@ final class Event
     {
         return $this->profile;
     }
+
+    public function getTraceId(): ?string
+    {
+        $traceId = $this->getContexts()['trace']['trace_id'];
+
+        if (\is_string($traceId) && !empty($traceId)) {
+            return $traceId;
+        }
+
+        return null;
+    }
 }

--- a/src/Integration/EnvironmentIntegration.php
+++ b/src/Integration/EnvironmentIntegration.php
@@ -70,6 +70,10 @@ final class EnvironmentIntegration implements IntegrationInterface
             $osContext->setKernelVersion(php_uname('a'));
         }
 
+        if (null === $osContext->getMachineType()) {
+            $osContext->setMachineType(php_uname('m'));
+        }
+
         return $osContext;
     }
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -185,7 +185,10 @@ final class Options
 
     public function getProfilesSampleRate(): ?float
     {
-        return $this->options['profiles_sample_rate'];
+        /** @var int|float|null $value */
+        $value = $this->options['profiles_sample_rate'] ?? null;
+
+        return $value ?? null;
     }
 
     public function setProfilesSampleRate(?float $sampleRate): void

--- a/src/Options.php
+++ b/src/Options.php
@@ -156,6 +156,18 @@ final class Options
         $this->options = $this->resolver->resolve($options);
     }
 
+    public function getProfilesSampleRate(): ?float
+    {
+        return $this->options['profiles_sample_rate'];
+    }
+
+    public function setProfilesSampleRate(?float $sampleRate): void
+    {
+        $options = array_merge($this->options, ['profiles_sample_rate' => $sampleRate]);
+
+        $this->options = $this->resolver->resolve($options);
+    }
+
     /**
      * Gets whether tracing is enabled or not. The feature is enabled when at
      * least one of the `traces_sample_rate` and `traces_sampler` options is
@@ -816,6 +828,7 @@ final class Options
             'sample_rate' => 1,
             'traces_sample_rate' => null,
             'traces_sampler' => null,
+            'profiles_sample_rate' => null,
             'attach_stacktrace' => false,
             'context_lines' => 5,
             'enable_compression' => true,
@@ -854,6 +867,7 @@ final class Options
         $resolver->setAllowedTypes('sample_rate', ['int', 'float']);
         $resolver->setAllowedTypes('traces_sample_rate', ['null', 'int', 'float']);
         $resolver->setAllowedTypes('traces_sampler', ['null', 'callable']);
+        $resolver->setAllowedTypes('profiles_sample_rate', ['null', 'int', 'float']);
         $resolver->setAllowedTypes('attach_stacktrace', 'bool');
         $resolver->setAllowedTypes('context_lines', ['null', 'int']);
         $resolver->setAllowedTypes('enable_compression', 'bool');

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -159,23 +159,26 @@ final class Profile
         $loggedStacks = $this->prepareStacks();
         foreach ($loggedStacks as $stackId => $stack) {
             foreach ($stack['trace'] as $frame) {
-                $file = (string) $frame['file'];
+                $absolutePath = (string) $frame['file'];
+                // TODO(michi) Strip the file path based on the `prefixes` option
+                $file = $absolutePath;
                 $module = null;
 
                 if (isset($frame['class'], $frame['function'])) {
                     // Class::method
-                    $function = (string) $frame['class'] . '::' . (string) $frame['function'];
-                    $module = (string) $frame['class'];
+                    $function = $frame['class'] . '::' . $frame['function'];
+                    $module = $frame['class'];
                 } elseif (isset($frame['function'])) {
                     // {clousre}
-                    $function = (string) $frame['function'];
+                    $function = $frame['function'];
                 } else {
-                    // /var/www/html/index.php
-                    $function = (string) $frame['file'];
+                    // /index.php
+                    $function = $file;
                 }
 
                 $frames[] = [
                     'filename' => $file,
+                    'abs_path' => $absolutePath,
                     'module' => $module,
                     'function' => $function,
                     'lineno' => !empty($frame['line']) ? (int) $frame['line'] : null,

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -178,9 +178,9 @@ final class Profile
         }
 
         // TODO(michi) This is too hacky
-        $now = \DateTime::createFromFormat('U.u', (string) $this->startTime);
+        $startTime = \DateTime::createFromFormat('U.u', (string) $this->startTime);
 
-        if (false === $now) {
+        if (false === $startTime) {
             return null;
         }
 
@@ -201,7 +201,7 @@ final class Profile
                 'name' => $runtimeContext->getName(),
                 'version' => $runtimeContext->getVersion(),
             ],
-            'timestamp' => $now->format(\DATE_RFC3339_EXTENDED),
+            'timestamp' => $startTime->format(\DATE_RFC3339_EXTENDED),
             'transaction' => [
                 'id' => (string) $event->getId(),
                 'name' => $event->getTransaction(),

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Profiling;
+
+use Sentry\Event;
+use Sentry\Util\SentryUid;
+
+/** 
+ * @phpstan-type ExcimerProfile array{
+ *     shared: array{
+ *         frames: array<int, array{
+ *             name: string,
+ *             file: string
+ *         }>,
+ *     },
+ *     profiles: array<int, array{
+ *        startValue: int,
+ *        endValue: int,
+ *        samples: array<int, array<int, int>>,
+ *        weights: array<int, int>
+ *     }>
+ * }
+ * 
+ * @phpstan-type SentryProfile array{
+ *    device: array{
+ *        architecture: string,
+ *    },
+ *    event_id: string,
+ *    os: array{
+ *       name: string,
+ *       version: string,
+ *       build_number: string,
+ *    },
+ *    platform: string,
+ *    release: string,
+ *    environment: string,
+ *    runtime: array{
+ *        name: string,
+ *        version: string,
+ *    },
+ *    timestamp: string,
+ *    transaction: array{
+ *        id: string,
+ *        name: string,
+ *        trace_id: string,
+ *        active_thread_id: string,
+ *    },
+ *    version: string,
+ *    profile: array{
+ *        frames: array<int, mixed>,
+ *        samples: array<int, mixed>,
+ *        stacks: array<int, mixed>,
+ *    },
+ * }
+ *
+ * @internal
+ */
+class Profile
+{
+    /**
+     * @var string The version of the profile format
+     */
+    private const VERSION = '1';
+
+    /**
+     * @var string The thread ID
+     */
+    private const THREAD_ID = '0';
+
+    /**
+     * @var int The minimum number of samples required to send a profile
+     */
+    private const MIN_SAMPLE_COUNT = 2;
+
+    /**
+     * @var string|null The start time of the profile
+     */
+    private ?string $startTime;
+
+    /**
+     * @var ExcimerProfile|null The data of the profile
+     */
+    private ?array $data;
+
+    public function getStartTime(): ?string
+    {
+        return $this->startTime;
+    }
+
+    public function setStartTime(?string $startTime): void
+    {
+        $this->startTime = $startTime;
+    }
+
+    /**
+     * @return ExcimerProfile
+     */
+    public function getData(): ?array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param ExcimerProfile|null $data
+     */
+    public function setData(?array $data): void
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return SentryProfile|null
+     */
+    public function getFormatedData(Event $event): ?array
+    {
+        if (empty($this->data)) {
+            return null;
+        }
+        dd($this->data);
+
+        $frames = $this->data['shared']['frames'];
+        foreach ($frames as $key => $frame) {
+            $frames[$key]['function'] = $frame['name'];
+            $frames[$key]['filename'] = $frame['file'];
+        }
+
+        $stacks = $this->data['profiles'][0]['samples'];
+        foreach ($stacks as $key => $stack) {
+            $stacks[$key] = array_reverse($stack);
+        }
+
+        $samples = [];
+        $time = 0;
+
+        $weights = $this->data['profiles'][0]['weights'];
+        foreach ($weights as $key => $weight) {
+            $time += $weight;
+            $samples[] = [
+                'elapsed_since_start_ns' => $time,
+                'stack_id' => $key,
+                'thread_id' => self::THREAD_ID,
+            ];
+        }
+
+        if (\count($samples) < self::MIN_SAMPLE_COUNT) {
+            return null;
+        }
+
+        $osContext = $event->getOsContext();
+        $runtimeContext = $event->getRuntimeContext();
+
+        // If we can't fetch the required data from the OS and runtime context, we don't send the profile
+        if (null === $osContext || null === $runtimeContext) {
+            return null;
+        }
+
+        return [
+            'device' => [
+                'architecture' => $osContext->getMachineType(),
+            ],
+            'event_id' => SentryUid::generate(),
+            'os' => [
+                'name' => $osContext->getName(),
+                'version' => $osContext->getVersion(),
+                'build_number' => $osContext->getBuild(),
+            ],
+            'platform' => 'php',
+            'release' => $event->getRelease() ?? '',
+            'environment' => $event->getEnvironment(),
+            'runtime' => [
+                'name' => $runtimeContext->getName(),
+                'version' => $runtimeContext->getVersion(),
+            ],
+            'timestamp' => $this->startTime,
+            'transaction' => [
+                'id' => (string) $event->getId(),
+                'name' => $event->getTransaction(),
+                'trace_id' => (string) $event->getContexts()['trace']['trace_id'],
+                'active_thread_id' => self::THREAD_ID,
+            ],
+            'version' => self::VERSION,
+            'profile' => [
+                'frames' => $frames,
+                'samples' => $samples,
+                'stacks' => $stacks,
+                // TODO(michi)
+                // Format needs to be "thread_metadata": { "0": { "name": "main" } }
+                // 'thread_metadata' => [
+                //     '0' => [
+                //         'name' => 'main',
+                //     ],
+                // ],
+            ],
+        ];
+    }
+}

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -146,7 +146,7 @@ final class Profile
     /**
      * @return SentryProfile|null
      */
-    public function getFormatedData(Event $event): ?array
+    public function getFormattedData(Event $event): ?array
     {
         if (!$this->validateExcimerLog()) {
             return null;
@@ -186,6 +186,11 @@ final class Profile
                 } else {
                     $function = $frame['file'];
                 }
+                // TBD add 'package' \Cake\Core\Configure -> Configure
+                // Allows for filtering by package
+
+                // filename is foo.php
+                // abs_path is /var/www/html/foo.php
 
                 $frames[] = [
                     'function' => $function,
@@ -245,6 +250,9 @@ final class Profile
         ];
     }
 
+    /**
+     * TBD: needed for tests
+     */
     private function prepareStacks(): array
     {
         $stacks = [];

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -11,25 +11,6 @@ use Sentry\EventId;
 use Sentry\Util\SentryUid;
 
 /**
- * Type definition of the Excimer profile format.
- * This format is guranteed to be returned if the extension is loaded.
- *
- * @see https://github.com/wikimedia/mediawiki-php-excimer/blob/c4bd691a505a8349b05999526167e67027a1cc87/excimer_log.c#L455
- * @phpstan-type ExcimerProfile array{
- *     shared: array{
- *         frames: array<int, array{
- *             name: string,
- *             file: string
- *         }>,
- *     },
- *     profiles: array<int, array{
- *        startValue: int,
- *        endValue: int,
- *        samples: array<int, array<int, int>>,
- *        weights: array<int, int>
- *     }>
- * }
- *
  * Type definition of the Sentry profile format.
  * All fields are none otpional.
  *
@@ -52,18 +33,12 @@ use Sentry\Util\SentryUid;
  *        version: string,
  *    },
  *    timestamp: string,
- *    transaction?: array{
+ *    transaction: array{
  *        id: string,
  *        name: string,
  *        trace_id: string,
  *        active_thread_id: string,
  *    },
- *    transactions: array<int, array{
- *        id: string,
- *        name: string,
- *        trace_id: string,
- *        active_thread_id: string,
- *    }>,
  *    version: string,
  *    profile: array{
  *        frames: array<int, array{
@@ -105,44 +80,44 @@ final class Profile
     private const MAX_PROFILE_DURATION = 30;
 
     /**
-     * @var string|null The start time of the profile
+     * @var float|null The start time of the profile
      */
     private $startTime = null;
 
     /**
-     * @var ExcimerProfile|null The data of the profile
+     * @var \ExcimerLog|null The data of the profile
      */
-    private $data = null;
+    private $excimerLog = null;
 
     /**
      * @var EventId|null The event ID of the profile
      */
     private $eventId = null;
 
-    public function getStartTime(): ?string
+    public function getStartTime(): ?float
     {
         return $this->startTime;
     }
 
-    public function setStartTime(?string $startTime): void
+    public function setStartTime(?float $startTime): void
     {
         $this->startTime = $startTime;
     }
 
     /**
-     * @return ExcimerProfile
+     * @return \ExcimerLog|null
      */
-    public function getData(): ?array
+    public function getExcimerLog(): ?\ExcimerLog
     {
-        return $this->data;
+        return $this->excimerLog;
     }
 
     /**
-     * @param ExcimerProfile|null $data
+     * @param \ExcimerLog|null $excimerLog
      */
-    public function setData(?array $data): void
+    public function setExcimerLog(?\ExcimerLog $excimerLog): void
     {
-        $this->data = $data;
+        $this->excimerLog = $excimerLog;
     }
 
     public function setEventId(EventId $eventId): void
@@ -155,13 +130,7 @@ final class Profile
      */
     public function getFormatedData(Event $event): ?array
     {
-        if (empty($this->data)) {
-            return null;
-        }
-
-        // If the profile duration is too long (> 30s), we don't send the profile.
-        // We convert nanoseconds to seconds by dividing by 1e-9.
-        if (($this->data['profiles'][0]['endValue'] * 1e-9) > self::MAX_PROFILE_DURATION) {
+        if (!$this->validateExcimerLog()) {
             return null;
         }
 
@@ -180,36 +149,44 @@ final class Profile
         }
 
         $frames = [];
-        foreach ($this->data['shared']['frames'] as $frame) {
-            $frames[] = [
-                'function' => $frame['name'],
-                'filename' => $frame['file'],
-            ];
-        }
-
-        $stacks = $this->data['profiles'][0]['samples'];
-        foreach ($stacks as $key => $stack) {
-            // Order stacks from outermost to innermost frame
-            $stacks[$key] = array_reverse($stack);
-        }
-
-        $time = 0;
         $samples = [];
+        $stacks = [];
 
-        $weights = $this->data['profiles'][0]['weights'];
-        foreach ($weights as $key => $weight) {
-            $time += $weight;
+        $frameIndex = 0;
+
+        foreach ($this->excimerLog as $stackId => $logEntry) {
+            $stack = $logEntry->getTrace();
+
+            foreach ($stack as $frame) {
+                $file = $frame['file'];
+                $function = '';
+
+                if (isset($frame['class']) && isset($frame['function'])) {
+                    $function = $frame['class'] . '::' . $frame['function'];
+                } else {
+                    $function = $frame['file'];
+                }
+
+                $frames[] = [
+                    'function' => $function,
+                    'filename' => $file,
+                    'lineno' => $frame['line'],
+                ];
+
+                $stacks[$stackId][] = $frameIndex;
+                ++$frameIndex;
+            }
+            $stacks[$stackId] = $stacks[$stackId];
+
             $samples[] = [
-                'elapsed_since_start_ns' => $time,
-                'stack_id' => $key,
+                'elapsed_since_start_ns' => (int) round($logEntry->getTimestamp() * 1e9, 0),
+                'stack_id' => $stackId,
                 'thread_id' => self::THREAD_ID,
             ];
         }
 
-        // If we did not collect enough (>= 2) samples, we don't send the profile.
-        if (\count($samples) < self::MIN_SAMPLE_COUNT) {
-            return null;
-        }
+        // TODO(michi) This is too hacky
+        $now = \DateTime::createFromFormat('U.u', (string) $this->startTime);
 
         return [
             'device' => [
@@ -228,23 +205,13 @@ final class Profile
                 'name' => $runtimeContext->getName(),
                 'version' => $runtimeContext->getVersion(),
             ],
-            'timestamp' => $this->startTime,
-            'transactions' => [
-                [
-                    'id' => (string) $event->getId(),
-                    'name' => $event->getTransaction(),
-                    'trace_id' => (string) $event->getContexts()['trace']['trace_id'],
-                    'active_thread_id' => self::THREAD_ID,
-                    'relative_start_ns' => 0,
-                    'relative_end_ns' => $this->data['profiles'][0]['endValue'],
-                ],
+            'timestamp' => $now->format(\DATE_RFC3339_EXTENDED),
+            'transaction' => [
+                'id' => (string) $event->getId(),
+                'name' => $event->getTransaction(),
+                'trace_id' => (string) $event->getContexts()['trace']['trace_id'],
+                'active_thread_id' => self::THREAD_ID,
             ],
-            // 'transaction' => [
-            //     'id' => (string) $event->getId(),
-            //     'name' => $event->getTransaction(),
-            //     'trace_id' => (string) $event->getContexts()['trace']['trace_id'],
-            //     'active_thread_id' => self::THREAD_ID,
-            // ],
             'version' => self::VERSION,
             'profile' => [
                 'frames' => $frames,
@@ -259,6 +226,24 @@ final class Profile
                 // ],
             ],
         ];
+    }
+
+    private function validateExcimerLog(): bool
+    {
+        if (null === $this->excimerLog) {
+            return false;
+        }
+
+        $sampleCount = $this->excimerLog->count();
+        if (0 === $sampleCount) {
+            return false;
+        }
+
+        if (self::MIN_SAMPLE_COUNT > $sampleCount) {
+            return false;
+        }
+
+        return true;
     }
 
     private function validateOsContext(?OsContext $osContext): bool

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -196,8 +196,7 @@ final class Profile
             ],
             'platform' => 'php',
             'release' => $event->getRelease() ?? '',
-            // @TODO: Validate "production" is the correct default environment
-            'environment' => $event->getEnvironment() ?? 'production',
+            'environment' => $event->getEnvironment() ?? Event::DEFAULT_ENVIRONMENT,
             'runtime' => [
                 'name' => $runtimeContext->getName(),
                 'version' => $runtimeContext->getVersion(),

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -131,7 +131,7 @@ final class Profile
     }
 
     /**
-     * @param \ExcimerLog|array<int, mixed> $excimerLog 
+     * @param \ExcimerLog|array<int, mixed> $excimerLog
      */
     public function setExcimerLog($excimerLog): void
     {
@@ -245,9 +245,6 @@ final class Profile
         ];
     }
 
-    /**
-     * @return array
-     */
     private function prepareStacks(): array
     {
         $stacks = [];
@@ -268,7 +265,7 @@ final class Profile
 
     private function validateExcimerLog(): bool
     {
-        if (self::MIN_SAMPLE_COUNT > count($this->excimerLog)) {
+        if (self::MIN_SAMPLE_COUNT > \count($this->excimerLog)) {
             return false;
         }
 

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -108,17 +108,17 @@ final class Profile
     /**
      * @var string|null The start time of the profile
      */
-    private ?string $startTime;
+    private $startTime = null;
 
     /**
      * @var ExcimerProfile|null The data of the profile
      */
-    private ?array $data;
+    private $data = null;
 
     /**
      * @var EventId|null The event ID of the profile
      */
-    private ?EventId $eventId = null;
+    private $eventId = null;
 
     public function getStartTime(): ?string
     {

--- a/src/Profiling/Profile.php
+++ b/src/Profiling/Profile.php
@@ -8,7 +8,6 @@ use Sentry\Context\OsContext;
 use Sentry\Context\RuntimeContext;
 use Sentry\Event;
 use Sentry\EventId;
-use Sentry\Tracing\TraceId;
 use Sentry\Util\SentryUid;
 
 /**

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Profiling;
 
-class Profiler
+/**
+ * @internal
+ */
+final class Profiler
 {
     private ?\ExcimerProfiler $profiler;
 

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -40,9 +40,6 @@ final class Profiler
     {
         if (null !== $this->profiler) {
             $this->profiler->start();
-
-            $this->profile->setStartTime($this->currentTimestampInMicroseconds());
-            $this->profile->setStartTimeStamp(microtime(true));
         }
     }
 
@@ -51,7 +48,6 @@ final class Profiler
         if (null !== $this->profiler) {
             $this->profiler->stop();
 
-            $this->profile->setStopTime($this->currentTimestampInMicroseconds());
             $this->profile->setExcimerLog($this->profiler->flush());
         }
     }
@@ -65,28 +61,11 @@ final class Profiler
     {
         if (\extension_loaded('excimer') && \PHP_VERSION_ID >= 70300) {
             $this->profiler = new \ExcimerProfiler();
+            $this->profile->setStartTimeStamp(microtime(true));
+
             $this->profiler->setEventType(EXCIMER_REAL);
             $this->profiler->setPeriod(self::SAMPLE_RATE);
             $this->profiler->setMaxDepth(self::MAX_STACK_DEPTH);
-
-            $this->profile->setInitTime(hrtime(true));
         }
-    }
-
-    /**
-     * Get the system's highest resolution of time possible.
-     *
-     * If the `hrtime` function is available, it will be used to get a nanosecond precision point in time.
-     *
-     * Otherwise, the `microtime` function will be used to get a microsecond precision point in time (that will be converted to look like a nanosecond precise timestamp).
-     */
-    private function currentTimestampInMicroseconds(): int
-    {
-        // Is the `hrtime` function available to get a nanosecond precision point in time?
-        if (\function_exists('hrtime')) {
-            return hrtime(true);
-        }
-
-        return (int) (microtime(true) * 1e9);
     }
 }

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -9,9 +9,15 @@ namespace Sentry\Profiling;
  */
 final class Profiler
 {
-    private ?\ExcimerProfiler $profiler;
+    /**
+     * @var \ExcimerProfiler|null
+     */
+    private $profiler;
 
-    private ?Profile $profile;
+    /**
+     * @var Profile
+     */
+    private $profile;
 
     /**
      * @var float The sample rate (10.01ms/101 Hz)
@@ -45,7 +51,7 @@ final class Profiler
         }
     }
 
-    public function getProfile(): ?Profile
+    public function getProfile(): Profile
     {
         return $this->profile;
     }

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Profiling;
+
+class Profiler
+{
+    private ?\ExcimerProfiler $profiler;
+
+    private ?Profile $profile;
+
+    /**
+     * @var float The sample rate (10.01ms/101 Hz)
+     */
+    private const SAMPLE_RATE = 0.0101;
+
+    /**
+     * @var int The maximum stack depth
+     */
+    private const MAX_STACK_DEPTH = 128;
+
+    public function __construct()
+    {
+        $this->profile = new Profile();
+
+        $this->initProfiler();
+    }
+
+    public function start(): void
+    {
+        if (null !== $this->profiler) {
+            $this->profiler->start();
+            $this->profile->setStartTime(gmdate('Y-m-d\TH:i:s\Z'));
+        }
+    }
+
+    public function stop(): void
+    {
+        if (null !== $this->profiler) {
+            $this->profiler->stop();
+            $this->profile->setData($this->profiler->flush()->getSpeedscopeData());
+        }
+    }
+
+    public function getProfile(): ?Profile
+    {
+        return $this->profile;
+    }
+
+    private function initProfiler(): void
+    {
+        if (\extension_loaded('excimer')) {
+            $this->profiler = new \ExcimerProfiler();
+            $this->profiler->setEventType(EXCIMER_REAL);
+            $this->profiler->setPeriod(self::SAMPLE_RATE);
+            $this->profiler->setMaxDepth(self::MAX_STACK_DEPTH);
+        }
+    }
+}

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -40,6 +40,9 @@ final class Profiler
     {
         if (null !== $this->profiler) {
             $this->profiler->start();
+
+            $this->profile->setStartTime(hrtime(true));
+            $this->profile->setStartTimeStamp(microtime(true));
         }
     }
 
@@ -47,6 +50,8 @@ final class Profiler
     {
         if (null !== $this->profiler) {
             $this->profiler->stop();
+
+            $this->profile->setStopTime(hrtime(true));
             $this->profile->setExcimerLog($this->profiler->flush());
         }
     }
@@ -58,13 +63,13 @@ final class Profiler
 
     private function initProfiler(): void
     {
-        if (\extension_loaded('excimer')) {
+        if (\extension_loaded('excimer') && \PHP_VERSION_ID >= 70300) {
             $this->profiler = new \ExcimerProfiler();
-            $this->profile->setStartTime(microtime(true));
-
             $this->profiler->setEventType(EXCIMER_REAL);
             $this->profiler->setPeriod(self::SAMPLE_RATE);
             $this->profiler->setMaxDepth(self::MAX_STACK_DEPTH);
+
+            $this->profile->setInitTime(hrtime(true));
         }
     }
 }

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -34,7 +34,6 @@ final class Profiler
     {
         if (null !== $this->profiler) {
             $this->profiler->start();
-            $this->profile->setStartTime(gmdate('Y-m-d\TH:i:s\Z'));
         }
     }
 
@@ -42,7 +41,7 @@ final class Profiler
     {
         if (null !== $this->profiler) {
             $this->profiler->stop();
-            $this->profile->setData($this->profiler->flush()->getSpeedscopeData());
+            $this->profile->setExcimerLog($this->profiler->flush());
         }
     }
 
@@ -55,6 +54,8 @@ final class Profiler
     {
         if (\extension_loaded('excimer')) {
             $this->profiler = new \ExcimerProfiler();
+            $this->profile->setStartTime(microtime(true));
+
             $this->profiler->setEventType(EXCIMER_REAL);
             $this->profiler->setPeriod(self::SAMPLE_RATE);
             $this->profiler->setMaxDepth(self::MAX_STACK_DEPTH);

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -41,7 +41,7 @@ final class Profiler
         if (null !== $this->profiler) {
             $this->profiler->start();
 
-            $this->profile->setStartTime(hrtime(true));
+            $this->profile->setStartTime($this->currentTimestampInMicroseconds());
             $this->profile->setStartTimeStamp(microtime(true));
         }
     }
@@ -51,7 +51,7 @@ final class Profiler
         if (null !== $this->profiler) {
             $this->profiler->stop();
 
-            $this->profile->setStopTime(hrtime(true));
+            $this->profile->setStopTime($this->currentTimestampInMicroseconds());
             $this->profile->setExcimerLog($this->profiler->flush());
         }
     }
@@ -71,5 +71,22 @@ final class Profiler
 
             $this->profile->setInitTime(hrtime(true));
         }
+    }
+
+    /**
+     * Get the system's highest resolution of time possible.
+     *
+     * If the `hrtime` function is available, it will be used to get a nanosecond precision point in time.
+     *
+     * Otherwise, the `microtime` function will be used to get a microsecond precision point in time (that will be converted to look like a nanosecond precise timestamp).
+     */
+    private function currentTimestampInMicroseconds(): int
+    {
+        // Is the `hrtime` function available to get a nanosecond precision point in time?
+        if (\function_exists('hrtime')) {
+            return hrtime(true);
+        }
+
+        return (int) (microtime(true) * 1e9);
     }
 }

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -237,7 +237,7 @@ final class PayloadSerializer implements PayloadSerializerInterface
     private function seralizeProfileAsEnvelope(Event $event): ?string
     {
         $itemHeader = [
-            'type' => (string) 'profile',
+            'type' => 'profile',
             'content_type' => 'application/json',
         ];
 

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -246,7 +246,7 @@ final class PayloadSerializer implements PayloadSerializerInterface
             return null;
         }
 
-        $profileData = $profile->getFormatedData($event);
+        $profileData = $profile->getFormattedData($event);
         if (null === $profileData) {
             return null;
         }

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -10,6 +10,7 @@ use Sentry\EventType;
 use Sentry\ExceptionDataBag;
 use Sentry\Frame;
 use Sentry\Options;
+use Sentry\Profiling\Profile;
 use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\TransactionMetadata;
@@ -233,7 +234,7 @@ final class PayloadSerializer implements PayloadSerializerInterface
         return sprintf("%s\n%s\n%s", JSON::encode($envelopeHeader), JSON::encode($itemHeader), $this->serializeAsEvent($event));
     }
 
-    private function seralizeProfileAsEnvelope(Event $event): string
+    private function seralizeProfileAsEnvelope(Event $event): ?string
     {
         $itemHeader = [
             'type' => (string) 'profile',
@@ -241,7 +242,14 @@ final class PayloadSerializer implements PayloadSerializerInterface
         ];
 
         $profile = $event->getSdkMetadata('profile');
+        if (!$profile instanceof Profile) {
+            return null;
+        }
+
         $profileData = $profile->getFormatedData($event);
+        if (null === $profileData) {
+            return null;
+        }
 
         return sprintf("%s\n%s", JSON::encode($itemHeader), JSON::encode($profileData));
     }

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -6,6 +6,7 @@ namespace Sentry\Tracing;
 
 use Sentry\Event;
 use Sentry\EventId;
+use Sentry\Profiling\Profiler;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 
@@ -33,6 +34,11 @@ final class Transaction extends Span
      * @var TransactionMetadata
      */
     protected $metadata;
+
+    /**
+     * @var Profiler|null Reference instance to the {@see Profiler}
+     */
+    protected $profiler = null;
 
     /**
      * Span constructor.
@@ -107,11 +113,37 @@ final class Transaction extends Span
         $this->spanRecorder->add($this);
     }
 
+    public function detachSpanRecorder(): void
+    {
+        $this->spanRecorder = null;
+    }
+
+    public function initProfiler(): void
+    {
+        if (null === $this->profiler) {
+            $this->profiler = new Profiler();
+        }
+    }
+
+    public function getProfiler(): ?Profiler
+    {
+        return $this->profiler;
+    }
+
+    public function detachProfiler(): void
+    {
+        $this->profiler = null;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function finish(?float $endTimestamp = null): ?EventId
     {
+        if (null !== $this->profiler) {
+            $this->profiler->stop();
+        }
+
         if (null !== $this->endTimestamp) {
             // Transaction was already finished once and we don't want to re-flush it
             return null;
@@ -142,6 +174,13 @@ final class Transaction extends Span
         $event->setContext('trace', $this->getTraceContext());
         $event->setSdkMetadata('dynamic_sampling_context', $this->getDynamicSamplingContext());
         $event->setSdkMetadata('transaction_metadata', $this->getMetadata());
+
+        if (null !== $this->profiler) {
+            $profile = $this->profiler->getProfile();
+            if (null !== $profile) {
+                $event->setSdkMetadata('profile', $profile);
+            }
+        }
 
         return $this->hub->captureEvent($event);
     }

--- a/stubs/ExcimerLog.stub
+++ b/stubs/ExcimerLog.stub
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * A collected series of stack traces and some utility methods to aggregate them.
+ *
+ * ExcimerLog acts as a container for ExcimerLogEntry objects. The Iterator or
+ * ArrayAccess interfaces may be used to access them. For example:
+ *
+ *   foreach ( $profiler->getLog() as $entry ) {
+ *      var_dump( $entry->getTrace() );
+ *   }
+ */
+class ExcimerLog implements ArrayAccess, Iterator {
+	/**
+	 * ExcimerLog is not constructible by user code. Objects of this type
+	 * are available via:
+	 *   - ExcimerProfiler::getLog()
+	 *   - ExcimerProfiler::flush()
+	 *   - The callback to ExcimerProfiler::setFlushCallback()
+	 */
+	private final function __construct() {
+	}
+
+	/**
+	 * Aggregate the stack traces and convert them to a line-based format
+	 * understood by Brendan Gregg's FlameGraph utility. Each stack trace is
+	 * represented as a series of function names, separated by semicolons.
+	 * After this identifier, there is a single space character, then a number
+	 * giving the number of times the stack appeared. Then there is a line
+	 * break. This is repeated for each unique stack trace.
+	 *
+	 * @return string
+	 */
+	function formatCollapsed() {
+	}
+
+	/**
+	 * Produce an array with an element for every function which appears in
+	 * the log. The key is a human-readable unique identifier for the function,
+	 * method or closure. The value is an associative array with the following
+	 * elements:
+	 *
+	 *   - self: The number of events in which the function itself was running,
+	 *     no other userspace function was being called. This includes time
+	 *     spent in internal functions that this function called.
+	 *   - inclusive: The number of events in which this function appeared
+	 *     somewhere in the stack.
+	 *
+	 * And optionally the following elements, if they are relevant:
+	 *
+	 *   - file: The filename in which the function appears
+	 *   - line: The exact line number at which the first relevant event
+	 *     occurred.
+	 *   - class: The class name in which the method is defined
+	 *   - function: The name of the function or method
+	 *   - closure_line: The line number at which the closure was defined
+	 *
+	 * The event counts in the "self" and "inclusive" fields are adjusted for
+	 * overruns. They represent an estimate of the number of profiling periods
+	 * in which those functions were present.
+	 *
+	 * @return array
+	 */
+	function aggregateByFunction() {
+	}
+
+	/**
+	 * Get an array which can be JSON encoded for import into speedscope
+	 *
+	 * @return array
+	 */
+	function getSpeedscopeData() {
+	}
+
+	/**
+	 * Get the total number of profiling periods represented by this log.
+	 *
+	 * @return int
+	 */
+	function getEventCount() {
+	}
+
+	/**
+	 * Get the current ExcimerLogEntry object. Part of the Iterator interface.
+	 *
+	 * @return ExcimerLogEntry|null
+	 */
+	function current() {
+	}
+
+	/**
+	 * Get the current integer key or null. Part of the Iterator interface.
+	 *
+	 * @return int|null
+	 */
+	function key() {
+	}
+
+	/**
+	 * Advance to the next log entry. Part of the Iterator interface.
+	 */
+	function next() {
+	}
+
+	/**
+	 * Rewind back to the first log entry. Part of the Iterator interface.
+	 */
+	function rewind() {
+	}
+
+	/**
+	 * Check if the current position is valid. Part of the Iterator interface.
+	 *
+	 * @return bool
+	 */
+	function valid() {
+	}
+
+	/**
+	 * Get the number of log entries contained in this log. This is always less
+	 * than or equal to the number returned by getEventCount(), which includes
+	 * overruns.
+	 *
+	 * @return int
+	 */
+	function count() {
+	}
+
+	/**
+	 * Determine whether a log entry exists at the specified array offset.
+	 * Part of the ArrayAccess interface.
+	 *
+	 * @param int $offset
+	 * @return bool
+	 */
+	function offsetExists( $offset ) {
+	}
+
+	/**
+	 * Get the ExcimerLogEntry object at the specified array offset.
+	 *
+	 * @param int $offset
+	 * @return ExcimerLogEntry|null
+	 */
+	function offsetGet( $offset ) {
+	}
+
+	/**
+	 * This function is included for compliance with the ArrayAccess interface.
+	 * It raises a warning and does nothing.
+	 *
+	 * @param int $offset
+	 * @param mixed $value
+	 */
+	function offsetSet( $offset, $value ) {
+	}
+
+	/**
+	 * This function is included for compliance with the ArrayAccess interface.
+	 * It raises a warning and does nothing.
+	 *
+	 * @param int $offset
+	 */
+	function offsetUnset( $offset ) {
+	}
+}

--- a/stubs/ExcimerLog.stub
+++ b/stubs/ExcimerLog.stub
@@ -1,166 +1,201 @@
 <?php
 
-/**
- * A collected series of stack traces and some utility methods to aggregate them.
- *
- * ExcimerLog acts as a container for ExcimerLogEntry objects. The Iterator or
- * ArrayAccess interfaces may be used to access them. For example:
- *
- *   foreach ( $profiler->getLog() as $entry ) {
- *      var_dump( $entry->getTrace() );
- *   }
- */
-class ExcimerLog implements ArrayAccess, Iterator {
-	/**
-	 * ExcimerLog is not constructible by user code. Objects of this type
-	 * are available via:
-	 *   - ExcimerProfiler::getLog()
-	 *   - ExcimerProfiler::flush()
-	 *   - The callback to ExcimerProfiler::setFlushCallback()
-	 */
-	private final function __construct() {
-	}
+namespace {
 
-	/**
-	 * Aggregate the stack traces and convert them to a line-based format
-	 * understood by Brendan Gregg's FlameGraph utility. Each stack trace is
-	 * represented as a series of function names, separated by semicolons.
-	 * After this identifier, there is a single space character, then a number
-	 * giving the number of times the stack appeared. Then there is a line
-	 * break. This is repeated for each unique stack trace.
-	 *
-	 * @return string
-	 */
-	function formatCollapsed() {
-	}
+    /**
+     * A collected series of stack traces and some utility methods to aggregate them.
+     *
+     * ExcimerLog acts as a container for ExcimerLogEntry objects. The Iterator or
+     * ArrayAccess interfaces may be used to access them. For example:
+     *
+     *   foreach ( $profiler->getLog() as $entry ) {
+     *      var_dump( $entry->getTrace() );
+     *   }
+     *
+     * @implements ArrayAccess<int, ExcimerLogEntry>
+     * @implements Iterator<int, ExcimerLogEntry>
+     */
+    class ExcimerLog implements ArrayAccess, Iterator
+    {
+        /**
+         * ExcimerLog is not constructible by user code. Objects of this type
+         * are available via:
+         *   - ExcimerProfiler::getLog()
+         *   - ExcimerProfiler::flush()
+         *   - The callback to ExcimerProfiler::setFlushCallback()
+         */
+        private final function __construct()
+        {
+        }
 
-	/**
-	 * Produce an array with an element for every function which appears in
-	 * the log. The key is a human-readable unique identifier for the function,
-	 * method or closure. The value is an associative array with the following
-	 * elements:
-	 *
-	 *   - self: The number of events in which the function itself was running,
-	 *     no other userspace function was being called. This includes time
-	 *     spent in internal functions that this function called.
-	 *   - inclusive: The number of events in which this function appeared
-	 *     somewhere in the stack.
-	 *
-	 * And optionally the following elements, if they are relevant:
-	 *
-	 *   - file: The filename in which the function appears
-	 *   - line: The exact line number at which the first relevant event
-	 *     occurred.
-	 *   - class: The class name in which the method is defined
-	 *   - function: The name of the function or method
-	 *   - closure_line: The line number at which the closure was defined
-	 *
-	 * The event counts in the "self" and "inclusive" fields are adjusted for
-	 * overruns. They represent an estimate of the number of profiling periods
-	 * in which those functions were present.
-	 *
-	 * @return array
-	 */
-	function aggregateByFunction() {
-	}
+        /**
+         * Aggregate the stack traces and convert them to a line-based format
+         * understood by Brendan Gregg's FlameGraph utility. Each stack trace is
+         * represented as a series of function names, separated by semicolons.
+         * After this identifier, there is a single space character, then a number
+         * giving the number of times the stack appeared. Then there is a line
+         * break. This is repeated for each unique stack trace.
+         *
+         * @return string
+         */
+        function formatCollapsed()
+        {
+        }
 
-	/**
-	 * Get an array which can be JSON encoded for import into speedscope
-	 *
-	 * @return array
-	 */
-	function getSpeedscopeData() {
-	}
+        /**
+         * Produce an array with an element for every function which appears in
+         * the log. The key is a human-readable unique identifier for the function,
+         * method or closure. The value is an associative array with the following
+         * elements:
+         *
+         *   - self: The number of events in which the function itself was running,
+         *     no other userspace function was being called. This includes time
+         *     spent in internal functions that this function called.
+         *   - inclusive: The number of events in which this function appeared
+         *     somewhere in the stack.
+         *
+         * And optionally the following elements, if they are relevant:
+         *
+         *   - file: The filename in which the function appears
+         *   - line: The exact line number at which the first relevant event
+         *     occurred.
+         *   - class: The class name in which the method is defined
+         *   - function: The name of the function or method
+         *   - closure_line: The line number at which the closure was defined
+         *
+         * The event counts in the "self" and "inclusive" fields are adjusted for
+         * overruns. They represent an estimate of the number of profiling periods
+         * in which those functions were present.
+         *
+         * @return array
+         */
+        function aggregateByFunction()
+        {
+        }
 
-	/**
-	 * Get the total number of profiling periods represented by this log.
-	 *
-	 * @return int
-	 */
-	function getEventCount() {
-	}
+        /**
+         * Get an array which can be JSON encoded for import into speedscope
+         *
+         * @return array
+         */
+        function getSpeedscopeData()
+        {
+        }
 
-	/**
-	 * Get the current ExcimerLogEntry object. Part of the Iterator interface.
-	 *
-	 * @return ExcimerLogEntry|null
-	 */
-	function current() {
-	}
+        /**
+         * Get the total number of profiling periods represented by this log.
+         *
+         * @return int
+         */
+        function getEventCount()
+        {
+        }
 
-	/**
-	 * Get the current integer key or null. Part of the Iterator interface.
-	 *
-	 * @return int|null
-	 */
-	function key() {
-	}
+        /**
+         * Get the current ExcimerLogEntry object. Part of the Iterator interface.
+         *
+         * @return ExcimerLogEntry
+         */
+        #[\ReturnTypeWillChange]
+        function current()
+        {
+        }
 
-	/**
-	 * Advance to the next log entry. Part of the Iterator interface.
-	 */
-	function next() {
-	}
+        /**
+         * Get the current integer key or null. Part of the Iterator interface.
+         *
+         * @return int
+         */
+        #[\ReturnTypeWillChange]
+        function key()
+        {
+        }
 
-	/**
-	 * Rewind back to the first log entry. Part of the Iterator interface.
-	 */
-	function rewind() {
-	}
+        /**
+         * Advance to the next log entry. Part of the Iterator interface.
+         *
+         * @return void
+         */
+        #[\ReturnTypeWillChange]
+        function next()
+        {
+        }
 
-	/**
-	 * Check if the current position is valid. Part of the Iterator interface.
-	 *
-	 * @return bool
-	 */
-	function valid() {
-	}
+        /**
+         * Rewind back to the first log entry. Part of the Iterator interface.
+         *
+         * @return void
+         */
+        #[\ReturnTypeWillChange]
+        function rewind()
+        {
+        }
 
-	/**
-	 * Get the number of log entries contained in this log. This is always less
-	 * than or equal to the number returned by getEventCount(), which includes
-	 * overruns.
-	 *
-	 * @return int
-	 */
-	function count() {
-	}
+        /**
+         * Check if the current position is valid. Part of the Iterator interface.
+         *
+         * @return bool
+         */
+        #[\ReturnTypeWillChange]
+        function valid()
+        {
+        }
 
-	/**
-	 * Determine whether a log entry exists at the specified array offset.
-	 * Part of the ArrayAccess interface.
-	 *
-	 * @param int $offset
-	 * @return bool
-	 */
-	function offsetExists( $offset ) {
-	}
+        /**
+         * Get the number of log entries contained in this log. This is always less
+         * than or equal to the number returned by getEventCount(), which includes
+         * overruns.
+         *
+         * @return int
+         */
+        function count()
+        {
+        }
 
-	/**
-	 * Get the ExcimerLogEntry object at the specified array offset.
-	 *
-	 * @param int $offset
-	 * @return ExcimerLogEntry|null
-	 */
-	function offsetGet( $offset ) {
-	}
+        /**
+         * Determine whether a log entry exists at the specified array offset.
+         * Part of the ArrayAccess interface.
+         *
+         * @param int $offset
+         * @return bool
+         */
+        #[\ReturnTypeWillChange]
+        function offsetExists($offset)
+        {
+        }
 
-	/**
-	 * This function is included for compliance with the ArrayAccess interface.
-	 * It raises a warning and does nothing.
-	 *
-	 * @param int $offset
-	 * @param mixed $value
-	 */
-	function offsetSet( $offset, $value ) {
-	}
+        /**
+         * Get the ExcimerLogEntry object at the specified array offset.
+         *
+         * @param int $offset
+         * @return ExcimerLogEntry
+         */
+        #[\ReturnTypeWillChange]
+        function offsetGet($offset)
+        {
+        }
 
-	/**
-	 * This function is included for compliance with the ArrayAccess interface.
-	 * It raises a warning and does nothing.
-	 *
-	 * @param int $offset
-	 */
-	function offsetUnset( $offset ) {
-	}
+        /**
+         * This function is included for compliance with the ArrayAccess interface.
+         * It raises a warning and does nothing.
+         *
+         * @param int|null $offset
+         * @param ExcimerLogEntry $value
+         */
+        #[\ReturnTypeWillChange]
+        function offsetSet($offset, $value)
+        {
+        }
+
+        /**
+         * This function is included for compliance with the ArrayAccess interface.
+         * It raises a warning and does nothing.
+         *
+         * @param int $offset
+         */
+        #[\ReturnTypeWillChange]
+        function offsetUnset($offset)
+        {
+        }
+    }
 }

--- a/stubs/ExcimerLogEntry.stub
+++ b/stubs/ExcimerLogEntry.stub
@@ -1,0 +1,45 @@
+<?php
+
+class ExcimerLogEntry {
+	/**
+	 * ExcimerLogEntry is not constructible by user code.
+	 */
+	private final function __construct() {
+	}
+
+	/**
+	 * Get the time at which the event occurred. This is the floating point
+	 * number of seconds since the ExcimerProfiler object was constructed.
+	 *
+	 * @return float
+	 */
+	public function getTimestamp() {
+	}
+
+	/**
+	 * Get the event count represented by this log entry. This will typically
+	 * be 1. If there were overruns, it will be 1 plus the number of overruns.
+	 *
+	 * @return int
+	 */
+	public function getEventCount() {
+	}
+
+	/**
+	 * Get an array of associative arrays describing the stack trace at the time
+	 * of the event. The first element in the array is the function which was
+	 * executing, the second function is the caller (parent) of that function,
+	 * and so on. Each element is an associative array with the following
+	 * optional fields:
+	 *
+	 *   - file: The filename in which the function appears
+	 *   - line: The exact line number at which the event occurred.
+	 *   - class: The class name in which the method is defined
+	 *   - function: The name of the function or method
+	 *   - closure_line: The line number at which the closure was defined
+	 *
+	 * @return array
+	 */
+	public function getTrace() {
+	}
+}

--- a/stubs/ExcimerLogEntry.stub
+++ b/stubs/ExcimerLogEntry.stub
@@ -1,45 +1,54 @@
 <?php
 
-class ExcimerLogEntry {
-	/**
-	 * ExcimerLogEntry is not constructible by user code.
-	 */
-	private final function __construct() {
-	}
+namespace {
 
-	/**
-	 * Get the time at which the event occurred. This is the floating point
-	 * number of seconds since the ExcimerProfiler object was constructed.
-	 *
-	 * @return float
-	 */
-	public function getTimestamp() {
-	}
+    class ExcimerLogEntry
+    {
+        /**
+         * ExcimerLogEntry is not constructible by user code.
+         */
+        private final function __construct()
+        {
+        }
 
-	/**
-	 * Get the event count represented by this log entry. This will typically
-	 * be 1. If there were overruns, it will be 1 plus the number of overruns.
-	 *
-	 * @return int
-	 */
-	public function getEventCount() {
-	}
+        /**
+         * Get the time at which the event occurred. This is the floating point
+         * number of seconds since the ExcimerProfiler object was constructed.
+         *
+         * @return float
+         */
+        public function getTimestamp()
+        {
+        }
 
-	/**
-	 * Get an array of associative arrays describing the stack trace at the time
-	 * of the event. The first element in the array is the function which was
-	 * executing, the second function is the caller (parent) of that function,
-	 * and so on. Each element is an associative array with the following
-	 * optional fields:
-	 *
-	 *   - file: The filename in which the function appears
-	 *   - line: The exact line number at which the event occurred.
-	 *   - class: The class name in which the method is defined
-	 *   - function: The name of the function or method
-	 *   - closure_line: The line number at which the closure was defined
-	 *
-	 * @return array
-	 */
-	public function getTrace() {
-	}
+        /**
+         * Get the event count represented by this log entry. This will typically
+         * be 1. If there were overruns, it will be 1 plus the number of overruns.
+         *
+         * @return int
+         */
+        public function getEventCount()
+        {
+        }
+
+        /**
+         * Get an array of associative arrays describing the stack trace at the time
+         * of the event. The first element in the array is the function which was
+         * executing, the second function is the caller (parent) of that function,
+         * and so on. Each element is an associative array with the following
+         * optional fields:
+         *
+         *   - file: The filename in which the function appears
+         *   - line: The exact line number at which the event occurred.
+         *   - class: The class name in which the method is defined
+         *   - function: The name of the function or method
+         *   - closure_line: The line number at which the closure was defined
+         *
+         * @return array
+         */
+        public function getTrace()
+        {
+        }
+    }
+
 }

--- a/stubs/ExcimerLogEntry.stub
+++ b/stubs/ExcimerLogEntry.stub
@@ -44,9 +44,15 @@ namespace {
          *   - function: The name of the function or method
          *   - closure_line: The line number at which the closure was defined
          *
-         * @return array
+         * @return array<int, array{
+         *     file: string|null,
+         *     line: string|int|null,
+         *     class: string,
+         *     function: string,
+         *     closure_line: int
+         * }>
          */
-        public function getTrace()
+        public function getTrace(): array
         {
         }
     }

--- a/stubs/ExcimerProfiler.stub
+++ b/stubs/ExcimerProfiler.stub
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * A sampling profiler.
+ *
+ * Collects a stack trace every time a timer event fires.
+ */
+class ExcimerProfiler {
+	/**
+	 * Set the period.
+	 *
+	 * This will take effect the next time start() is called.
+	 *
+	 * If this method is not called, the default period of 0.1 seconds
+	 * will be used.
+	 *
+	 * @param float $period The period in seconds
+	 */
+	public function setPeriod( $period ) {
+	}
+
+	/**
+	 * Set the event type. May be either EXCIMER_REAL, for real (wall-clock)
+	 * time, or EXCIMER_CPU, for CPU time. The default is EXCIMER_REAL.
+	 *
+	 * This will take effect the next time start() is called.
+	 *
+	 * @param int $eventType
+	 */
+	public function setEventType( $eventType ) {
+	}
+
+	/**
+	 * Set the maximum depth of stack trace collection. If this depth is
+	 * exceeded, the traversal up the stack will be terminated, so the function
+	 * will appear to have no caller.
+	 *
+	 * By default, there is no limit. If this is called with a depth of zero,
+	 * the limit is disabled.
+	 *
+	 * This will take effect immediately.
+	 *
+	 * @param int $maxDepth
+	 */
+	public function setMaxDepth( $maxDepth ) {
+	}
+
+	/**
+	 * Set a callback which will be called once the specified number of samples
+	 * has been collected.
+	 *
+	 * When the ExcimerProfiler object is destroyed, the callback will also
+	 * be called, unless no samples have been collected.
+	 *
+	 * The callback will be called with a single argument: the ExcimerLog
+	 * object containing the samples. Before the callback is called, a new
+	 * ExcimerLog object will be created and registered with the
+	 * ExcimerProfiler. So ExcimerProfiler::getLog() should not be used from
+	 * the callback, since it will not return the samples.
+	 *
+	 * @param callable $callback
+	 * @param int $maxSamples
+	 */
+	public function setFlushCallback( $callback, $maxSamples ) {
+	}
+
+	/**
+	 * Clear the flush callback. No callback will be called regardless of
+	 * how many samples are collected.
+	 */
+	public function clearFlushCallback() {
+	}
+
+	/**
+	 * Start the profiler. If the profiler was already running, it will be
+	 * stopped and restarted with new options.
+	 */
+	public function start() {
+	}
+
+	/**
+	 * Stop the profiler.
+	 */
+	public function stop() {
+	}
+
+	/**
+	 * Get the current ExcimerLog object.
+	 *
+	 * Note that if the profiler is running, the object thus returned may be
+	 * modified by a timer event at any time, potentially invalidating your
+	 * analysis. Instead, the profiler should be stopped first, or flush()
+	 * should be used.
+	 *
+	 * @return ExcimerLog
+	 */
+	public function getLog() {
+	}
+
+	/**
+	 * Create and register a new ExcimerLog object, and return the old
+	 * ExcimerLog object.
+	 *
+	 * This will return all accumulated events to this point, and reset the
+	 * log with a new log of zero length.
+	 *
+	 * @return ExcimerLog
+	 */
+	public function flush() {
+	}
+}

--- a/stubs/ExcimerProfiler.stub
+++ b/stubs/ExcimerProfiler.stub
@@ -1,111 +1,135 @@
 <?php
 
-/**
- * A sampling profiler.
- *
- * Collects a stack trace every time a timer event fires.
- */
-class ExcimerProfiler {
-	/**
-	 * Set the period.
-	 *
-	 * This will take effect the next time start() is called.
-	 *
-	 * If this method is not called, the default period of 0.1 seconds
-	 * will be used.
-	 *
-	 * @param float $period The period in seconds
-	 */
-	public function setPeriod( $period ) {
-	}
+namespace {
 
-	/**
-	 * Set the event type. May be either EXCIMER_REAL, for real (wall-clock)
-	 * time, or EXCIMER_CPU, for CPU time. The default is EXCIMER_REAL.
-	 *
-	 * This will take effect the next time start() is called.
-	 *
-	 * @param int $eventType
-	 */
-	public function setEventType( $eventType ) {
-	}
+    /**
+     * A sampling profiler.
+     *
+     * Collects a stack trace every time a timer event fires.
+     */
+    class ExcimerProfiler
+    {
+        /**
+         * Set the period.
+         *
+         * This will take effect the next time start() is called.
+         *
+         * If this method is not called, the default period of 0.1 seconds
+         * will be used.
+         *
+         * @param float $period The period in seconds
+         * @return void
+         */
+        public function setPeriod($period)
+        {
+        }
 
-	/**
-	 * Set the maximum depth of stack trace collection. If this depth is
-	 * exceeded, the traversal up the stack will be terminated, so the function
-	 * will appear to have no caller.
-	 *
-	 * By default, there is no limit. If this is called with a depth of zero,
-	 * the limit is disabled.
-	 *
-	 * This will take effect immediately.
-	 *
-	 * @param int $maxDepth
-	 */
-	public function setMaxDepth( $maxDepth ) {
-	}
+        /**
+         * Set the event type. May be either EXCIMER_REAL, for real (wall-clock)
+         * time, or EXCIMER_CPU, for CPU time. The default is EXCIMER_REAL.
+         *
+         * This will take effect the next time start() is called.
+         *
+         * @param int $eventType
+         * @return void
+         */
+        public function setEventType($eventType)
+        {
+        }
 
-	/**
-	 * Set a callback which will be called once the specified number of samples
-	 * has been collected.
-	 *
-	 * When the ExcimerProfiler object is destroyed, the callback will also
-	 * be called, unless no samples have been collected.
-	 *
-	 * The callback will be called with a single argument: the ExcimerLog
-	 * object containing the samples. Before the callback is called, a new
-	 * ExcimerLog object will be created and registered with the
-	 * ExcimerProfiler. So ExcimerProfiler::getLog() should not be used from
-	 * the callback, since it will not return the samples.
-	 *
-	 * @param callable $callback
-	 * @param int $maxSamples
-	 */
-	public function setFlushCallback( $callback, $maxSamples ) {
-	}
+        /**
+         * Set the maximum depth of stack trace collection. If this depth is
+         * exceeded, the traversal up the stack will be terminated, so the function
+         * will appear to have no caller.
+         *
+         * By default, there is no limit. If this is called with a depth of zero,
+         * the limit is disabled.
+         *
+         * This will take effect immediately.
+         *
+         * @param int $maxDepth
+         * @return void
+         */
+        public function setMaxDepth($maxDepth)
+        {
+        }
 
-	/**
-	 * Clear the flush callback. No callback will be called regardless of
-	 * how many samples are collected.
-	 */
-	public function clearFlushCallback() {
-	}
+        /**
+         * Set a callback which will be called once the specified number of samples
+         * has been collected.
+         *
+         * When the ExcimerProfiler object is destroyed, the callback will also
+         * be called, unless no samples have been collected.
+         *
+         * The callback will be called with a single argument: the ExcimerLog
+         * object containing the samples. Before the callback is called, a new
+         * ExcimerLog object will be created and registered with the
+         * ExcimerProfiler. So ExcimerProfiler::getLog() should not be used from
+         * the callback, since it will not return the samples.
+         *
+         * @param callable $callback
+         * @param int $maxSamples
+         * @return void
+         */
+        public function setFlushCallback($callback, $maxSamples)
+        {
+        }
 
-	/**
-	 * Start the profiler. If the profiler was already running, it will be
-	 * stopped and restarted with new options.
-	 */
-	public function start() {
-	}
+        /**
+         * Clear the flush callback. No callback will be called regardless of
+         * how many samples are collected.
+         *
+         * @return void
+         */
+        public function clearFlushCallback()
+        {
+        }
 
-	/**
-	 * Stop the profiler.
-	 */
-	public function stop() {
-	}
+        /**
+         * Start the profiler. If the profiler was already running, it will be
+         * stopped and restarted with new options.
+         *
+         * @return void
+         */
+        public function start()
+        {
+        }
 
-	/**
-	 * Get the current ExcimerLog object.
-	 *
-	 * Note that if the profiler is running, the object thus returned may be
-	 * modified by a timer event at any time, potentially invalidating your
-	 * analysis. Instead, the profiler should be stopped first, or flush()
-	 * should be used.
-	 *
-	 * @return ExcimerLog
-	 */
-	public function getLog() {
-	}
+        /**
+         * Stop the profiler.
+         *
+         * @return void
+         */
+        public function stop()
+        {
+        }
 
-	/**
-	 * Create and register a new ExcimerLog object, and return the old
-	 * ExcimerLog object.
-	 *
-	 * This will return all accumulated events to this point, and reset the
-	 * log with a new log of zero length.
-	 *
-	 * @return ExcimerLog
-	 */
-	public function flush() {
-	}
+        /**
+         * Get the current ExcimerLog object.
+         *
+         * Note that if the profiler is running, the object thus returned may be
+         * modified by a timer event at any time, potentially invalidating your
+         * analysis. Instead, the profiler should be stopped first, or flush()
+         * should be used.
+         *
+         * @return ExcimerLog
+         */
+        public function getLog()
+        {
+        }
+
+        /**
+         * Create and register a new ExcimerLog object, and return the old
+         * ExcimerLog object.
+         *
+         * This will return all accumulated events to this point, and reset the
+         * log with a new log of zero length.
+         *
+         * @return ExcimerLog
+         */
+        public function flush()
+        {
+        }
+    }
+
 }

--- a/stubs/ExcimerTimer.stub
+++ b/stubs/ExcimerTimer.stub
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * Generic timer class. Calls a callback after a specified time has elapsed, or
+ * periodically with a given interval.
+ */
+class ExcimerTimer {
+	/**
+	 * Set the type of time used by this object. May be either EXCIMER_REAL for
+	 * real (wall-clock) time, or EXCIMER_CPU for CPU time. If this function is
+	 * not called, EXCIMER_REAL will be used.
+	 *
+	 * @param int $eventType
+	 */
+	public function setEventType( $eventType ) {
+	}
+
+	/**
+	 * Switch to one-shot mode, and set the interval. This will take effect
+	 * when start() is next called.
+	 *
+	 * @param float $interval The interval in seconds
+	 */
+	public function setInterval( $interval ) {
+	}
+
+	/**
+	 * Switch to periodic mode, and set the period. This will take effect when
+	 * start() is next called.
+	 *
+	 * @param float $interval The period in seconds.
+	 */
+	public function setPeriod( $period ) {
+	}
+
+	/**
+	 * Set the callback function, to be called next time either a one-shot
+	 * or periodic event occurs.
+	 *
+	 * The callback function shall take one parameter: an integer representing
+	 * the number of periods which have elapsed since the callback was last
+	 * called. This may be greater than 1 for two reasons:
+	 *
+	 *   - The kernel or C library may fail to respond to the event in time,
+	 *     and so may increment an overrun counter.
+	 *
+	 *   - The native callback may be called multiple times before the PHP VM
+	 *     has the chance to interrupt execution. For example, a long-running
+	 *     native function such as a database connect will not be interrupted
+	 *     when the timer is triggered.
+	 *
+	 * If the callback is set to null, or if this function has not been called,
+	 * no action is taken when the event occurs.
+	 *
+	 * @param callable|null $callback
+	 */
+	public function setCallback( $callback ) {
+	}
+
+	/**
+	 * Start the timer.
+	 *
+	 * If the timer is already running, it will be stopped and restarted,
+	 * respecting any changes to the interval, period or event type.
+	 */
+	public function start() {
+	}
+
+	/**
+	 * Stop the timer.
+	 *
+	 * If the timer is not already running, this will have no effect.
+	 */
+	public function stop() {
+	}
+
+	/**
+	 * Get the time until the next expiration, in seconds. If this is zero,
+	 * the timer is currently not running.
+	 *
+	 * @return float
+	 */
+	public function getTime() {
+	}
+}

--- a/stubs/ExcimerTimer.stub
+++ b/stubs/ExcimerTimer.stub
@@ -1,85 +1,105 @@
 <?php
 
-/**
- * Generic timer class. Calls a callback after a specified time has elapsed, or
- * periodically with a given interval.
- */
-class ExcimerTimer {
-	/**
-	 * Set the type of time used by this object. May be either EXCIMER_REAL for
-	 * real (wall-clock) time, or EXCIMER_CPU for CPU time. If this function is
-	 * not called, EXCIMER_REAL will be used.
-	 *
-	 * @param int $eventType
-	 */
-	public function setEventType( $eventType ) {
-	}
+namespace {
 
-	/**
-	 * Switch to one-shot mode, and set the interval. This will take effect
-	 * when start() is next called.
-	 *
-	 * @param float $interval The interval in seconds
-	 */
-	public function setInterval( $interval ) {
-	}
+    /**
+     * Generic timer class. Calls a callback after a specified time has elapsed, or
+     * periodically with a given interval.
+     */
+    class ExcimerTimer
+    {
+        /**
+         * Set the type of time used by this object. May be either EXCIMER_REAL for
+         * real (wall-clock) time, or EXCIMER_CPU for CPU time. If this function is
+         * not called, EXCIMER_REAL will be used.
+         *
+         * @param int $eventType
+         * @return void
+         */
+        public function setEventType($eventType)
+        {
+        }
 
-	/**
-	 * Switch to periodic mode, and set the period. This will take effect when
-	 * start() is next called.
-	 *
-	 * @param float $interval The period in seconds.
-	 */
-	public function setPeriod( $period ) {
-	}
+        /**
+         * Switch to one-shot mode, and set the interval. This will take effect
+         * when start() is next called.
+         *
+         * @param float $interval The interval in seconds
+         * @return void
+         */
+        public function setInterval($interval)
+        {
+        }
 
-	/**
-	 * Set the callback function, to be called next time either a one-shot
-	 * or periodic event occurs.
-	 *
-	 * The callback function shall take one parameter: an integer representing
-	 * the number of periods which have elapsed since the callback was last
-	 * called. This may be greater than 1 for two reasons:
-	 *
-	 *   - The kernel or C library may fail to respond to the event in time,
-	 *     and so may increment an overrun counter.
-	 *
-	 *   - The native callback may be called multiple times before the PHP VM
-	 *     has the chance to interrupt execution. For example, a long-running
-	 *     native function such as a database connect will not be interrupted
-	 *     when the timer is triggered.
-	 *
-	 * If the callback is set to null, or if this function has not been called,
-	 * no action is taken when the event occurs.
-	 *
-	 * @param callable|null $callback
-	 */
-	public function setCallback( $callback ) {
-	}
+        /**
+         * Switch to periodic mode, and set the period. This will take effect when
+         * start() is next called.
+         *
+         * @param float $period The period in seconds.
+         * @return void
+         */
+        public function setPeriod($period)
+        {
+        }
 
-	/**
-	 * Start the timer.
-	 *
-	 * If the timer is already running, it will be stopped and restarted,
-	 * respecting any changes to the interval, period or event type.
-	 */
-	public function start() {
-	}
+        /**
+         * Set the callback function, to be called next time either a one-shot
+         * or periodic event occurs.
+         *
+         * The callback function shall take one parameter: an integer representing
+         * the number of periods which have elapsed since the callback was last
+         * called. This may be greater than 1 for two reasons:
+         *
+         *   - The kernel or C library may fail to respond to the event in time,
+         *     and so may increment an overrun counter.
+         *
+         *   - The native callback may be called multiple times before the PHP VM
+         *     has the chance to interrupt execution. For example, a long-running
+         *     native function such as a database connect will not be interrupted
+         *     when the timer is triggered.
+         *
+         * If the callback is set to null, or if this function has not been called,
+         * no action is taken when the event occurs.
+         *
+         * @param callable|null $callback
+         * @return void
+         */
+        public function setCallback($callback)
+        {
+        }
 
-	/**
-	 * Stop the timer.
-	 *
-	 * If the timer is not already running, this will have no effect.
-	 */
-	public function stop() {
-	}
+        /**
+         * Start the timer.
+         *
+         * If the timer is already running, it will be stopped and restarted,
+         * respecting any changes to the interval, period or event type.
+         *
+         * @return void
+         */
+        public function start()
+        {
+        }
 
-	/**
-	 * Get the time until the next expiration, in seconds. If this is zero,
-	 * the timer is currently not running.
-	 *
-	 * @return float
-	 */
-	public function getTime() {
-	}
+        /**
+         * Stop the timer.
+         *
+         * If the timer is not already running, this will have no effect.
+         *
+         * @return void
+         */
+        public function stop()
+        {
+        }
+
+        /**
+         * Get the time until the next expiration, in seconds. If this is zero,
+         * the timer is currently not running.
+         *
+         * @return float
+         */
+        public function getTime()
+        {
+        }
+    }
+
 }

--- a/stubs/LICENSE
+++ b/stubs/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/stubs/autoload.php
+++ b/stubs/autoload.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/ExcimerLog.stub';
+require_once __DIR__ . '/ExcimerLogEntry.stub';
+require_once __DIR__ . '/ExcimerProfiler.stub';
+require_once __DIR__ . '/ExcimerTimer.stub';
+require_once __DIR__ . '/globals.stub';

--- a/stubs/globals.stub
+++ b/stubs/globals.stub
@@ -1,0 +1,28 @@
+<?php
+
+/** Real (wall-clock) time */
+define( 'EXCIMER_REAL', 0 );
+
+/** CPU time (user and system) consumed by the thread during execution */
+define( 'EXCIMER_CPU', 1 );
+
+/**
+ * Abbreviated interface for starting a wall-clock timer. Equivalent to:
+ *
+ *   $timer = new ExcimerTimer;
+ *   $timer->setCallback( $callback );
+ *   $timer->setInterval( $interval );
+ *   $timer->start();
+ *   return $timer;
+ *
+ * Note that you must keep a copy of the return value. If it goes out of scope,
+ * the object will be destroyed and the timer will stop.
+ *
+ * If the callback is not callable, a warning is raised and null is returned.
+ *
+ * @param callable $callback
+ * @param float $interval
+ * @return ExcimerTimer|null
+ */
+function excimer_set_timeout( $callback, $interval ) {
+}

--- a/stubs/globals.stub
+++ b/stubs/globals.stub
@@ -1,28 +1,32 @@
 <?php
 
-/** Real (wall-clock) time */
-define( 'EXCIMER_REAL', 0 );
+namespace {
 
-/** CPU time (user and system) consumed by the thread during execution */
-define( 'EXCIMER_CPU', 1 );
+    /** Real (wall-clock) time */
+    define( 'EXCIMER_REAL', 0 );
 
-/**
- * Abbreviated interface for starting a wall-clock timer. Equivalent to:
- *
- *   $timer = new ExcimerTimer;
- *   $timer->setCallback( $callback );
- *   $timer->setInterval( $interval );
- *   $timer->start();
- *   return $timer;
- *
- * Note that you must keep a copy of the return value. If it goes out of scope,
- * the object will be destroyed and the timer will stop.
- *
- * If the callback is not callable, a warning is raised and null is returned.
- *
- * @param callable $callback
- * @param float $interval
- * @return ExcimerTimer|null
- */
-function excimer_set_timeout( $callback, $interval ) {
+    /** CPU time (user and system) consumed by the thread during execution */
+    define( 'EXCIMER_CPU', 1 );
+
+    /**
+     * Abbreviated interface for starting a wall-clock timer. Equivalent to:
+     *
+     *   $timer = new ExcimerTimer;
+     *   $timer->setCallback( $callback );
+     *   $timer->setInterval( $interval );
+     *   $timer->start();
+     *   return $timer;
+     *
+     * Note that you must keep a copy of the return value. If it goes out of scope,
+     * the object will be destroyed and the timer will stop.
+     *
+     * If the callback is not callable, a warning is raised and null is returned.
+     *
+     * @param callable $callback
+     * @param float $interval
+     * @return ExcimerTimer|null
+     */
+    function excimer_set_timeout( $callback, $interval ) {
+    }
+
 }

--- a/tests/Context/OsContextTest.php
+++ b/tests/Context/OsContextTest.php
@@ -12,14 +12,15 @@ final class OsContextTest extends TestCase
     /**
      * @dataProvider valuesDataProvider
      */
-    public function testConstructor(string $expectedName, ?string $expectedVersion, ?string $expectedBuild, ?string $expectedKernelVersion): void
+    public function testConstructor(string $expectedName, ?string $expectedVersion, ?string $expectedBuild, ?string $expectedKernelVersion, ?string $expectedMachineType): void
     {
-        $context = new OsContext($expectedName, $expectedVersion, $expectedBuild, $expectedKernelVersion);
+        $context = new OsContext($expectedName, $expectedVersion, $expectedBuild, $expectedKernelVersion, $expectedMachineType);
 
         $this->assertSame($expectedName, $context->getName());
         $this->assertSame($expectedVersion, $context->getVersion());
         $this->assertSame($expectedBuild, $context->getBuild());
         $this->assertSame($expectedKernelVersion, $context->getKernelVersion());
+        $this->assertSame($expectedMachineType, $context->getMachineType());
     }
 
     public function testConstructorThrowsOnInvalidArgument(): void
@@ -33,18 +34,20 @@ final class OsContextTest extends TestCase
     /**
      * @dataProvider valuesDataProvider
      */
-    public function testGettersAndSetters(string $expectedName, ?string $expectedVersion, ?string $expectedBuild, ?string $expectedKernelVersion): void
+    public function testGettersAndSetters(string $expectedName, ?string $expectedVersion, ?string $expectedBuild, ?string $expectedKernelVersion, ?string $expectedMachineType): void
     {
         $context = new OsContext('Windows');
         $context->setName($expectedName);
         $context->setVersion($expectedVersion);
         $context->setBuild($expectedBuild);
         $context->setKernelVersion($expectedKernelVersion);
+        $context->setMachineType($expectedMachineType);
 
         $this->assertSame($expectedName, $context->getName());
         $this->assertSame($expectedVersion, $context->getVersion());
         $this->assertSame($expectedBuild, $context->getBuild());
         $this->assertSame($expectedKernelVersion, $context->getKernelVersion());
+        $this->assertSame($expectedMachineType, $context->getMachineType());
     }
 
     public function valuesDataProvider(): iterable
@@ -54,10 +57,12 @@ final class OsContextTest extends TestCase
             '4.19.104-microsoft-standard',
             '#1 SMP Wed Feb 19 06:37:35 UTC 2020',
             'Linux c03a247f5e13 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64',
+            'x86_64',
         ];
 
         yield [
             'Linux',
+            null,
             null,
             null,
             null,

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -150,6 +150,15 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'profiles_sample_rate',
+            0.5,
+            'getProfilesSampleRate',
+            'setProfilesSampleRate',
+            null,
+            null,
+        ];
+
+        yield [
             'attach_stacktrace',
             false,
             'shouldAttachStacktrace',

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -56,7 +56,7 @@ final class ProfileTest extends TestCase
                 [
                     'trace' => [
                         [
-                            'file' => 'index.php',
+                            'file' => '/var/www/html/index.php',
                             'line' => 42,
                         ],
                     ],
@@ -65,13 +65,13 @@ final class ProfileTest extends TestCase
                 [
                     'trace' => [
                         [
-                            'file' => 'index.php',
+                            'file' => '/var/www/html/index.php',
                             'line' => 42,
                         ],
                         [
                             'class' => 'Function',
                             'function' => 'doStuff',
-                            'file' => 'function.php',
+                            'file' => '/var/www/html/function.php',
                             'line' => 84,
                         ],
                     ],
@@ -80,24 +80,24 @@ final class ProfileTest extends TestCase
                 [
                     'trace' => [
                         [
-                            'file' => 'index.php',
+                            'file' => '/var/www/html/index.php',
                             'line' => 42,
                         ],
                         [
                             'class' => 'Function',
                             'function' => 'doStuff',
-                            'file' => 'function.php',
+                            'file' => '/var/www/html/function.php',
                             'line' => 84,
                         ],
                         [
                             'class' => 'Class\Something',
                             'function' => 'run',
-                            'file' => 'class.php',
+                            'file' => '/var/www/html/class.php',
                             'line' => 42,
                         ],
                         [
                             'function' => '{closure}',
-                            'file' => 'index.php',
+                            'file' => '/var/www/html/index.php',
                             'line' => 126,
                         ],
                     ],
@@ -132,43 +132,50 @@ final class ProfileTest extends TestCase
                 'profile' => [
                     'frames' => [
                         [
-                            'filename' => 'index.php',
+                            'filename' => '/var/www/html/index.php',
+                            'abs_path' => '/var/www/html/index.php',
                             'module' => null,
-                            'function' => 'index.php',
+                            'function' => '/var/www/html/index.php',
                             'lineno' => 42,
                         ],
                         [
-                            'filename' => 'index.php',
+                            'filename' => '/var/www/html/index.php',
+                            'abs_path' => '/var/www/html/index.php',
                             'module' => null,
-                            'function' => 'index.php',
+                            'function' => '/var/www/html/index.php',
                             'lineno' => 42,
                         ],
                         [
-                            'filename' => 'function.php',
+                            'filename' => '/var/www/html/function.php',
+                            'abs_path' => '/var/www/html/function.php',
                             'module' => 'Function',
                             'function' => 'Function::doStuff',
                             'lineno' => 84,
                         ],
                         [
-                            'filename' => 'index.php',
+                            'filename' => '/var/www/html/index.php',
+                            'abs_path' => '/var/www/html/index.php',
                             'module' => null,
-                            'function' => 'index.php',
+                            'function' => '/var/www/html/index.php',
                             'lineno' => 42,
                         ],
                         [
-                            'filename' => 'function.php',
+                            'filename' => '/var/www/html/function.php',
+                            'abs_path' => '/var/www/html/function.php',
                             'module' => 'Function',
                             'function' => 'Function::doStuff',
                             'lineno' => 84,
                         ],
                         [
-                            'filename' => 'class.php',
+                            'filename' => '/var/www/html/class.php',
+                            'abs_path' => '/var/www/html/class.php',
                             'module' => 'Class\Something',
                             'function' => 'Class\Something::run',
                             'lineno' => 42,
                         ],
                         [
-                            'filename' => 'index.php',
+                            'filename' => '/var/www/html/index.php',
+                            'abs_path' => '/var/www/html/index.php',
                             'module' => null,
                             'function' => '{closure}',
                             'lineno' => 126,
@@ -232,7 +239,7 @@ final class ProfileTest extends TestCase
                 [
                     'trace' => [
                         [
-                            'file' => 'index.php',
+                            'file' => '/var/www/html/index.php',
                             'line' => 42,
                         ],
                     ],
@@ -241,13 +248,13 @@ final class ProfileTest extends TestCase
                 [
                     'trace' => [
                         [
-                            'file' => 'index.php',
+                            'file' => '/var/www/html/index.php',
                             'line' => 42,
                         ],
                         [
                             'class' => 'Function',
                             'function' => 'doStuff',
-                            'file' => 'function.php',
+                            'file' => '/var/www/html/function.php',
                             'line' => 84,
                         ],
                     ],

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -14,9 +14,9 @@ use Sentry\Profiling\Profile;
 final class ProfileTest extends TestCase
 {
     /**
-     * @dataProvider formatedDataDataProvider
+     * @dataProvider formattedDataDataProvider
      */
-    public function testGetFormatedData(Event $event, int $startTime, int $stopTime, array $excimerLog, $expectedData): void
+    public function testGetFormattedData(Event $event, int $startTime, int $stopTime, array $excimerLog, $expectedData): void
     {
         $profile = new Profile();
         $profile->setInitTime((int) (0.001 / 1e+9));
@@ -30,10 +30,10 @@ final class ProfileTest extends TestCase
         $profile->setExcimerLog($excimerLog);
         $profile->setEventId((new EventId('815e57b4bb134056ab1840919834689d')));
 
-        $this->assertSame($expectedData, $profile->getFormatedData($event));
+        $this->assertSame($expectedData, $profile->getFormattedData($event));
     }
 
-    public function formatedDataDataProvider(): \Generator
+    public function formattedDataDataProvider(): \Generator
     {
         $event = Event::createTransaction(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setRelease('1.0.0');

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -16,14 +16,9 @@ final class ProfileTest extends TestCase
     /**
      * @dataProvider formattedDataDataProvider
      */
-    public function testGetFormattedData(Event $event, int $startTime, int $stopTime, array $excimerLog, $expectedData): void
+    public function testGetFormattedData(Event $event, array $excimerLog, $expectedData): void
     {
         $profile = new Profile();
-        $profile->setInitTime((int) (0.001 / 1e+9));
-
-        $profile->setStartTime($startTime);
-        $profile->setStopTime($stopTime);
-
         // 2022-02-28T09:41:00Z
         $profile->setStartTimeStamp(1677573660.0000);
 
@@ -57,14 +52,27 @@ final class ProfileTest extends TestCase
 
         yield [
             $event,
-            2000000,
-            3000000,
             [
                 [
                     'trace' => [
                         [
                             'file' => 'index.php',
                             'line' => 42,
+                        ],
+                    ],
+                    'timestamp' => 0.001,
+                ],
+                [
+                    'trace' => [
+                        [
+                            'file' => 'index.php',
+                            'line' => 42,
+                        ],
+                        [
+                            'class' => 'Function',
+                            'function' => 'doStuff',
+                            'file' => 'function.php',
+                            'line' => 84,
                         ],
                     ],
                     'timestamp' => 0.002,
@@ -80,6 +88,17 @@ final class ProfileTest extends TestCase
                             'function' => 'doStuff',
                             'file' => 'function.php',
                             'line' => 84,
+                        ],
+                        [
+                            'class' => 'Class\Something',
+                            'function' => 'run',
+                            'file' => 'class.php',
+                            'line' => 42,
+                        ],
+                        [
+                            'function' => '{closure}',
+                            'file' => 'index.php',
+                            'line' => 126,
                         ],
                     ],
                     'timestamp' => 0.003,
@@ -113,30 +132,62 @@ final class ProfileTest extends TestCase
                 'profile' => [
                     'frames' => [
                         [
-                            'function' => 'index.php',
                             'filename' => 'index.php',
+                            'module' => null,
+                            'function' => 'index.php',
                             'lineno' => 42,
                         ],
                         [
-                            'function' => 'index.php',
                             'filename' => 'index.php',
+                            'module' => null,
+                            'function' => 'index.php',
                             'lineno' => 42,
                         ],
                         [
-                            'function' => 'Function::doStuff',
                             'filename' => 'function.php',
+                            'module' => 'Function',
+                            'function' => 'Function::doStuff',
                             'lineno' => 84,
+                        ],
+                        [
+                            'filename' => 'index.php',
+                            'module' => null,
+                            'function' => 'index.php',
+                            'lineno' => 42,
+                        ],
+                        [
+                            'filename' => 'function.php',
+                            'module' => 'Function',
+                            'function' => 'Function::doStuff',
+                            'lineno' => 84,
+                        ],
+                        [
+                            'filename' => 'class.php',
+                            'module' => 'Class\Something',
+                            'function' => 'Class\Something::run',
+                            'lineno' => 42,
+                        ],
+                        [
+                            'filename' => 'index.php',
+                            'module' => null,
+                            'function' => '{closure}',
+                            'lineno' => 126,
                         ],
                     ],
                     'samples' => [
                         [
-                            'elapsed_since_start_ns' => 0,
+                            'elapsed_since_start_ns' => 1000000,
                             'stack_id' => 0,
                             'thread_id' => '0',
                         ],
                         [
-                            'elapsed_since_start_ns' => 1000000,
+                            'elapsed_since_start_ns' => 2000000,
                             'stack_id' => 1,
+                            'thread_id' => '0',
+                        ],
+                        [
+                            'elapsed_since_start_ns' => 3000000,
+                            'stack_id' => 2,
                             'thread_id' => '0',
                         ],
                     ],
@@ -148,6 +199,12 @@ final class ProfileTest extends TestCase
                             1,
                             2,
                         ],
+                        [
+                            3,
+                            4,
+                            5,
+                            6,
+                        ],
                     ],
                 ],
             ],
@@ -155,8 +212,6 @@ final class ProfileTest extends TestCase
 
         yield 'Too little samples' => [
             $event,
-            2000000,
-            3000000,
             [
                 [
                     'trace' => [
@@ -165,7 +220,7 @@ final class ProfileTest extends TestCase
                             'line' => 42,
                         ],
                     ],
-                    'timestamp' => 0.002,
+                    'timestamp' => 0.001,
                 ],
             ],
             null,
@@ -173,8 +228,6 @@ final class ProfileTest extends TestCase
 
         yield 'Too long duration' => [
             $event,
-            2000000,
-            32000000000,
             [
                 [
                     'trace' => [
@@ -183,7 +236,7 @@ final class ProfileTest extends TestCase
                             'line' => 42,
                         ],
                     ],
-                    'timestamp' => 15,
+                    'timestamp' => 15.000,
                 ],
                 [
                     'trace' => [
@@ -198,7 +251,7 @@ final class ProfileTest extends TestCase
                             'line' => 84,
                         ],
                     ],
-                    'timestamp' => 15,
+                    'timestamp' => 30.001,
                 ],
             ],
             null,

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -34,7 +34,7 @@ final class ProfileTest extends TestCase
         $event->setTransaction('GET /');
         $event->setContext('trace', [
             'trace_id' => '566e3688a61d4bc888951642d6f14a19',
-            'span_id' => '566e3688a61d4bc8'
+            'span_id' => '566e3688a61d4bc8',
         ]);
         $event->setRuntimeContext(new RuntimeContext(
             'php',
@@ -101,29 +101,25 @@ final class ProfileTest extends TestCase
                     'version' => '8.2.3',
                 ],
                 'timestamp' => '2022-02-28T09:41:00Z',
-                'transactions' => [
-                    [
-                        'id' => 'fc9442f5aef34234bb22b9a615e30ccd',
-                        'name' => 'GET /',
-                        'trace_id' => '566e3688a61d4bc888951642d6f14a19',
-                        'active_thread_id' => '0',
-                        'relative_start_ns' => 0,
-                        'relative_end_ns' => 200000,
-                    ],
+                'transaction' => [
+                    'id' => 'fc9442f5aef34234bb22b9a615e30ccd',
+                    'name' => 'GET /',
+                    'trace_id' => '566e3688a61d4bc888951642d6f14a19',
+                    'active_thread_id' => '0',
                 ],
                 'version' => '1',
                 'profile' => [
-                    'frames' => [
-                        [
-                            'function' => 'index.php',
-                            'filename' => 'index.php',
-                        ],
-                        [
-                            'function' => 'Function::doStuff',
-                            'filename' => 'function.php',
-                        ],
-                    ],
                     'samples' => [
+                        'frames' => [
+                            [
+                                'function' => 'index.php',
+                                'filename' => 'index.php',
+                            ],
+                            [
+                                'function' => 'Function::doStuff',
+                                'filename' => 'function.php',
+                            ],
+                        ],
                         [
                             'elapsed_since_start_ns' => 100000,
                             'stack_id' => 0,

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Context\OsContext;
+use Sentry\Context\RuntimeContext;
+use Sentry\Event;
+use Sentry\EventId;
+use Sentry\Profiling\Profile;
+
+final class ProfileTest extends TestCase
+{
+    /**
+     * @dataProvider formatedDataDataProvider
+     */
+    public function testGetFormatedData(Event $event, array $rawProfile, $expectedData): void
+    {
+        $profile = new Profile();
+        $profile->setData($rawProfile);
+        $profile->setStartTime('2022-02-28T09:41:00Z');
+        $profile->setEventId((new EventId('815e57b4bb134056ab1840919834689d')));
+
+        $this->assertSame($expectedData, $profile->getFormatedData($event));
+    }
+
+    public function formatedDataDataProvider(): \Generator
+    {
+        $event = Event::createTransaction(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setRelease('1.0.0');
+        $event->setEnvironment('dev');
+        $event->setTransaction('GET /');
+        $event->setContext('trace', [
+            'trace_id' => '566e3688a61d4bc888951642d6f14a19',
+            'span_id' => '566e3688a61d4bc8',
+        ]);
+        $event->setRuntimeContext(new RuntimeContext(
+            'php',
+            '8.2.3',
+        ));
+        $event->setOsContext(new OsContext(
+            'macOS',
+            '13.2.1',
+            '22D68',
+            'Darwin Kernel Version 22.2.0',
+            'aarch64',
+        ));
+
+        yield [
+            $event,
+            [
+                'shared' => [
+                    'frames' => [
+                        [
+                            'name' => 'index.php',
+                            'file' => 'index.php',
+                        ],
+                        [
+                            'name' => 'Function::doStuff',
+                            'file' => 'function.php',
+                        ],
+                    ],
+                ],
+                'profiles' => [
+                    [
+                        'startValue' => 0,
+                        'endValue' => 200000,
+                        'samples' => [
+                            [
+                                1,
+                            ],
+                            [
+                                1,
+                                2,
+                            ],
+                        ],
+                        'weights' => [
+                            100000,
+                            100000,
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'device' => [
+                    'architecture' => 'aarch64',
+                ],
+                'event_id' => '815e57b4bb134056ab1840919834689d',
+                'os' => [
+                    'name' => 'macOS',
+                    'version' => '13.2.1',
+                    'build_number' => '22D68',
+                ],
+                'platform' => 'php',
+                'release' => '1.0.0',
+                'environment' => 'dev',
+                'runtime' => [
+                    'name' => 'php',
+                    'version' => '8.2.3',
+                ],
+                'timestamp' => '2022-02-28T09:41:00Z',
+                'transactions' => [
+                    [
+                        'id' => 'fc9442f5aef34234bb22b9a615e30ccd',
+                        'name' => 'GET /',
+                        'trace_id' => '566e3688a61d4bc888951642d6f14a19',
+                        'active_thread_id' => '0',
+                        'relative_start_ns' => 0,
+                        'relative_end_ns' => 200000,
+                    ],
+                ],
+                'version' => '1',
+                'profile' => [
+                    'frames' => [
+                        [
+                            'function' => 'index.php',
+                            'filename' => 'index.php',
+                        ],
+                        [
+                            'function' => 'Function::doStuff',
+                            'filename' => 'function.php',
+                        ],
+                    ],
+                    'samples' => [
+                        [
+                            'elapsed_since_start_ns' => 100000,
+                            'stack_id' => 0,
+                            'thread_id' => '0',
+                        ],
+                        [
+                            'elapsed_since_start_ns' => 200000,
+                            'stack_id' => 1,
+                            'thread_id' => '0',
+                        ],
+                    ],
+                    'stacks' => [
+                        [
+                            1,
+                        ],
+                        [
+                            2,
+                            1,
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        yield 'Too little samples' => [
+            $event,
+            [
+                'shared' => [
+                    'frames' => [
+                        [
+                            'name' => 'index.php',
+                            'file' => 'index.php',
+                        ],
+                        [
+                            'name' => 'Function::doStuff',
+                            'file' => 'function.php',
+                        ],
+                    ],
+                ],
+                'profiles' => [
+                    [
+                        'startValue' => 0,
+                        'endValue' => 200000,
+                        'samples' => [
+                            [
+                                1,
+                            ],
+                        ],
+                        'weights' => [
+                            100000,
+                        ],
+                    ],
+                ],
+            ],
+            null,
+        ];
+
+        yield 'Too long duration' => [
+            $event,
+            [
+                'shared' => [
+                    'frames' => [
+                        [
+                            'name' => 'index.php',
+                            'file' => 'index.php',
+                        ],
+                        [
+                            'name' => 'Function::doStuff',
+                            'file' => 'function.php',
+                        ],
+                    ],
+                ],
+                'profiles' => [
+                    [
+                        'startValue' => 0,
+                        'endValue' => (30 * 1e+9),
+                        'samples' => [
+                            [
+                                1,
+                            ],
+                            [
+                                1,
+                                2,
+                            ],
+                        ],
+                        'weights' => [
+                            (15 * 1e+9),
+                            (15 * 1e+9),
+                        ],
+                    ],
+                ],
+            ],
+            null,
+        ];
+
+        yield 'Empty Excimer profile' => [
+            $event,
+            [
+                'shared' => [
+                    'frames' => [],
+                ],
+                'profiles' => [
+                    [
+                        'startValue' => 0,
+                        'endValue' => 0,
+                        'samples' => [],
+                        'weights' => [],
+                    ],
+                ],
+            ],
+            null,
+        ];
+    }
+}

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -34,18 +34,18 @@ final class ProfileTest extends TestCase
         $event->setTransaction('GET /');
         $event->setContext('trace', [
             'trace_id' => '566e3688a61d4bc888951642d6f14a19',
-            'span_id' => '566e3688a61d4bc8',
+            'span_id' => '566e3688a61d4bc8'
         ]);
         $event->setRuntimeContext(new RuntimeContext(
             'php',
-            '8.2.3',
+            '8.2.3'
         ));
         $event->setOsContext(new OsContext(
             'macOS',
             '13.2.1',
             '22D68',
             'Darwin Kernel Version 22.2.0',
-            'aarch64',
+            'aarch64'
         ));
 
         yield [


### PR DESCRIPTION
![Screenshot 2023-02-24 at 19 06 14](https://user-images.githubusercontent.com/6617432/221690459-af38ddcd-9396-4b0e-a997-c40975f722e9.png)

This adds initial support for profiling in PHP.

Under the hood, we're using Wikiepdia's sampling profiler [Excimer](https://github.com/wikimedia/mediawiki-php-excimer). We chose this profiler for its low overhead and for being used in production by one of the largest PHP-powered websites in the world.

As with our SDK, the profiler works with PHP 7.2 and up.

There is currently no support for either Windows or macOS.

```bash
apt-get install php-excimer
```

Once the extension is installed, you may enable profiling by adding a new `profiles_sample_rate` config option to your `Sentry::init` method.

```php
\Sentry\init([
    'dsn' => '__DSN__',
    'traces_sample_rate' => 1.0,
    'profiles_sample_rate' => 1.0,
]);
```

Profiles are being sampled in relation to your `traces_sample_rate`.

Once a transaction is started, the profiler will sample with a rate of 101Hz (every ~10ms) until the transaction is finished.

Closes #1474 