### PR TITLE
Use HTTP/1.1 when compression is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 3.19.1
+
+The Sentry SDK team is happy to announce the immediate availability of Sentry PHP SDK v3.19.1.
+
+### Bug Fixes
+
+- Use HTTP/1.1 when compression is enabled [(#1542)](https://github.com/getsentry/sentry-php/pull/1542)
+
 ## 3.19.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry PHP SDK v3.19.0.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,6 +56,11 @@ parameters:
 			path: src/HttpClient/HttpClientFactory.php
 
 		-
+			message: "#^Call to static method createWithConfig\\(\\) on an unknown class Http\\\\Adapter\\\\Guzzle6\\\\Client\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
 			message: "#^Constructor of class Sentry\\\\HttpClient\\\\HttpClientFactory has an unused parameter \\$responseFactory\\.$#"
 			count: 1
 			path: src/HttpClient/HttpClientFactory.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,7 +9,8 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="src/HttpClient/HttpClientFactory.php">
-    <UndefinedClass occurrences="4">
+    <UndefinedClass occurrences="5">
+      <code>Guzzle6HttpClient</code>
       <code>GuzzleHttpClientOptions</code>
       <code>GuzzleHttpClientOptions</code>
       <code>GuzzleHttpClientOptions</code>

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -114,6 +114,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
             $symfonyConfig = [
                 'timeout' => $options->getHttpConnectTimeout(),
                 'max_duration' => $options->getHttpTimeout(),
+                'http_version' => $options->isCompressionEnabled() ? '1.1' : null,
             ];
 
             if (null !== $options->getHttpProxy()) {
@@ -139,6 +140,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
         if (class_exists(CurlHttpClient::class)) {
             $curlConfig = [
                 \CURLOPT_TIMEOUT => $options->getHttpTimeout(),
+                \CURLOPT_HTTP_VERSION => $options->isCompressionEnabled() ? \CURL_HTTP_VERSION_1_1 : \CURL_HTTP_VERSION_NONE,
                 \CURLOPT_CONNECTTIMEOUT => $options->getHttpConnectTimeout(),
             ];
 

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sentry\HttpClient;
 
 use GuzzleHttp\RequestOptions as GuzzleHttpClientOptions;
-use Http\Adapter\Guzzle6\Client as GuzzleHttpClient;
+use Http\Adapter\Guzzle6\Client as Guzzle6HttpClient;
+use Http\Adapter\Guzzle7\Client as Guzzle7HttpClient;
 use Http\Client\Common\Plugin\AuthenticationPlugin;
 use Http\Client\Common\Plugin\DecoderPlugin;
 use Http\Client\Common\Plugin\ErrorPlugin;
@@ -124,7 +125,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
             return new SymfonyHttplugClient(SymfonyHttpClient::create($symfonyConfig));
         }
 
-        if (class_exists(GuzzleHttpClient::class)) {
+        if (class_exists(Guzzle7HttpClient::class) || class_exists(Guzzle6HttpClient::class)) {
             $guzzleConfig = [
                 GuzzleHttpClientOptions::TIMEOUT => $options->getHttpTimeout(),
                 GuzzleHttpClientOptions::CONNECT_TIMEOUT => $options->getHttpConnectTimeout(),
@@ -134,7 +135,11 @@ final class HttpClientFactory implements HttpClientFactoryInterface
                 $guzzleConfig[GuzzleHttpClientOptions::PROXY] = $options->getHttpProxy();
             }
 
-            return GuzzleHttpClient::createWithConfig($guzzleConfig);
+            if (class_exists(Guzzle7HttpClient::class)) {
+                return Guzzle7HttpClient::createWithConfig($guzzleConfig);
+            }
+
+            return Guzzle6HttpClient::createWithConfig($guzzleConfig);
         }
 
         if (class_exists(CurlHttpClient::class)) {


### PR DESCRIPTION
curl 8.1+ is more strict in it's handling for http/2 requests and this is causing issues with the current state of our compression. Since there is no good way to detect from userland if we are going to make a http/2 request we can't omit the problematic `TE` header dynamically. Removing the compression altogether is also not really an option since payloads might be rejected by the Sentry server because uncompressed they would be too large.

So I landed on the option to force http/1.1 requests if compression is enabled until we can figure out a better solution to the problem where we can support both 1.1 and 2.0 requests. However, it's not a major issue since http/2 doesn't offer many if any benefits for the type of communication the Sentry SDK does.

I've also taken the opportunity to add support for Guzzle 7 timeout and proxy options since those were not implemented from the looks of it.

Note that I didn't force the http version on the guzzle client since 1.1 is [their default](https://docs.guzzlephp.org/en/stable/request-options.html#version).