### PR TITLE
ref: Ignore empty context values

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -469,14 +469,16 @@ final class Event
     }
 
     /**
-     * Sets the data of the context with the given name.
+     * Sets data to the context by a given name.
      *
      * @param string               $name The name that uniquely identifies the context
      * @param array<string, mixed> $data The data of the context
      */
     public function setContext(string $name, array $data): self
     {
-        $this->contexts[$name] = $data;
+        if (!empty($data)) {
+            $this->contexts[$name] = $data;
+        }
 
         return $this;
     }

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -118,7 +118,7 @@ final class Scope
     }
 
     /**
-     * Sets context data with the given name.
+     * Sets data to the context by a given name.
      *
      * @param string               $name  The name that uniquely identifies the context
      * @param array<string, mixed> $value The value
@@ -127,7 +127,9 @@ final class Scope
      */
     public function setContext(string $name, array $value): self
     {
-        $this->contexts[$name] = $value;
+        if (!empty($value)) {
+            $this->contexts[$name] = $value;
+        }
 
         return $this;
     }

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -92,6 +92,13 @@ final class ScopeTest extends TestCase
 
         $this->assertNotNull($event);
         $this->assertSame([], $event->getContexts());
+
+        $scope->setContext('foo', []);
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertSame([], $event->getContexts());
     }
 
     public function testSetExtra(): void


### PR DESCRIPTION
Setting an empty context value currently triggers an error in the Sentry UI.

![Screenshot 2023-05-15 at 16 55 00](https://github.com/getsentry/sentry-php/assets/6617432/d97ddb0e-eaff-4bc8-9932-f9a90d5a5172)

While not directly an issue, the UX could be better. So, we can just ignore setting an empty array moving forward.

closes https://github.com/getsentry/sentry-php/issues/1526