### PR TITLE
Attach tracing headers

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -231,7 +231,7 @@ parameters:
 			path: src/Options.php
 
 		-
-			message: "#^Method Sentry\\\\Options\\:\\:getTracePropagationTargets\\(\\) should return array\\<string\\> but returns mixed\\.$#"
+			message: "#^Method Sentry\\\\Options\\:\\:getTracePropagationTargets\\(\\) should return array\\<string\\>\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -515,9 +515,9 @@ final class Options
     /**
      * Gets an allow list of trace propagation targets.
      *
-     * @return string[]
+     * @return string[]|null
      */
-    public function getTracePropagationTargets(): array
+    public function getTracePropagationTargets(): ?array
     {
         return $this->options['trace_propagation_targets'];
     }

--- a/src/Options.php
+++ b/src/Options.php
@@ -964,7 +964,7 @@ final class Options
         $resolver->setAllowedTypes('before_send_transaction', ['callable']);
         $resolver->setAllowedTypes('ignore_exceptions', 'string[]');
         $resolver->setAllowedTypes('ignore_transactions', 'string[]');
-        $resolver->setAllowedTypes('trace_propagation_targets', 'string[]');
+        $resolver->setAllowedTypes('trace_propagation_targets', ['null', 'string[]']);
         $resolver->setAllowedTypes('tags', 'string[]');
         $resolver->setAllowedTypes('error_types', ['null', 'int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -29,10 +29,12 @@ final class GuzzleTracingMiddleware
                 $client = $hub->getClient();
                 $span = $hub->getSpan();
 
-                if (null === $span && self::shouldAttachTracingHeaders($client, $request)) {
-                    $request = $request
-                        ->withHeader('sentry-trace', traceparent())
-                        ->withHeader('baggage', baggage());
+                if (null === $span) {
+                    if (self::shouldAttachTracingHeaders($client, $request)) {
+                        $request = $request
+                            ->withHeader('sentry-trace', traceparent())
+                            ->withHeader('baggage', baggage());
+                    }
 
                     return $handler($request, $options);
                 }

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -122,8 +122,10 @@ final class GuzzleTracingMiddleware
             if (
                 null !== $sdkOptions->getTracePropagationTargets() &&
                 // Due to BC, we treat an empty array (the default) as all hosts are allow listed
-                [] === $sdkOptions->getTracePropagationTargets() ||
-                \in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())
+                (
+                    [] === $sdkOptions->getTracePropagationTargets() ||
+                    \in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())
+                )
             ) {
                 return true;
             }

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -10,6 +10,7 @@ use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Sentry\Breadcrumb;
+use Sentry\ClientInterface;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
 use function Sentry\baggage;
@@ -28,8 +29,7 @@ final class GuzzleTracingMiddleware
                 $client = $hub->getClient();
                 $span = $hub->getSpan();
 
-                if (null === $span) {
-                    // TODO(michi) Decide on trace_propagation_targets handling
+                if (null === $span && self::shouldAttachTracingHeaders($client, $request)) {
                     $request = $request
                         ->withHeader('sentry-trace', traceparent())
                         ->withHeader('baggage', baggage());
@@ -54,17 +54,10 @@ final class GuzzleTracingMiddleware
 
                 $childSpan = $span->startChild($spanContext);
 
-                $request = $request
-                    ->withHeader('sentry-trace', $childSpan->toTraceparent());
-
-                // Check if the request destination is allow listed in the trace_propagation_targets option.
-                if (null !== $client) {
-                    $sdkOptions = $client->getOptions();
-
-                    if (\in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())) {
-                        $request = $request
-                            ->withHeader('baggage', $childSpan->toBaggage());
-                    }
+                if (self::shouldAttachTracingHeaders($client, $request)) {
+                    $request = $request
+                        ->withHeader('sentry-trace', $childSpan->toTraceparent())
+                        ->withHeader('baggage', $childSpan->toBaggage());
                 }
 
                 $handlerPromiseCallback = static function ($responseOrException) use ($hub, $request, $childSpan, $partialUri) {
@@ -116,5 +109,24 @@ final class GuzzleTracingMiddleware
                 return $handler($request, $options)->then($handlerPromiseCallback, $handlerPromiseCallback);
             };
         };
+    }
+
+    private static function shouldAttachTracingHeaders(?ClientInterface $client, RequestInterface $request): bool
+    {
+        if (null !== $client) {
+            $sdkOptions = $client->getOptions();
+
+            // Check if the request destination is allow listed in the trace_propagation_targets option.
+            if (
+                null !== $sdkOptions->getTracePropagationTargets() &&
+                // Due to BC, we treat an empty array (the default) as all hosts are allow listed
+                [] === $sdkOptions->getTracePropagationTargets() ||
+                \in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())
+            ) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -26,6 +26,9 @@ final class GuzzleTracingMiddlewareTest extends TestCase
     public function testTraceDoesNothingIfSpanIsNotSet(): void
     {
         $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getOptions')
+            ->willReturn(new Options());
 
         $hub = new Hub($client);
 


### PR DESCRIPTION
Follow up of #1516.

`trace_propagation_targets` now accepts `null` to disable header propagation entirely.
The option's default `[]` attaches the headers to all requests when using the `GuzzleTracingMiddleware`.