### PR TITLE
ref: Attach the DSC to error events

### DIFF
--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -367,7 +367,7 @@ final class Scope
             // Apply the dynamic sampling context to errors if there is a Transaction on the Scope
             $transaction = $this->span->getTransaction();
             if (null !== $transaction) {
-                $event->setSdkMetadata('dynamic_sampling_context', $this->span->getTransaction()->getDynamicSamplingContext());
+                $event->setSdkMetadata('dynamic_sampling_context', $transaction->getDynamicSamplingContext());
             }
         }
 

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -360,9 +360,15 @@ final class Scope
             $event->setUser($user);
         }
 
-        // We do this here to also apply the trace context to errors if there is a Span on the Scope
+        // Apply the trace context to errors if there is a Span on the Scope
         if (null !== $this->span) {
             $event->setContext('trace', $this->span->getTraceContext());
+
+            // Apply the dynamic sampling context to errors if there is a Transaction on the Scope
+            $transaction = $this->span->getTransaction();
+            if (null !== $transaction) {
+                $event->setSdkMetadata('dynamic_sampling_context', $this->span->getTransaction()->getDynamicSamplingContext());
+            }
         }
 
         foreach (array_merge($this->contexts, $event->getContexts()) as $name => $data) {

--- a/src/Tracing/DynamicSamplingContext.php
+++ b/src/Tracing/DynamicSamplingContext.php
@@ -148,7 +148,11 @@ final class DynamicSamplingContext
     {
         $samplingContext = new self();
         $samplingContext->set('trace_id', (string) $transaction->getTraceId());
-        $samplingContext->set('sample_rate', (string) $transaction->getMetaData()->getSamplingRate());
+
+        $sampleRate = $transaction->getMetaData()->getSamplingRate();
+        if (null !== $sampleRate) {
+            $samplingContext->set('sample_rate', (string) $sampleRate);
+        }
 
         // Only include the transaction name if it has good quality
         if ($transaction->getMetadata()->getSource() !== TransactionSource::url()) {

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -10,9 +10,13 @@ use Sentry\Event;
 use Sentry\EventHint;
 use Sentry\Severity;
 use Sentry\State\Scope;
+use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanId;
 use Sentry\Tracing\TraceId;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
 use Sentry\UserDataBag;
 
 final class ScopeTest extends TestCase
@@ -357,9 +361,13 @@ final class ScopeTest extends TestCase
         $event = Event::createEvent();
         $event->setContext('foocontext', ['foo' => 'foo', 'bar' => 'bar']);
 
-        $span = new Span();
+        $transactionContext = new TransactionContext('foo');
+        $transaction = new Transaction($transactionContext);
+        $transaction->setSpanId(new SpanId('8c2df92a922b4efe'));
+        $transaction->setTraceId(new TraceId('566e3688a61d4bc888951642d6f14a19'));
+
+        $span = $transaction->startChild(new SpanContext());
         $span->setSpanId(new SpanId('566e3688a61d4bc8'));
-        $span->setTraceId(new TraceId('566e3688a61d4bc888951642d6f14a19'));
 
         $scope = new Scope();
         $scope->setLevel(Severity::warning());
@@ -387,10 +395,17 @@ final class ScopeTest extends TestCase
             'trace' => [
                 'span_id' => '566e3688a61d4bc8',
                 'trace_id' => '566e3688a61d4bc888951642d6f14a19',
+                'parent_span_id' => '8c2df92a922b4efe',
             ],
             'barcontext' => [
                 'bar' => 'foo',
             ],
         ], $event->getContexts());
+
+        $dynamicSamplingContext = $event->getSdkMetadata('dynamic_sampling_context');
+
+        $this->assertInstanceOf(DynamicSamplingContext::class, $dynamicSamplingContext);
+        $this->assertSame('foo', $dynamicSamplingContext->get('transaction'));
+        $this->assertSame('566e3688a61d4bc888951642d6f14a19', $dynamicSamplingContext->get('trace_id'));
     }
 }

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -11,7 +11,6 @@ use Sentry\EventHint;
 use Sentry\Severity;
 use Sentry\State\Scope;
 use Sentry\Tracing\DynamicSamplingContext;
-use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanId;
 use Sentry\Tracing\TraceId;

--- a/tests/Tracing/DynamicSamplingContextTest.php
+++ b/tests/Tracing/DynamicSamplingContextTest.php
@@ -100,6 +100,7 @@ final class DynamicSamplingContextTest extends TestCase
         $transactionContext->setName('foo');
 
         $transaction = new Transaction($transactionContext, $hub);
+        $transaction->getMetadata()->setSamplingRate(1.0);
 
         $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $hub);
 


### PR DESCRIPTION
Attach the DSC to error events as well. This will only be the case if the performance feature is enabled, as sending the DSC requires the use of envelopes, sent to the `envelope` endpoint.

Refs https://github.com/getsentry/team-replay/issues/70 and https://github.com/getsentry/team-webplatform-meta/issues/45