### PR TITLE
[4.x] Profiler frame processor

### DIFF
--- a/tests/Profiling/ProfileTest.php
+++ b/tests/Profiling/ProfileTest.php
@@ -17,8 +17,10 @@ final class ProfileTest extends TestCase
     /**
      * @dataProvider formattedDataDataProvider
      */
-    public function testGetFormattedData(Event $event, array $excimerLog, $expectedData, ?Options $options = null): void
+    public function testGetFormattedData(Event $event, array $excimerLog, $expectedData, ?Options $options = null, ?callable $frameProcessor = null): void
     {
+        Profile::setFrameProcessor($frameProcessor);
+
         $profile = new Profile($options);
         // 2022-02-28T09:41:00Z
         $profile->setStartTimeStamp(1677573660.0000);
@@ -314,6 +316,112 @@ final class ProfileTest extends TestCase
             new Options([
                 'prefixes' => ['/var/www/html'],
             ]),
+        ];
+
+        yield 'With frame processor' => [
+            $event,
+            $excimerLog,
+            [
+                'device' => [
+                    'architecture' => 'aarch64',
+                ],
+                'event_id' => '815e57b4bb134056ab1840919834689d',
+                'os' => [
+                    'name' => 'macOS',
+                    'version' => '13.2.1',
+                    'build_number' => '22D68',
+                ],
+                'platform' => 'php',
+                'release' => '1.0.0',
+                'environment' => 'dev',
+                'runtime' => [
+                    'name' => 'php',
+                    'version' => '8.2.3',
+                ],
+                'timestamp' => '2023-02-28T08:41:00.000+00:00',
+                'transaction' => [
+                    'id' => 'fc9442f5aef34234bb22b9a615e30ccd',
+                    'name' => 'GET /',
+                    'trace_id' => '566e3688a61d4bc888951642d6f14a19',
+                    'active_thread_id' => '0',
+                ],
+                'version' => '1',
+                'profile' => [
+                    'frames' => [
+                        [
+                            'filename' => '/var/www/html/index.php',
+                            'abs_path' => '/var/www/html/index.php',
+                            'module' => 'foo',
+                            'function' => '/var/www/html/index.php',
+                            'lineno' => 42,
+                        ],
+                        [
+                            'filename' => '/var/www/html/function.php',
+                            'abs_path' => '/var/www/html/function.php',
+                            'module' => 'foo',
+                            'function' => 'Function::doStuff',
+                            'lineno' => 84,
+                        ],
+                        [
+                            'filename' => '/var/www/html/class.php',
+                            'abs_path' => '/var/www/html/class.php',
+                            'module' => 'foo',
+                            'function' => 'Class\Something::run',
+                            'lineno' => 42,
+                        ],
+                        [
+                            'filename' => '/var/www/html/index.php',
+                            'abs_path' => '/var/www/html/index.php',
+                            'module' => 'foo',
+                            'function' => '{closure}',
+                            'lineno' => 126,
+                        ],
+                    ],
+                    'samples' => [
+                        [
+                            'stack_id' => 0,
+                            'thread_id' => '0',
+                            'elapsed_since_start_ns' => 1000000,
+                        ],
+                        [
+                            'stack_id' => 0,
+                            'thread_id' => '0',
+                            'elapsed_since_start_ns' => 2000000,
+                        ],
+                        [
+                            'stack_id' => 1,
+                            'thread_id' => '0',
+                            'elapsed_since_start_ns' => 3000000,
+                        ],
+                        [
+                            'stack_id' => 2,
+                            'thread_id' => '0',
+                            'elapsed_since_start_ns' => 4000000,
+                        ],
+                    ],
+                    'stacks' => [
+                        [
+                            0,
+                        ],
+                        [
+                            0,
+                            1,
+                        ],
+                        [
+                            0,
+                            1,
+                            2,
+                            3,
+                        ],
+                    ],
+                ],
+            ],
+            null,
+            static function (array $data): array {
+                $data['module'] = 'foo';
+
+                return $data;
+            },
         ];
 
         yield 'Too little samples' => [


### PR DESCRIPTION
A very pragmatic way to set a frame processor. This is intended for internal use in framework SDKs to do further processing on the frame. For example, in Laravel we want to show original view paths instead of the cached view path for frames inside blade views.