### PR TITLE
Prevent calling magic methods to retrieve ID from object

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,11 +21,6 @@ parameters:
 			path: src/Dsn.php
 
 		-
-			message: "#^Offset 'host'\\|'path'\\|'scheme'\\|'user' on array\\{scheme\\?\\: string, host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\} in isset\\(\\) always exists and is not nullable\\.$#"
-			count: 1
-			path: src/Dsn.php
-
-		-
 			message: "#^Offset 'path' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 4
 			path: src/Dsn.php
@@ -39,11 +34,6 @@ parameters:
 			message: "#^Offset 'user' does not exist on array\\{scheme\\: 'http'\\|'https', host\\?\\: string, port\\?\\: int\\<0, 65535\\>, user\\?\\: string, pass\\?\\: string, path\\?\\: string, query\\?\\: string, fragment\\?\\: string\\}\\.$#"
 			count: 1
 			path: src/Dsn.php
-
-		-
-			message: "#^Result of && is always false\\.$#"
-			count: 3
-			path: src/EventHint.php
 
 		-
 			message: "#^Access to constant CONNECT_TIMEOUT on an unknown class GuzzleHttp\\\\RequestOptions\\.$#"

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
 
 namespace Sentry\Serializer;
 
-use ReflectionException;
 use Sentry\Exception\InvalidArgumentException;
 use Sentry\Options;
 

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 
 namespace Sentry\Serializer;
 
+use ReflectionException;
 use Sentry\Exception\InvalidArgumentException;
 use Sentry\Options;
 
@@ -241,14 +242,20 @@ abstract class AbstractSerializer
         }
 
         if (\is_object($value)) {
+            $reflection = new \ReflectionObject($value);
+
             $objectId = null;
-            if (isset($value->id)) {
-                $objectId = $value->id;
-            } elseif (\is_callable([$value, 'getId']) && method_exists($value, 'getId')) {
-                $objectId = $value->getId();
+            if ($reflection->hasProperty('id') && ($idProperty = $reflection->getProperty('id'))->isPublic()) {
+                $objectId = $idProperty->getValue($value);
+            } elseif ($reflection->hasMethod('getId') && ($getIdMethod = $reflection->getMethod('getId'))->isPublic()) {
+                try {
+                    $objectId = $getIdMethod->invoke($value);
+                } catch (\Throwable $e) {
+                    // Do nothing on purpose
+                }
             }
 
-            return 'Object ' . \get_class($value) . ((null !== $objectId) ? '(#' . $objectId . ')' : '');
+            return 'Object ' . $reflection->getName() . ((null !== $objectId) ? '(#' . $objectId . ')' : '');
         }
 
         if (\is_resource($value)) {

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -63,6 +63,15 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame('Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty(#bar)', $result);
     }
 
+    public function testObjectsWithMagicIdPropertyDoesNotInvokeMagicMethods(): void
+    {
+        $serializer = $this->createSerializer();
+        $input = new SerializerTestObjectWithMagicGetAndIssetMethods();
+        $result = $this->invokeSerialization($serializer, $input);
+
+        $this->assertSame('Object Sentry\Tests\Serializer\SerializerTestObjectWithMagicGetAndIssetMethods', $result);
+    }
+
     public function testObjectsWithSerializerTestObjectWithGetIdMethodAreStrings(): void
     {
         $serializer = $this->createSerializer();
@@ -606,6 +615,30 @@ class SerializerTestObjectWithGetIdMethod extends SerializerTestObject
     public function getId()
     {
         return $this->id . 'bar';
+    }
+}
+
+class SerializerTestObjectWithMagicGetAndIssetMethods
+{
+    public function __isset(string $name): bool
+    {
+        throw new \RuntimeException('We should not reach this!');
+    }
+
+    /**
+     * @return mixed
+     */
+    public function __get(string $name)
+    {
+        throw new \RuntimeException('We should not reach this!');
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function __set(string $name, $value): void
+    {
+        throw new \RuntimeException('We should not reach this!');
     }
 }
 


### PR DESCRIPTION
It seems that in some codebases this causes side-effects, it might be better to be a little more strict/safe here.

Fixes #1476.