### PR TITLE
Compat support for PHPUnit `10`

### DIFF
--- a/src/Integration/FrameContextifierIntegration.php
+++ b/src/Integration/FrameContextifierIntegration.php
@@ -27,7 +27,7 @@ final class FrameContextifierIntegration implements IntegrationInterface
     /**
      * Creates a new instance of this integration.
      *
-     * @param LoggerInterface $logger A PSR-3 logger
+     * @param LoggerInterface|null $logger A PSR-3 logger
      */
     public function __construct(?LoggerInterface $logger = null)
     {

--- a/tests/BreadcrumbTest.php
+++ b/tests/BreadcrumbTest.php
@@ -44,7 +44,7 @@ final class BreadcrumbTest extends TestCase
         $this->assertSame($expectedTimestamp, $breadcrumb->getTimestamp());
     }
 
-    public function constructorDataProvider(): \Generator
+    public static function constructorDataProvider(): \Generator
     {
         yield [
             [
@@ -112,7 +112,7 @@ final class BreadcrumbTest extends TestCase
         $this->assertSame($expectedTimestamp, $breadcrumb->getTimestamp());
     }
 
-    public function fromArrayDataProvider(): iterable
+    public static function fromArrayDataProvider(): iterable
     {
         yield [
             [

--- a/tests/CheckInTest.php
+++ b/tests/CheckInTest.php
@@ -47,7 +47,7 @@ final class CheckInTest extends TestCase
         $this->assertEquals($expectedData, $checkIn->$getterMethod());
     }
 
-    public function gettersAndSettersDataProvider(): array
+    public static function gettersAndSettersDataProvider(): array
     {
         return [
             ['getId', 'setId', SentryUid::generate()],

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -7,7 +7,6 @@ namespace Sentry\Tests;
 use GuzzleHttp\Promise\FulfilledPromise;
 use GuzzleHttp\Promise\PromiseInterface;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Sentry\Client;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -182,7 +182,7 @@ final class ClientTest extends TestCase
         $this->assertTrue($beforeSendCallbackCalled);
     }
 
-    public function captureExceptionWithEventHintDataProvider(): \Generator
+    public static function captureExceptionWithEventHintDataProvider(): \Generator
     {
         yield [
             EventHint::fromArray([
@@ -223,7 +223,7 @@ final class ClientTest extends TestCase
         $this->assertSame($event->getId(), $client->captureEvent($event));
     }
 
-    public function captureEventDataProvider(): \Generator
+    public static function captureEventDataProvider(): \Generator
     {
         $event = Event::createEvent();
         $expectedEvent = clone $event;
@@ -347,7 +347,7 @@ final class ClientTest extends TestCase
         $this->assertNotNull($client->captureEvent(Event::createEvent(), $hint));
     }
 
-    public function captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider(): \Generator
+    public static function captureEventAttachesStacktraceAccordingToAttachStacktraceOptionDataProvider(): \Generator
     {
         yield 'Stacktrace attached when attach_stacktrace = true and both payload.exception and payload.stacktrace are unset' => [
             true,
@@ -497,7 +497,7 @@ final class ClientTest extends TestCase
         $this->assertSame($expectedBeforeSendCall, $beforeSendCalled);
     }
 
-    public function processEventChecksBeforeSendOptionDataProvider(): \Generator
+    public static function processEventChecksBeforeSendOptionDataProvider(): \Generator
     {
         yield [
             Event::createEvent(),
@@ -530,7 +530,7 @@ final class ClientTest extends TestCase
         $this->assertSame($expectedBeforeSendCall, $beforeSendTransactionCalled);
     }
 
-    public function processEventChecksBeforeSendTransactionOptionDataProvider(): \Generator
+    public static function processEventChecksBeforeSendTransactionOptionDataProvider(): \Generator
     {
         yield [
             Event::createEvent(),
@@ -543,48 +543,40 @@ final class ClientTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider processEventDiscardsEventWhenItIsSampledDueToSampleRateOptionDataProvider
-     */
-    public function testProcessEventDiscardsEventWhenItIsSampledDueToSampleRateOption(float $sampleRate, InvocationOrder $transportCallInvocationMatcher, InvocationOrder $loggerCallInvocationMatcher): void
+    public function testProcessEventDiscardsEventWhenSampleRateOptionIsZero(): void
     {
-        /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
-        $transport->expects($transportCallInvocationMatcher)
+        $transport->expects($this->never())
             ->method('send')
             ->with($this->anything());
 
-        /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
-        $logger->expects($loggerCallInvocationMatcher)
+        $logger->expects($this->once())
             ->method('info')
             ->with('The event will be discarded because it has been sampled.', $this->callback(static function (array $context): bool {
                 return isset($context['event']) && $context['event'] instanceof Event;
             }));
 
-        $client = ClientBuilder::create(['sample_rate' => $sampleRate])
+        $client = ClientBuilder::create(['sample_rate' => 0])
             ->setTransportFactory($this->createTransportFactory($transport))
             ->setLogger($logger)
             ->getClient();
 
-        for ($i = 0; $i < 10; ++$i) {
-            $client->captureMessage('foo');
-        }
+        $client->captureEvent(Event::createEvent());
     }
 
-    public function processEventDiscardsEventWhenItIsSampledDueToSampleRateOptionDataProvider(): \Generator
+    public function testProcessEventCapturesEventWhenSampleRateOptionIsAboveZero(): void
     {
-        yield [
-            0,
-            $this->never(),
-            $this->exactly(10),
-        ];
+        $transport = $this->createMock(TransportInterface::class);
+        $transport->expects($this->once())
+            ->method('send')
+            ->with($this->anything());
 
-        yield [
-            1,
-            $this->exactly(10),
-            $this->never(),
-        ];
+        $client = ClientBuilder::create(['sample_rate' => 1])
+            ->setTransportFactory($this->createTransportFactory($transport))
+            ->getClient();
+
+        $client->captureEvent(Event::createEvent());
     }
 
     public function testProcessEventDiscardsEventWhenIgnoreExceptionsMatches(): void
@@ -967,7 +959,7 @@ final class ClientTest extends TestCase
         $this->assertSame($expectedUrl, $client->getCspReportUrl());
     }
 
-    public function getCspReportUrlDataProvider(): \Generator
+    public static function getCspReportUrlDataProvider(): \Generator
     {
         yield [
             ['dsn' => null],

--- a/tests/Context/OsContextTest.php
+++ b/tests/Context/OsContextTest.php
@@ -50,7 +50,7 @@ final class OsContextTest extends TestCase
         $this->assertSame($expectedMachineType, $context->getMachineType());
     }
 
-    public function valuesDataProvider(): iterable
+    public static function valuesDataProvider(): iterable
     {
         yield [
             'Linux',

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -36,7 +36,7 @@ final class DsnTest extends TestCase
         $this->assertSame($expectedPath, $dsn->getPath());
     }
 
-    public function createFromStringDataProvider(): \Generator
+    public static function createFromStringDataProvider(): \Generator
     {
         yield [
             'http://public@example.com/sentry/1',
@@ -138,7 +138,7 @@ final class DsnTest extends TestCase
         Dsn::createFromString($value);
     }
 
-    public function createFromStringThrowsExceptionIfValueIsInvalidDataProvider(): \Generator
+    public static function createFromStringThrowsExceptionIfValueIsInvalidDataProvider(): \Generator
     {
         yield 'invalid DSN' => [
             ':',
@@ -186,7 +186,7 @@ final class DsnTest extends TestCase
         $this->assertSame($expectedUrl, $dsn->getStoreApiEndpointUrl());
     }
 
-    public function getStoreApiEndpointUrlDataProvider(): \Generator
+    public static function getStoreApiEndpointUrlDataProvider(): \Generator
     {
         yield [
             'http://public@example.com/sentry/1',
@@ -224,7 +224,7 @@ final class DsnTest extends TestCase
         $this->assertSame($expectedUrl, $dsn->getCspReportEndpointUrl());
     }
 
-    public function getCspReportEndpointUrlDataProvider(): \Generator
+    public static function getCspReportEndpointUrlDataProvider(): \Generator
     {
         yield [
             'http://public@example.com/sentry/1',
@@ -260,7 +260,7 @@ final class DsnTest extends TestCase
         $this->assertSame($value, (string) Dsn::createFromString($value));
     }
 
-    public function toStringDataProvider(): array
+    public static function toStringDataProvider(): array
     {
         return [
             ['http://public@example.com/sentry/1'],

--- a/tests/EventHintTest.php
+++ b/tests/EventHintTest.php
@@ -44,7 +44,7 @@ final class EventHintTest extends TestCase
         EventHint::fromArray($hintData);
     }
 
-    public function createFromArrayWithInvalidValuesDataProvider(): \Generator
+    public static function createFromArrayWithInvalidValuesDataProvider(): \Generator
     {
         yield [
             ['exception' => 'foo'],

--- a/tests/EventIdTest.php
+++ b/tests/EventIdTest.php
@@ -27,7 +27,7 @@ final class EventIdTest extends TestCase
         new EventId($value);
     }
 
-    public function constructorThrowsOnInvalidValueDataProvider(): \Generator
+    public static function constructorThrowsOnInvalidValueDataProvider(): \Generator
     {
         yield 'Value too long' => ['566e3688a61d4bc888951642d6f14a199'];
         yield 'Value too short' => ['566e3688a61d4bc888951642d6f14a1'];

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -35,7 +35,7 @@ final class EventTest extends TestCase
         $this->assertSame($expectedValue['formatted'], $event->getMessageFormatted());
     }
 
-    public function getMessageDataProvider(): array
+    public static function getMessageDataProvider(): array
     {
         return [
             [
@@ -86,7 +86,7 @@ final class EventTest extends TestCase
         $this->assertEquals($event->$getterMethod(), $propertyValue);
     }
 
-    public function gettersAndSettersDataProvider(): array
+    public static function gettersAndSettersDataProvider(): array
     {
         return [
             ['sdkIdentifier', 'sentry.sdk.test-identifier'],

--- a/tests/ExceptionDataBagTest.php
+++ b/tests/ExceptionDataBagTest.php
@@ -25,7 +25,7 @@ final class ExceptionDataBagTest extends TestCase
         $this->assertSame($expectedExceptionMechansim, $exceptionDataBag->getMechanism());
     }
 
-    public function constructorDataProvider(): \Generator
+    public static function constructorDataProvider(): \Generator
     {
         yield [
             [

--- a/tests/ExceptionMechanismTest.php
+++ b/tests/ExceptionMechanismTest.php
@@ -25,7 +25,7 @@ final class ExceptionMechanismTest extends TestCase
         $this->assertSame($expectedData, $exceptionMechanism->getData());
     }
 
-    public function constructorDataProvider(): iterable
+    public static function constructorDataProvider(): iterable
     {
         yield [
             [

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -27,7 +27,7 @@ final class FrameBuilderTest extends TestCase
         $this->assertSame($expectedFrame->getAbsoluteFilePath(), $frame->getAbsoluteFilePath());
     }
 
-    public function buildFromBacktraceFrameDataProvider(): \Generator
+    public static function buildFromBacktraceFrameDataProvider(): \Generator
     {
         yield [
             new Options([]),
@@ -162,7 +162,7 @@ final class FrameBuilderTest extends TestCase
         $this->assertSame($expectedResult, $frame->isInApp());
     }
 
-    public function addFrameSetsInAppFlagCorrectlyDataProvider(): \Generator
+    public static function addFrameSetsInAppFlagCorrectlyDataProvider(): \Generator
     {
         yield 'No config specified' => [
             new Options([

--- a/tests/FrameTest.php
+++ b/tests/FrameTest.php
@@ -29,7 +29,7 @@ final class FrameTest extends TestCase
         $this->assertEquals($expectedData, $frame->$getterMethod());
     }
 
-    public function gettersAndSettersDataProvider(): array
+    public static function gettersAndSettersDataProvider(): array
     {
         return [
             ['getPreContext', 'setPreContext', ['foo' => 'bar', 'bar' => 'baz']],

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -66,7 +66,7 @@ final class FunctionsTest extends TestCase
         $this->assertSame($eventId, captureMessage(...$functionCallArgs));
     }
 
-    public function captureMessageDataProvider(): \Generator
+    public static function captureMessageDataProvider(): \Generator
     {
         yield [
             [
@@ -112,7 +112,7 @@ final class FunctionsTest extends TestCase
         $this->assertSame($eventId, captureException(...$functionCallArgs));
     }
 
-    public function captureExceptionDataProvider(): \Generator
+    public static function captureExceptionDataProvider(): \Generator
     {
         yield [
             [
@@ -172,7 +172,7 @@ final class FunctionsTest extends TestCase
         $this->assertSame($eventId, captureLastError(...$functionCallArgs));
     }
 
-    public function captureLastErrorDataProvider(): \Generator
+    public static function captureLastErrorDataProvider(): \Generator
     {
         yield [
             [],

--- a/tests/HttpClient/HttpClientFactoryTest.php
+++ b/tests/HttpClient/HttpClientFactoryTest.php
@@ -51,7 +51,7 @@ final class HttpClientFactoryTest extends TestCase
         $this->assertSame($expectedRequestBody, (string) $httpRequest->getBody());
     }
 
-    public function createDataProvider(): \Generator
+    public static function createDataProvider(): \Generator
     {
         yield [
             false,

--- a/tests/Integration/EnvironmentIntegrationTest.php
+++ b/tests/Integration/EnvironmentIntegrationTest.php
@@ -64,7 +64,7 @@ final class EnvironmentIntegrationTest extends TestCase
         });
     }
 
-    public function invokeDataProvider(): iterable
+    public static function invokeDataProvider(): iterable
     {
         yield 'Integration disabled => do nothing' => [
             false,

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -92,7 +92,7 @@ final class FrameContextifierIntegrationTest extends TestCase
         }
     }
 
-    public function invokeDataProvider(): \Generator
+    public static function invokeDataProvider(): \Generator
     {
         yield 'short file' => [
             realpath(__DIR__ . '/../Fixtures/code/ShortFile.php'),

--- a/tests/Integration/FrameContextifierIntegrationTest.php
+++ b/tests/Integration/FrameContextifierIntegrationTest.php
@@ -13,30 +13,12 @@ use Sentry\Frame;
 use Sentry\Integration\FrameContextifierIntegration;
 use Sentry\Options;
 use Sentry\SentrySdk;
-use Sentry\Serializer\RepresentationSerializerInterface;
-use Sentry\Serializer\SerializerInterface;
 use Sentry\Stacktrace;
 use Sentry\State\Scope;
 use function Sentry\withScope;
 
 final class FrameContextifierIntegrationTest extends TestCase
 {
-    /**
-     * @var MockObject&SerializerInterface
-     */
-    private $serializer;
-
-    /**
-     * @var MockObject&RepresentationSerializerInterface
-     */
-    private $representationSerializer;
-
-    protected function setUp(): void
-    {
-        $this->serializer = $this->createMock(SerializerInterface::class);
-        $this->representationSerializer = $this->createMock(RepresentationSerializerInterface::class);
-    }
-
     /**
      * @dataProvider invokeDataProvider
      */

--- a/tests/Integration/IgnoreErrorsIntegrationTest.php
+++ b/tests/Integration/IgnoreErrorsIntegrationTest.php
@@ -43,7 +43,7 @@ final class IgnoreErrorsIntegrationTest extends TestCase
         });
     }
 
-    public function invokeDataProvider(): \Generator
+    public static function invokeDataProvider(): \Generator
     {
         $event = Event::createEvent();
         $event->setExceptions([new ExceptionDataBag(new \RuntimeException())]);

--- a/tests/Integration/IntegrationRegistryTest.php
+++ b/tests/Integration/IntegrationRegistryTest.php
@@ -49,7 +49,7 @@ final class IntegrationRegistryTest extends TestCase
         $this->assertEquals($expectedIntegrations, IntegrationRegistry::getInstance()->setupIntegrations($options, $logger));
     }
 
-    public function setupIntegrationsDataProvider(): iterable
+    public static function setupIntegrationsDataProvider(): iterable
     {
         $integration1 = new class() implements IntegrationInterface {
             public function setupOnce(): void
@@ -319,7 +319,7 @@ final class IntegrationRegistryTest extends TestCase
         );
     }
 
-    public function setupIntegrationsThrowsExceptionIfValueReturnedFromOptionIsNotValidDataProvider(): iterable
+    public static function setupIntegrationsThrowsExceptionIfValueReturnedFromOptionIsNotValidDataProvider(): iterable
     {
         yield [
             12.34,

--- a/tests/Integration/ModulesIntegrationTest.php
+++ b/tests/Integration/ModulesIntegrationTest.php
@@ -44,7 +44,7 @@ final class ModulesIntegrationTest extends TestCase
         });
     }
 
-    public function invokeDataProvider(): \Generator
+    public static function invokeDataProvider(): \Generator
     {
         yield [
             false,

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -62,7 +62,7 @@ final class RequestIntegrationTest extends TestCase
         });
     }
 
-    public function invokeDataProvider(): iterable
+    public static function invokeDataProvider(): iterable
     {
         yield [
             [

--- a/tests/Integration/TransactionIntegrationTest.php
+++ b/tests/Integration/TransactionIntegrationTest.php
@@ -44,7 +44,7 @@ final class TransactionIntegrationTest extends TestCase
         });
     }
 
-    public function setupOnceDataProvider(): \Generator
+    public static function setupOnceDataProvider(): \Generator
     {
         yield [
             Event::createEvent(),

--- a/tests/MonitorConfigTest.php
+++ b/tests/MonitorConfigTest.php
@@ -39,7 +39,7 @@ final class MonitorConfigTest extends TestCase
         $this->assertEquals($expectedData, $monitorConfig->$getterMethod());
     }
 
-    public function gettersAndSettersDataProvider(): array
+    public static function gettersAndSettersDataProvider(): array
     {
         return [
             ['getSchedule', 'setSchedule', MonitorSchedule::crontab('foo')],

--- a/tests/MonitorScheduleTest.php
+++ b/tests/MonitorScheduleTest.php
@@ -54,7 +54,7 @@ final class MonitorScheduleTest extends TestCase
         $this->assertEquals($expectedData, $monitorSchedule->$getterMethod());
     }
 
-    public function gettersAndSettersDataProvider(): array
+    public static function gettersAndSettersDataProvider(): array
     {
         return [
             ['getType', 'setType', MonitorSchedule::TYPE_INTERVAL],

--- a/tests/Monolog/BreadcrumbHandlerTest.php
+++ b/tests/Monolog/BreadcrumbHandlerTest.php
@@ -39,7 +39,7 @@ final class BreadcrumbHandlerTest extends TestCase
     /**
      * @return iterable<LogRecord|array{array<string, mixed>, Breadcrumb}>
      */
-    public function handleDataProvider(): iterable
+    public static function handleDataProvider(): iterable
     {
         $defaultBreadcrumb = new Breadcrumb(
             Breadcrumb::LEVEL_DEBUG,

--- a/tests/Monolog/HandlerTest.php
+++ b/tests/Monolog/HandlerTest.php
@@ -49,7 +49,7 @@ final class HandlerTest extends TestCase
         $handler->handle($record);
     }
 
-    public function handleDataProvider(): iterable
+    public static function handleDataProvider(): iterable
     {
         $event = Event::createEvent();
         $event->setMessage('foo bar');

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -84,7 +84,7 @@ final class OptionsTest extends TestCase
         $this->assertEquals($value, $options->$getterMethod());
     }
 
-    public function optionsDataProvider(): \Generator
+    public static function optionsDataProvider(): \Generator
     {
         yield [
             'send_attempts',
@@ -421,7 +421,7 @@ final class OptionsTest extends TestCase
         $this->assertEquals($expectedDsnAsObject, $options->getDsn());
     }
 
-    public function dsnOptionDataProvider(): \Generator
+    public static function dsnOptionDataProvider(): \Generator
     {
         yield [
             'http://public:secret@example.com/sentry/1',
@@ -490,7 +490,7 @@ final class OptionsTest extends TestCase
         new Options(['dsn' => $value]);
     }
 
-    public function dsnOptionThrowsOnInvalidValueDataProvider(): \Generator
+    public static function dsnOptionThrowsOnInvalidValueDataProvider(): \Generator
     {
         yield [
             true,
@@ -557,7 +557,7 @@ final class OptionsTest extends TestCase
         $this->assertSame($value, $options->getMaxBreadcrumbs());
     }
 
-    public function maxBreadcrumbsOptionIsValidatedCorrectlyDataProvider(): array
+    public static function maxBreadcrumbsOptionIsValidatedCorrectlyDataProvider(): array
     {
         return [
             [false, -1],
@@ -585,7 +585,7 @@ final class OptionsTest extends TestCase
         new Options(['context_lines' => $value]);
     }
 
-    public function contextLinesOptionValidatesInputValueDataProvider(): \Generator
+    public static function contextLinesOptionValidatesInputValueDataProvider(): \Generator
     {
         yield [
             -1,
@@ -665,7 +665,7 @@ final class OptionsTest extends TestCase
         $this->assertSame($expectedResult, $options->isTracingEnabled());
     }
 
-    public function enableTracingDataProvider(): array
+    public static function enableTracingDataProvider(): array
     {
         return [
             [null, null, false],

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sentry\Tests;
+namespace Sentry\Tests\Profiling;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\Context\OsContext;

--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -28,7 +28,7 @@ final class ProfileTest extends TestCase
         $this->assertSame($expectedData, $profile->getFormattedData($event));
     }
 
-    public function formattedDataDataProvider(): \Generator
+    public static function formattedDataDataProvider(): \Generator
     {
         $event = Event::createTransaction(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setRelease('1.0.0');

--- a/tests/ResponseStatusTest.php
+++ b/tests/ResponseStatusTest.php
@@ -17,7 +17,7 @@ final class ResponseStatusTest extends TestCase
         $this->assertSame($expectedStringRepresentation, (string) $responseStatus);
     }
 
-    public function toStringDataProvider(): iterable
+    public static function toStringDataProvider(): iterable
     {
         yield [
             ResponseStatus::success(),
@@ -58,7 +58,7 @@ final class ResponseStatusTest extends TestCase
         $this->assertSame($expectedResponseStatus, ResponseStatus::createFromHttpStatusCode($httpStatusCode));
     }
 
-    public function createFromHttpStatusCodeDataProvider(): iterable
+    public static function createFromHttpStatusCodeDataProvider(): iterable
     {
         yield [
             ResponseStatus::success(),

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -20,7 +20,7 @@ abstract class AbstractSerializerTest extends TestCase
     {
     }
 
-    public function serializeAllObjectsDataProvider(): array
+    public static function serializeAllObjectsDataProvider(): array
     {
         return [
             ['serializeAllObjects' => false],
@@ -54,7 +54,7 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame('Object Sentry\Tests\Serializer\SerializerTestObject', $result);
     }
 
-    public function objectsWithIdPropertyDataProvider(): array
+    public static function objectsWithIdPropertyDataProvider(): array
     {
         return [
             ['bar', 'Object Sentry\Tests\Serializer\SerializerTestObjectWithIdProperty(#bar)'],
@@ -124,7 +124,7 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame($input, $output);
     }
 
-    public function iterableDataProvider(): \Generator
+    public static function iterableDataProvider(): \Generator
     {
         yield [
             'iterable' => ['value1', 'value2'],
@@ -183,7 +183,7 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame([[['Array of length 0']]], $result);
     }
 
-    public function dataRecursionInObjectsDataProvider(): \Generator
+    public static function dataRecursionInObjectsDataProvider(): \Generator
     {
         $object = new SerializerTestObject();
         $object->key = $object;
@@ -285,7 +285,7 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertEquals($expectedResult, $result);
     }
 
-    public function recursionMaxDepthForObjectDataProvider(): array
+    public static function recursionMaxDepthForObjectDataProvider(): array
     {
         return [
             [
@@ -575,7 +575,7 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame($expected, $this->invokeSerialization($serializer, $string));
     }
 
-    public function serializationForBadStringsDataProvider(): array
+    public static function serializationForBadStringsDataProvider(): array
     {
         $utf8String = 'äöü';
 

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -84,7 +84,7 @@ final class PayloadSerializerTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
-    public function serializeAsJsonDataProvider(): iterable
+    public static function serializeAsJsonDataProvider(): iterable
     {
         ClockMock::withClockMock(1597790835);
 
@@ -649,7 +649,7 @@ TEXT
         ];
     }
 
-    public function serializeAsEnvelopeDataProvider(): iterable
+    public static function serializeAsEnvelopeDataProvider(): iterable
     {
         ClockMock::withClockMock(1597790835);
 

--- a/tests/SeverityTest.php
+++ b/tests/SeverityTest.php
@@ -33,7 +33,7 @@ final class SeverityTest extends TestCase
         $this->assertSame($expectedStringRepresentation, (string) $severity);
     }
 
-    public function constantsDataProvider(): array
+    public static function constantsDataProvider(): array
     {
         return [
             [Severity::debug(), 'debug'],
@@ -62,7 +62,7 @@ final class SeverityTest extends TestCase
         $this->assertSame($expectedSeverity, (string) Severity::fromError($errorLevel));
     }
 
-    public function levelsDataProvider(): array
+    public static function levelsDataProvider(): array
     {
         return [
             // Warning

--- a/tests/StacktraceTest.php
+++ b/tests/StacktraceTest.php
@@ -32,7 +32,7 @@ final class StacktraceTest extends TestCase
         new Stacktrace($values);
     }
 
-    public function constructorThrowsIfFramesListContainsUnexpectedValueDataProvider(): \Generator
+    public static function constructorThrowsIfFramesListContainsUnexpectedValueDataProvider(): \Generator
     {
         yield [
             [
@@ -94,7 +94,7 @@ final class StacktraceTest extends TestCase
         $this->assertFrameEquals($frames[0], 'test_function_parent', 'path/to/file', 12);
     }
 
-    public function removeFrameDataProvider(): \Generator
+    public static function removeFrameDataProvider(): \Generator
     {
         yield [
             -1,
@@ -126,7 +126,7 @@ final class StacktraceTest extends TestCase
         }
     }
 
-    public function buildFromBacktraceDataProvider(): \Generator
+    public static function buildFromBacktraceDataProvider(): \Generator
     {
         yield 'Plain backtrace' => [
             new Options(),

--- a/tests/State/HubAdapterTest.php
+++ b/tests/State/HubAdapterTest.php
@@ -155,7 +155,7 @@ final class HubAdapterTest extends TestCase
         $this->assertSame($eventId, HubAdapter::getInstance()->captureMessage(...$expectedFunctionCallArgs));
     }
 
-    public function captureMessageDataProvider(): \Generator
+    public static function captureMessageDataProvider(): \Generator
     {
         yield [
             [
@@ -192,7 +192,7 @@ final class HubAdapterTest extends TestCase
         $this->assertSame($eventId, HubAdapter::getInstance()->captureException(...$expectedFunctionCallArgs));
     }
 
-    public function captureExceptionDataProvider(): \Generator
+    public static function captureExceptionDataProvider(): \Generator
     {
         yield [
             [
@@ -242,7 +242,7 @@ final class HubAdapterTest extends TestCase
         $this->assertSame($eventId, HubAdapter::getInstance()->captureLastError(...$expectedFunctionCallArgs));
     }
 
-    public function captureLastErrorDataProvider(): \Generator
+    public static function captureLastErrorDataProvider(): \Generator
     {
         yield [
             [],

--- a/tests/State/HubTest.php
+++ b/tests/State/HubTest.php
@@ -251,7 +251,7 @@ final class HubTest extends TestCase
         $this->assertSame($eventId, $hub->captureMessage(...$functionCallArgs));
     }
 
-    public function captureMessageDataProvider(): \Generator
+    public static function captureMessageDataProvider(): \Generator
     {
         $propagationContext = PropagationContext::fromDefaults();
 
@@ -309,7 +309,7 @@ final class HubTest extends TestCase
         $this->assertSame($eventId, $hub->captureException(...$functionCallArgs));
     }
 
-    public function captureExceptionDataProvider(): \Generator
+    public static function captureExceptionDataProvider(): \Generator
     {
         $propagationContext = PropagationContext::fromDefaults();
 
@@ -365,7 +365,7 @@ final class HubTest extends TestCase
         $this->assertSame($eventId, $hub->captureLastError(...$functionCallArgs));
     }
 
-    public function captureLastErrorDataProvider(): \Generator
+    public static function captureLastErrorDataProvider(): \Generator
     {
         $propagationContext = PropagationContext::fromDefaults();
 
@@ -586,7 +586,7 @@ final class HubTest extends TestCase
         $this->assertSame($expectedSampled, $transaction->getSampled());
     }
 
-    public function startTransactionDataProvider(): iterable
+    public static function startTransactionDataProvider(): iterable
     {
         yield 'Acceptable float value returned from traces_sampler' => [
             new Options([

--- a/tests/Tracing/DynamicSamplingContextTest.php
+++ b/tests/Tracing/DynamicSamplingContextTest.php
@@ -43,7 +43,7 @@ final class DynamicSamplingContextTest extends TestCase
         $this->assertSame($expectedTransaction, $samplingContext->get('transaction'));
     }
 
-    public function fromHeaderDataProvider(): \Generator
+    public static function fromHeaderDataProvider(): \Generator
     {
         yield [
             '',
@@ -169,7 +169,7 @@ final class DynamicSamplingContextTest extends TestCase
         $this->assertSame($expectedDynamicSamplingContext, $samplingContext->getEntries());
     }
 
-    public function getEntriesDataProvider(): \Generator
+    public static function getEntriesDataProvider(): \Generator
     {
         yield [
             DynamicSamplingContext::fromHeader(''),
@@ -203,7 +203,7 @@ final class DynamicSamplingContextTest extends TestCase
         $this->assertSame($expectedString, (string) $samplingContext);
     }
 
-    public function toStringDataProvider(): \Generator
+    public static function toStringDataProvider(): \Generator
     {
         yield [
             DynamicSamplingContext::fromHeader(''),

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -127,7 +127,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
         $transaction->finish();
     }
 
-    public function traceHeadersDataProvider(): iterable
+    public static function traceHeadersDataProvider(): iterable
     {
         yield [
             new Request('GET', 'https://www.example.com'),
@@ -263,7 +263,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
         $transaction->finish();
     }
 
-    public function traceDataProvider(): iterable
+    public static function traceDataProvider(): iterable
     {
         yield [
             new Request('GET', 'https://www.example.com'),

--- a/tests/Tracing/PropagationContextTest.php
+++ b/tests/Tracing/PropagationContextTest.php
@@ -68,7 +68,7 @@ final class PropagationContextTest extends TestCase
         $this->assertSame($expectedDynamicSamplingContextFrozen, $propagationContext->getDynamicSamplingContext()->isFrozen());
     }
 
-    public function tracingDataProvider(): iterable
+    public static function tracingDataProvider(): iterable
     {
         yield [
             '566e3688a61d4bc888951642d6f14a19-566e3688a61d4bc8-1',
@@ -147,7 +147,7 @@ final class PropagationContextTest extends TestCase
         $this->assertEquals($expectedData, $propagationContext->$getterMethod());
     }
 
-    public function gettersAndSettersDataProvider(): array
+    public static function gettersAndSettersDataProvider(): array
     {
         $scope = new Scope();
         $options = new Options([

--- a/tests/Tracing/SpanContextTest.php
+++ b/tests/Tracing/SpanContextTest.php
@@ -36,7 +36,7 @@ final class SpanContextTest extends TestCase
         $this->assertSame($expectedSampled, $spanContext->getSampled());
     }
 
-    public function fromTraceparentDataProvider(): iterable
+    public static function fromTraceparentDataProvider(): iterable
     {
         yield [
             '0',

--- a/tests/Tracing/SpanIdTest.php
+++ b/tests/Tracing/SpanIdTest.php
@@ -27,7 +27,7 @@ final class SpanIdTest extends TestCase
         new SpanId($value);
     }
 
-    public function constructorThrowsOnInvalidValueDataProvider(): \Generator
+    public static function constructorThrowsOnInvalidValueDataProvider(): \Generator
     {
         yield 'Value too long' => ['566e3688a61d4bc88'];
         yield 'Value too short' => ['566e3688a61d4b8'];

--- a/tests/Tracing/SpanStatusTest.php
+++ b/tests/Tracing/SpanStatusTest.php
@@ -17,7 +17,7 @@ final class SpanStatusTest extends TestCase
         $this->assertSame($expectedStringRepresentation, (string) $spanStatus);
     }
 
-    public function toStringDataProvider(): iterable
+    public static function toStringDataProvider(): iterable
     {
         yield [
             SpanStatus::unauthenticated(),
@@ -93,7 +93,7 @@ final class SpanStatusTest extends TestCase
         $this->assertSame($expectedSpanStatus, SpanStatus::createFromHttpStatusCode($httpStatusCode));
     }
 
-    public function createFromHttpStatusCodeDataProvider(): iterable
+    public static function createFromHttpStatusCodeDataProvider(): iterable
     {
         yield [
             SpanStatus::unauthenticated(),

--- a/tests/Tracing/SpanTest.php
+++ b/tests/Tracing/SpanTest.php
@@ -31,7 +31,7 @@ final class SpanTest extends TestCase
         $this->assertSame($expectedEndTimestamp, $span->getEndTimestamp());
     }
 
-    public function finishDataProvider(): iterable
+    public static function finishDataProvider(): iterable
     {
         yield [
             1598660006,
@@ -86,7 +86,7 @@ final class SpanTest extends TestCase
         $this->assertSame($expectedValue, $span->toTraceparent());
     }
 
-    public function toTraceparentDataProvider(): iterable
+    public static function toTraceparentDataProvider(): iterable
     {
         yield [
             null,
@@ -118,7 +118,7 @@ final class SpanTest extends TestCase
         $this->assertSame($expectedValue, $transaction->toBaggage());
     }
 
-    public function toBaggageDataProvider(): iterable
+    public static function toBaggageDataProvider(): iterable
     {
         yield [
             '',

--- a/tests/Tracing/TraceIdTest.php
+++ b/tests/Tracing/TraceIdTest.php
@@ -27,7 +27,7 @@ final class TraceIdTest extends TestCase
         new TraceId($value);
     }
 
-    public function constructorThrowsOnInvalidValueDataProvider(): \Generator
+    public static function constructorThrowsOnInvalidValueDataProvider(): \Generator
     {
         yield 'Value too long' => ['566e3688a61d4bc888951642d6f14a199'];
         yield 'Value too short' => ['566e3688a61d4bc888951642d6f14a1'];

--- a/tests/Tracing/TransactionContextTest.php
+++ b/tests/Tracing/TransactionContextTest.php
@@ -51,7 +51,7 @@ final class TransactionContextTest extends TestCase
         $this->assertSame($expectedParentSampled, $spanContext->getParentSampled());
     }
 
-    public function fromSentryTraceDataProvider(): iterable
+    public static function fromSentryTraceDataProvider(): iterable
     {
         yield [
             '0',
@@ -117,7 +117,7 @@ final class TransactionContextTest extends TestCase
         $this->assertSame($expectedDynamicSamplingContextFrozen, $spanContext->getMetadata()->getDynamicSamplingContext()->isFrozen());
     }
 
-    public function tracingDataProvider(): iterable
+    public static function tracingDataProvider(): iterable
     {
         yield [
             '0',

--- a/tests/Tracing/TransactionMetadataTest.php
+++ b/tests/Tracing/TransactionMetadataTest.php
@@ -21,7 +21,7 @@ final class TransactionMetadataTest extends TestCase
         $this->assertSame($expectedSource, $transactionMetadata->getSource());
     }
 
-    public function constructorDataProvider(): \Generator
+    public static function constructorDataProvider(): \Generator
     {
         $samplingContext = DynamicSamplingContext::fromHeader('sentry-public_key=public,sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-sample_rate=1');
         $source = TransactionSource::custom();

--- a/tests/Tracing/TransactionTest.php
+++ b/tests/Tracing/TransactionTest.php
@@ -107,7 +107,7 @@ final class TransactionTest extends TestCase
         $this->assertSame($expectedSampled, $transaction->getSampled());
     }
 
-    public function parentTransactionContextDataProvider(): Generator
+    public static function parentTransactionContextDataProvider(): Generator
     {
         yield [
             new TransactionContext(TransactionContext::DEFAULT_NAME, true),

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -181,7 +181,7 @@ final class HttpTransportTest extends TestCase
         $this->assertSame($event, $promiseResult->getEvent());
     }
 
-    public function sendDataProvider(): iterable
+    public static function sendDataProvider(): iterable
     {
         yield [
             200,

--- a/tests/Transport/RateLimiterTest.php
+++ b/tests/Transport/RateLimiterTest.php
@@ -53,7 +53,7 @@ final class RateLimiterTest extends TestCase
         $this->assertSame($event, $transportResponse->getEvent());
     }
 
-    public function handleResponseDataProvider(): \Generator
+    public static function handleResponseDataProvider(): \Generator
     {
         yield 'Rate limits headers missing' => [
             Event::createEvent(),

--- a/tests/UserDataBagTest.php
+++ b/tests/UserDataBagTest.php
@@ -42,7 +42,7 @@ final class UserDataBagTest extends TestCase
         $this->assertSame($expectedMetadata, $userDataBag->getMetadata());
     }
 
-    public function createFromArrayDataProvider(): iterable
+    public static function createFromArrayDataProvider(): iterable
     {
         yield [
             ['id' => 1234],
@@ -149,7 +149,7 @@ final class UserDataBagTest extends TestCase
         UserDataBag::createFromUserIdentifier($value);
     }
 
-    public function unexpectedValueForIdFieldDataProvider(): iterable
+    public static function unexpectedValueForIdFieldDataProvider(): iterable
     {
         yield [
             12.34,

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -20,7 +20,7 @@ final class JSONTest extends TestCase
         $this->assertSame($expectedResult, JSON::encode($value));
     }
 
-    public function encodeDataProvider(): \Generator
+    public static function encodeDataProvider(): \Generator
     {
         yield [
             [
@@ -78,7 +78,7 @@ final class JSONTest extends TestCase
         $this->assertSame($expectedResult, JSON::encode($value));
     }
 
-    public function encodeSubstitutesInvalidUtf8CharactersDataProvider(): \Generator
+    public static function encodeSubstitutesInvalidUtf8CharactersDataProvider(): \Generator
     {
         yield [
             "\x61\xb0\x62",
@@ -132,7 +132,7 @@ final class JSONTest extends TestCase
         JSON::encode('foo', 0, $maxDepth);
     }
 
-    public function encodeThrowsExceptionIfMaxDepthArgumentIsInvalidDataProvider(): \Generator
+    public static function encodeThrowsExceptionIfMaxDepthArgumentIsInvalidDataProvider(): \Generator
     {
         yield [0];
         yield [-1];
@@ -151,7 +151,7 @@ final class JSONTest extends TestCase
         $this->assertSame($expectedResult, JSON::decode($value));
     }
 
-    public function decodeDataProvider(): \Generator
+    public static function decodeDataProvider(): \Generator
     {
         yield [
             '{"key":"value"}',


### PR DESCRIPTION
Now that PHPUnit `10` has been released, a few things that changed must be addressed before even considering updating to it. The biggest change that affects us is that the data providers are now expected to be `static` functions. While updating things here and there, I also found some little typos or mistakes in the code that I fixed in separate commits.