### PR TITLE
fix: Guard against empty profiles

### DIFF
--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -52,8 +52,12 @@ final class Profiler
         }
     }
 
-    public function getProfile(): Profile
+    public function getProfile(): ?Profile
     {
+        if (null === $this->profiler) {
+            return null;
+        }
+
         return $this->profile;
     }
 


### PR DESCRIPTION
Setting a `profiles_sample_rate` but not installing Excimer currently results in an `Call to a member function count() on null` error, which the client silently swallows.
This will result in no transaction events being sent, hence I added a safeguard to the profiler to check if the excimer instance was initialized.

We already check for the profile being `null` [here](https://github.com/getsentry/sentry-php/blob/master/src/Tracing/Transaction.php#L179-L182).