### PR TITLE
Improve tests of `captureCheckIn()`

### DIFF
--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -173,11 +173,9 @@ final class Hub implements HubInterface
     }
 
     /**
-     * @param string             $slug          Identifier of the Monitor
-     * @param CheckInStatus      $status        The status of the check-in
-     * @param int|float|null     $duration      The duration of the check-in
-     * @param MonitorConfig|null $monitorConfig Configuration of the Monitor
-     * @param string|null        $checkInId     A check-in ID from the previous check-in
+     * {@inheritdoc}
+     *
+     * @param int|float|null $duration
      */
     public function captureCheckIn(string $slug, CheckInStatus $status, $duration = null, ?MonitorConfig $monitorConfig = null, ?string $checkInId = null): ?string
     {

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -138,11 +138,9 @@ final class HubAdapter implements HubInterface
     }
 
     /**
-     * @param string             $slug          Identifier of the Monitor
-     * @param CheckInStatus      $status        The status of the check-in
-     * @param int|float|null     $duration      The duration of the check-in
-     * @param MonitorConfig|null $monitorConfig Configuration of the Monitor
-     * @param string|null        $checkInId     A check-in ID from the previous check-in
+     * {@inheritdoc}
+     *
+     * @param int|float|null $duration
      */
     public function captureCheckIn(string $slug, CheckInStatus $status, $duration = null, ?MonitorConfig $monitorConfig = null, ?string $checkInId = null): ?string
     {

--- a/src/State/HubInterface.php
+++ b/src/State/HubInterface.php
@@ -23,7 +23,7 @@ use Sentry\Tracing\TransactionContext;
  * stack of pairs of clients and scopes. It is the main entry point to talk
  * with the Sentry client.
  *
- * @method string|null captureCheckIn(string $slug, CheckInStatus $status, $duration = null, ?MonitorConfig $upsertMonitorConfig = null, ?string $checkInId = null) Captures a check-in
+ * @method string|null captureCheckIn(string $slug, CheckInStatus $status, int|float|null $duration = null, ?MonitorConfig $monitorConfig = null, ?string $checkInId = null) Captures a check-in
  */
 interface HubInterface
 {

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -190,34 +190,29 @@ final class FunctionsTest extends TestCase
         ];
     }
 
-    public function testCaptureCheckIn()
+    public function testCaptureCheckIn(): void
     {
-        $hub = new Hub();
-        $options = new Options([
-            'environment' => Event::DEFAULT_ENVIRONMENT,
-            'release' => '1.1.8',
-        ]);
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $hub->bindClient($client);
-        SentrySdk::setCurrentHub($hub);
-
         $checkInId = SentryUid::generate();
+        $monitorConfig = new MonitorConfig(
+            MonitorSchedule::crontab('*/5 * * * *'),
+            5,
+            30,
+            'UTC'
+        );
+
+        $hub = $this->createMock(HubInterface::class);
+        $hub->expects($this->once())
+            ->method('captureCheckIn')
+            ->with('test-crontab', CheckInStatus::ok(), 10, $monitorConfig, $checkInId)
+            ->willReturn($checkInId);
+
+        SentrySdk::setCurrentHub($hub);
 
         $this->assertSame($checkInId, captureCheckIn(
             'test-crontab',
             CheckInStatus::ok(),
             10,
-            new MonitorConfig(
-                MonitorSchedule::crontab('*/5 * * * *'),
-                5,
-                30,
-                'UTC'
-            ),
+            $monitorConfig,
             $checkInId
         ));
     }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -200,7 +200,7 @@ final class FunctionsTest extends TestCase
             'UTC'
         );
 
-        $hub = $this->createMock(HubInterface::class);
+        $hub = $this->createMock(StubHubInterface::class);
         $hub->expects($this->once())
             ->method('captureCheckIn')
             ->with('test-crontab', CheckInStatus::ok(), 10, $monitorConfig, $checkInId)
@@ -439,4 +439,9 @@ final class FunctionsTest extends TestCase
             $this->assertTrue($dynamicSamplingContext->isFrozen());
         });
     }
+}
+
+interface StubHubInterface extends HubInterface
+{
+    public function captureCheckIn(string $slug, CheckInStatus $status, $duration = null, ?MonitorConfig $monitorConfig = null, ?string $checkInId = null): ?string;
 }


### PR DESCRIPTION
Round of small improvements to the tests of the `captureCheckIn()` function. I also noticed that the method definition added to `HubInterface` was incorrect, so I fixed it.