### PR TITLE
Always return a `TransactionContext` from `continueTrace()`

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -234,10 +234,8 @@ function getBaggage(): string
  * If the SDK is configured with enabled tracing,
  * this function returns a populated TransactionContext.
  * In any other cases, it populates the propagation context on the scope.
- *
- * @return mixed
  */
-function continueTrace(string $sentryTrace, string $baggage)
+function continueTrace(string $sentryTrace, string $baggage): TransactionContext
 {
     $hub = SentrySdk::getCurrentHub();
     $hub->configureScope(function (Scope $scope) use ($sentryTrace, $baggage) {
@@ -245,13 +243,5 @@ function continueTrace(string $sentryTrace, string $baggage)
         $scope->setPropagationContext($propagationContext);
     });
 
-    $client = $hub->getClient();
-
-    if (null !== $client) {
-        $options = $client->getOptions();
-
-        if (null !== $options && $options->isTracingEnabled()) {
-            return TransactionContext::fromHeaders($sentryTrace, $baggage);
-        }
-    }
+    return TransactionContext::fromHeaders($sentryTrace, $baggage);
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -382,16 +382,7 @@ final class FunctionsTest extends TestCase
 
     public function testContinueTrace(): void
     {
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->atLeastOnce())
-            ->method('getOptions')
-            ->willReturn(new Options([
-                'traces_sample_rate' => 1.0,
-                'release' => '1.0.0',
-                'environment' => 'development',
-            ]));
-
-        $hub = new Hub($client);
+        $hub = new Hub();
 
         SentrySdk::setCurrentHub($hub);
 


### PR DESCRIPTION
From an ergonomics perspective, it might make more sense always to return a `TransactionContext` when calling `continueTrace()`. By doing so, we can avoid adding null checks in our other SDKs and rely on an eventual sampling decision of the transaction later on.