### PR TITLE
Try to encode anything when encountering JSON encoding error

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/Dsn.php
 
 		-
-			message: "#^Offset 'host'\\|'path'\\|'scheme'\\|'user' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Dsn.php
-
-		-
 			message: "#^Offset 'path' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 4
 			path: src/Dsn.php
@@ -39,11 +34,6 @@ parameters:
 			message: "#^Offset 'user' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 1
 			path: src/Dsn.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 3
-			path: src/EventHint.php
 
 		-
 			message: "#^Access to constant CONNECT_TIMEOUT on an unknown class GuzzleHttp\\\\RequestOptions\\.$#"

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -30,11 +30,15 @@ final class JSON
             throw new \InvalidArgumentException('The $maxDepth argument must be an integer greater than 0.');
         }
 
-        $options |= \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE;
+        $options |= \JSON_UNESCAPED_UNICODE | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_PARTIAL_OUTPUT_ON_ERROR;
 
         $encodedData = json_encode($data, $options, $maxDepth);
 
-        if (\JSON_ERROR_NONE !== json_last_error()) {
+        $allowedErrors = [\JSON_ERROR_NONE, \JSON_ERROR_RECURSION, \JSON_ERROR_INF_OR_NAN, \JSON_ERROR_UNSUPPORTED_TYPE];
+
+        $encounteredAnyError = \JSON_ERROR_NONE !== json_last_error();
+
+        if (($encounteredAnyError && ('null' === $encodedData || false === $encodedData)) || !\in_array(json_last_error(), $allowedErrors, true)) {
             throw new JsonException(sprintf('Could not encode value into JSON format. Error was: "%s".', json_last_error_msg()));
         }
 

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -60,6 +60,14 @@ final class JSONTest extends TestCase
             new JsonSerializableClass(),
             '{"key":"value"}',
         ];
+
+        $data = [];
+        $data['recursive'] = &$data;
+
+        yield [
+            $data,
+            '{"recursive":{"recursive":null}}',
+        ];
     }
 
     /**


### PR DESCRIPTION
We try to output a partial JSON encoded value when encoding as JSON to try and send anything if we can. This makes the output a little more lenient for recursion, unsupported types and inf/nan in the JSON data.

Fixes #1480.

Doing this:

```php
\Sentry\init(['dsn' => 'https://...']);

$data = ['foo' => 'bar'];
$data['ref'] = &$data;

\Sentry\withScope(function (\Sentry\State\Scope $scope) use ($data): void {
    $scope->setExtra('data', $data);
    \Sentry\captureException(new Exception('This is a test!'));
});
```

Now results in:

![image](https://user-images.githubusercontent.com/1090754/221543486-679fefdc-85c5-40d4-ba5c-1930438d3332.png)

with the rest of the event details intact.