### PR TITLE
Support Symfony `PSR-18` HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "php-http/discovery": "^1.15",
         "php-http/httplug": "^1.1|^2.0",
         "php-http/message": "^1.5",
-        "php-http/message-factory": "^1.1",
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
         "psr/log": "^1.0|^2.0|^3.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -52,7 +52,7 @@ parameters:
 
 		-
 			message: "#^Call to static method create\\(\\) on an unknown class Symfony\\\\Component\\\\HttpClient\\\\HttpClient\\.$#"
-			count: 1
+			count: 2
 			path: src/HttpClient/HttpClientFactory.php
 
 		-
@@ -71,12 +71,22 @@ parameters:
 			path: src/HttpClient/HttpClientFactory.php
 
 		-
+			message: "#^Instantiated class Symfony\\\\Component\\\\HttpClient\\\\HttplugClient not found\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
 			message: "#^Method Sentry\\\\HttpClient\\\\HttpClientFactory\\:\\:resolveClient\\(\\) should return Http\\\\Client\\\\HttpAsyncClient\\|Psr\\\\Http\\\\Client\\\\ClientInterface but returns Http\\\\Client\\\\Curl\\\\Client\\.$#"
 			count: 1
 			path: src/HttpClient/HttpClientFactory.php
 
 		-
 			message: "#^Method Sentry\\\\HttpClient\\\\HttpClientFactory\\:\\:resolveClient\\(\\) should return Http\\\\Client\\\\HttpAsyncClient\\|Psr\\\\Http\\\\Client\\\\ClientInterface but returns Symfony\\\\Component\\\\HttpClient\\\\HttplugClient\\.$#"
+			count: 1
+			path: src/HttpClient/HttpClientFactory.php
+
+		-
+			message: "#^Method Sentry\\\\HttpClient\\\\HttpClientFactory\\:\\:resolveClient\\(\\) should return Http\\\\Client\\\\HttpAsyncClient\\|Psr\\\\Http\\\\Client\\\\ClientInterface but returns Symfony\\\\Component\\\\HttpClient\\\\Psr18Client\\.$#"
 			count: 1
 			path: src/HttpClient/HttpClientFactory.php
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,12 +9,14 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="src/HttpClient/HttpClientFactory.php">
-    <UndefinedClass occurrences="5">
+    <UndefinedClass occurrences="7">
       <code>Guzzle6HttpClient</code>
       <code>GuzzleHttpClientOptions</code>
       <code>GuzzleHttpClientOptions</code>
       <code>GuzzleHttpClientOptions</code>
       <code>SymfonyHttpClient</code>
+      <code>SymfonyHttpClient</code>
+      <code>SymfonyHttplugClient</code>
     </UndefinedClass>
   </file>
   <file src="src/Integration/IntegrationRegistry.php">

--- a/src/HttpClient/HttpClientFactory.php
+++ b/src/HttpClient/HttpClientFactory.php
@@ -25,6 +25,7 @@ use Sentry\HttpClient\Plugin\GzipEncoderPlugin;
 use Sentry\Options;
 use Symfony\Component\HttpClient\HttpClient as SymfonyHttpClient;
 use Symfony\Component\HttpClient\HttplugClient as SymfonyHttplugClient;
+use Symfony\Component\HttpClient\Psr18Client as SymfonyPsr18Client;
 
 /**
  * Default implementation of the {@HttpClientFactoryInterface} interface that uses
@@ -111,7 +112,7 @@ final class HttpClientFactory implements HttpClientFactoryInterface
      */
     private function resolveClient(Options $options)
     {
-        if (class_exists(SymfonyHttplugClient::class)) {
+        if (class_exists(SymfonyPsr18Client::class) || class_exists(SymfonyHttplugClient::class)) {
             $symfonyConfig = [
                 'timeout' => $options->getHttpConnectTimeout(),
                 'max_duration' => $options->getHttpTimeout(),
@@ -120,6 +121,10 @@ final class HttpClientFactory implements HttpClientFactoryInterface
 
             if (null !== $options->getHttpProxy()) {
                 $symfonyConfig['proxy'] = $options->getHttpProxy();
+            }
+
+            if (class_exists(SymfonyPsr18Client::class)) {
+                return new SymfonyPsr18Client(SymfonyHttpClient::create($symfonyConfig));
             }
 
             return new SymfonyHttplugClient(SymfonyHttpClient::create($symfonyConfig));


### PR DESCRIPTION
To work around issue #1541, we could support the built-in Symfony `PSR-18` HTTP client and make it the preferred one to use. `Http\Client\Common\PluginClient` ensures that a non-async client gets wrapped by [`EmulatedHttpAsyncClient`](https://github.com/php-http/client-common/blob/2.x/src/EmulatedHttpAsyncClient.php) and this allows us to not have to change anything in the rest of the codebase. There is no version of Symfony that doesn't have both the `PSR-18` and Httplug client, so the possibilities of instantiating the `SymfonyHttplugClient` class should be none.

Since the `HttpTransport` is already [syncronous](https://github.com/getsentry/sentry-php/blob/bf0bdd367d56a40a47a369715fcec3688a00769b/src/Transport/HttpTransport.php#L131), I don't expect any performance penalty with this change. However, the dependency on the `php-http/message-factory` package can now be removed safely.