### PR TITLE
fix(serializer): serializeValue uses only scalar object IDs

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -248,7 +248,7 @@ abstract class AbstractSerializer
                 $objectId = $value->getId();
             }
 
-            return 'Object ' . \get_class($value) . ((null !== $objectId) ? '(#' . $objectId . ')' : '');
+            return 'Object ' . \get_class($value) . (\is_scalar($objectId) ? '(#' . $objectId . ')' : '');
         }
 
         if (\is_resource($value)) {

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -54,13 +54,28 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame('Object Sentry\Tests\Serializer\SerializerTestObject', $result);
     }
 
-    public function testObjectsWithIdPropertyAreStrings(): void
+    public function objectsWithIdPropertyDataProvider(): array
+    {
+        return [
+            ['bar', 'Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty(#bar)'],
+            [123, 'Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty(#123)'],
+            [[1,2,3], 'Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty'],
+            [(object) ['id' => 321], 'Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty'],
+            [null, 'Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty'],
+        ];
+    }
+
+    /**
+     * @dataProvider objectsWithIdPropertyDataProvider
+     */
+    public function testObjectsWithIdPropertyAreStrings($id, string $expectedResult): void
     {
         $serializer = $this->createSerializer();
         $input = new SerializerTestObjectWithIdProperty();
+        $input->id = $id;
         $result = $this->invokeSerialization($serializer, $input);
 
-        $this->assertSame('Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty(#bar)', $result);
+        $this->assertSame($expectedResult, $result);
     }
 
     public function testObjectsWithSerializerTestObjectWithGetIdMethodAreStrings(): void


### PR DESCRIPTION
Handle object IDs that aren't scalars. It prevents php warning 'Array to string conversion' and similar.