### PR TITLE
Remove branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,10 +94,5 @@
             "phpstan/extension-installer": true
         }
     },
-    "prefer-stable": true,
-    "extra": {
-        "branch-alias": {
-            "dev-master": "3.13.x-dev"
-        }
-    }
+    "prefer-stable": true
 }


### PR DESCRIPTION
The alias is not needed anymore, as we now solely work on the master branch.
If someone wants to install the current master state, they can use `dev-master` or add an alias if their composer configuration does not allow dev as a minimum level, like `dev-master as 3.20.0`.