### PR TITLE
feat: Add `TransactionContext::fromEnvironment`

### DIFF
--- a/src/Tracing/TransactionContext.php
+++ b/src/Tracing/TransactionContext.php
@@ -137,6 +137,17 @@ final class TransactionContext extends SpanContext
     }
 
     /**
+     * Returns a context populated with the data of the given environment variables.
+     *
+     * @param string $sentryTrace The sentry-trace value from the environment
+     * @param string $baggage     The baggage header value from the environment
+     */
+    public static function fromEnvironment(string $sentryTrace, string $baggage): self
+    {
+        return self::parseTraceAndBaggage($sentryTrace, $baggage);
+    }
+
+    /**
      * Returns a context populated with the data of the given headers.
      *
      * @param string $sentryTraceHeader The sentry-trace header from an incoming request
@@ -144,10 +155,15 @@ final class TransactionContext extends SpanContext
      */
     public static function fromHeaders(string $sentryTraceHeader, string $baggageHeader): self
     {
+        return self::parseTraceAndBaggage($sentryTraceHeader, $baggageHeader);
+    }
+
+    private static function parseTraceAndBaggage(string $sentryTrace, string $baggage): self
+    {
         $context = new self();
         $hasSentryTrace = false;
 
-        if (preg_match(self::TRACEPARENT_HEADER_REGEX, $sentryTraceHeader, $matches)) {
+        if (preg_match(self::TRACEPARENT_HEADER_REGEX, $sentryTrace, $matches)) {
             if (!empty($matches['trace_id'])) {
                 $context->traceId = new TraceId($matches['trace_id']);
                 $hasSentryTrace = true;
@@ -164,7 +180,7 @@ final class TransactionContext extends SpanContext
             }
         }
 
-        $samplingContext = DynamicSamplingContext::fromHeader($baggageHeader);
+        $samplingContext = DynamicSamplingContext::fromHeader($baggage);
 
         if ($hasSentryTrace && !$samplingContext->hasEntries()) {
             // The request comes from an old SDK which does not support Dynamic Sampling.

--- a/tests/Tracing/TransactionContextTest.php
+++ b/tests/Tracing/TransactionContextTest.php
@@ -90,7 +90,7 @@ final class TransactionContextTest extends TestCase
     }
 
     /**
-     * @dataProvider fromHeadersDataProvider
+     * @dataProvider tracingDataProvider
      */
     public function testFromHeaders(string $sentryTraceHeader, string $baggageHeader, ?SpanId $expectedSpanId, ?TraceId $expectedTraceId, ?bool $expectedParentSampled, ?string $expectedDynamicSamplingContextClass, ?bool $expectedDynamicSamplingContextFrozen)
     {
@@ -103,7 +103,21 @@ final class TransactionContextTest extends TestCase
         $this->assertSame($expectedDynamicSamplingContextFrozen, $spanContext->getMetadata()->getDynamicSamplingContext()->isFrozen());
     }
 
-    public function fromHeadersDataProvider(): iterable
+    /**
+     * @dataProvider tracingDataProvider
+     */
+    public function testFromEnvironment(string $sentryTrace, string $baggage, ?SpanId $expectedSpanId, ?TraceId $expectedTraceId, ?bool $expectedParentSampled, ?string $expectedDynamicSamplingContextClass, ?bool $expectedDynamicSamplingContextFrozen)
+    {
+        $spanContext = TransactionContext::fromEnvironment($sentryTrace, $baggage);
+
+        $this->assertEquals($expectedSpanId, $spanContext->getParentSpanId());
+        $this->assertEquals($expectedTraceId, $spanContext->getTraceId());
+        $this->assertSame($expectedParentSampled, $spanContext->getParentSampled());
+        $this->assertInstanceOf($expectedDynamicSamplingContextClass, $spanContext->getMetadata()->getDynamicSamplingContext());
+        $this->assertSame($expectedDynamicSamplingContextFrozen, $spanContext->getMetadata()->getDynamicSamplingContext()->isFrozen());
+    }
+
+    public function tracingDataProvider(): iterable
     {
         yield [
             '0',


### PR DESCRIPTION
`TransactionContext::fromEnvironment` has the same behaviour as `TransactionContext::fromHeaders`.

A use-case for this is the `sentry-cli`, where the CLI wraps a PHP script or framework console command to be cron monitored and exposes `SENTRY_TRACE` & `SENTRY_BAGGAGE` when executing it.