### PR TITLE
Allow unsetting of whole context

### DIFF
--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -139,9 +139,13 @@ final class Scope
      *
      * @return $this
      */
-    public function removeContext(string $name): self
+    public function removeContext(string $name = ''): self
     {
-        unset($this->contexts[$name]);
+        if ($name == ''){
+            unset($this->contexts[$name]);
+        } else {
+            $this->contexts = [];
+        }
 
         return $this;
     }


### PR DESCRIPTION
The problem in 2023 is that long running PHP scripts that run multiple requests are a thing.

In my use case, I have a Symfony worker that runs for "a long period of time" and will process many incoming messages from a message bus.

When we use the following code, the context is appended, not replaced

```
 \Sentry\configureScope(function (\Sentry\State\Scope $scope) use ($message): void {
            $scope->setContext('SomeContextKey', [
                'message' => $message,
            ]);
        });
```

This leads to a crash report containing context from previous "requests" (a request here being a different message from the message bus being processed by a long running worker).

There needs to be a way to reset the context on each "run" of a new message that the long running worker is processing so that the context only contains data related to that message. 

Tweaking the `removeContext` method will allow use to reset the whole context or, backward compatibility to remove just a named context. 

Im aware there is already a `clear` method, but this clears way too much
