### PR TITLE
Use `isTracingEnabled` instead of `getEnableTracing`

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -183,7 +183,7 @@ function getTraceparent(): string
     if (null !== $client) {
         $options = $client->getOptions();
 
-        if (null !== $options && $options->getEnableTracing()) {
+        if (null !== $options && $options->isTracingEnabled()) {
             $span = SentrySdk::getCurrentHub()->getSpan();
             if (null !== $span) {
                 return $span->toTraceparent();
@@ -213,7 +213,7 @@ function getBaggage(): string
     if (null !== $client) {
         $options = $client->getOptions();
 
-        if (null !== $options && $options->getEnableTracing()) {
+        if (null !== $options && $options->isTracingEnabled()) {
             $span = SentrySdk::getCurrentHub()->getSpan();
             if (null !== $span) {
                 return $span->toBaggage();
@@ -250,7 +250,7 @@ function continueTrace(string $sentryTrace, string $baggage)
     if (null !== $client) {
         $options = $client->getOptions();
 
-        if (null !== $options && $options->getEnableTracing()) {
+        if (null !== $options && $options->isTracingEnabled()) {
             return TransactionContext::fromHeaders($sentryTrace, $baggage);
         }
     }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -304,7 +304,7 @@ final class FunctionsTest extends TestCase
         $client->expects($this->once())
             ->method('getOptions')
             ->willReturn(new Options([
-                'enable_tracing' => true,
+                'traces_sample_rate' => 1.0,
             ]));
 
         $hub = new Hub($client);
@@ -354,7 +354,7 @@ final class FunctionsTest extends TestCase
         $client->expects($this->atLeastOnce())
             ->method('getOptions')
             ->willReturn(new Options([
-                'enable_tracing' => true,
+                'traces_sample_rate' => 1.0,
                 'release' => '1.0.0',
                 'environment' => 'development',
             ]));
@@ -386,7 +386,7 @@ final class FunctionsTest extends TestCase
         $client->expects($this->atLeastOnce())
             ->method('getOptions')
             ->willReturn(new Options([
-                'enable_tracing' => true,
+                'traces_sample_rate' => 1.0,
                 'release' => '1.0.0',
                 'environment' => 'development',
             ]));


### PR DESCRIPTION
The newly added functions (`getBaggage()`, `getTraceparent()` and `continueTrace()`) are checking the wrong option to check if tracing is enabled.

Updated the tests as `enable_tracing` does not surface this.