### PR TITLE
Rename traceparent() & baggage()

### DIFF
--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -13,8 +13,8 @@ use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\SentrySdk;
 use Sentry\State\HubInterface;
-use function Sentry\baggage;
-use function Sentry\traceparent;
+use function Sentry\getBaggage;
+use function Sentry\getTraceparent;
 
 /**
  * This handler traces each outgoing HTTP request by recording performance data.
@@ -32,8 +32,8 @@ final class GuzzleTracingMiddleware
                 if (null === $span) {
                     if (self::shouldAttachTracingHeaders($client, $request)) {
                         $request = $request
-                            ->withHeader('sentry-trace', traceparent())
-                            ->withHeader('baggage', baggage());
+                            ->withHeader('sentry-trace', getTraceparent())
+                            ->withHeader('baggage', getBaggage());
                     }
 
                     return $handler($request, $options);

--- a/src/functions.php
+++ b/src/functions.php
@@ -175,7 +175,7 @@ function trace(callable $trace, SpanContext $context)
  * This function is context aware, as in it either returns the traceparent based
  * on the current span, or the scope's propagation context.
  */
-function traceparent(): string
+function getTraceparent(): string
 {
     $hub = SentrySdk::getCurrentHub();
     $client = $hub->getClient();
@@ -205,7 +205,7 @@ function traceparent(): string
  * This function is context aware, as in it either returns the baggage based
  * on the current span or the scope's propagation context.
  */
-function baggage(): string
+function getBaggage(): string
 {
     $hub = SentrySdk::getCurrentHub();
     $client = $hub->getClient();

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -26,7 +26,7 @@ use Sentry\Tracing\TraceId;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use function Sentry\addBreadcrumb;
-use function Sentry\baggage;
+use function Sentry\getBaggage;
 use function Sentry\captureEvent;
 use function Sentry\captureException;
 use function Sentry\captureLastError;
@@ -36,7 +36,7 @@ use function Sentry\continueTrace;
 use function Sentry\init;
 use function Sentry\startTransaction;
 use function Sentry\trace;
-use function Sentry\traceparent;
+use function Sentry\getTraceparent;
 use function Sentry\withScope;
 
 final class FunctionsTest extends TestCase
@@ -293,7 +293,7 @@ final class FunctionsTest extends TestCase
 
         SentrySdk::setCurrentHub($hub);
 
-        $traceParent = traceparent();
+        $traceParent = getTraceparent();
 
         $this->assertSame('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8', $traceParent);
     }
@@ -319,7 +319,7 @@ final class FunctionsTest extends TestCase
 
         $hub->setSpan($span);
 
-        $traceParent = traceparent();
+        $traceParent = getTraceparent();
 
         $this->assertSame('566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8', $traceParent);
     }
@@ -343,7 +343,7 @@ final class FunctionsTest extends TestCase
 
         SentrySdk::setCurrentHub($hub);
 
-        $baggage = baggage();
+        $baggage = getBaggage();
 
         $this->assertSame('sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-release=1.0.0,sentry-environment=development', $baggage);
     }
@@ -375,7 +375,7 @@ final class FunctionsTest extends TestCase
 
         $hub->setSpan($span);
 
-        $baggage = baggage();
+        $baggage = getBaggage();
 
         $this->assertSame('sentry-trace_id=566e3688a61d4bc888951642d6f14a19,sentry-sample_rate=1,sentry-transaction=Test,sentry-release=1.0.0,sentry-environment=development', $baggage);
     }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -26,17 +26,17 @@ use Sentry\Tracing\TraceId;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use function Sentry\addBreadcrumb;
-use function Sentry\getBaggage;
 use function Sentry\captureEvent;
 use function Sentry\captureException;
 use function Sentry\captureLastError;
 use function Sentry\captureMessage;
 use function Sentry\configureScope;
 use function Sentry\continueTrace;
+use function Sentry\getBaggage;
+use function Sentry\getTraceparent;
 use function Sentry\init;
 use function Sentry\startTransaction;
 use function Sentry\trace;
-use function Sentry\getTraceparent;
 use function Sentry\withScope;
 
 final class FunctionsTest extends TestCase


### PR DESCRIPTION
Decided to rename `traceparent()` and `baggage()` and add a `get` prefix.
This is BC as we did not release yet.