### PR TITLE
Don't add empty HTTP fragment or query to breadcrumb data

### DIFF
--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -80,9 +80,13 @@ final class GuzzleTracingMiddleware
                         'url' => (string) $partialUri,
                         'method' => $request->getMethod(),
                         'request_body_size' => $request->getBody()->getSize(),
-                        'http.query' => $request->getUri()->getQuery(),
-                        'http.fragment' => $request->getUri()->getFragment(),
                     ];
+                    if ('' !== $request->getUri()->getQuery()) {
+                        $breadcrumbData['http.query'] = $request->getUri()->getQuery();
+                    }
+                    if ('' !== $request->getUri()->getFragment()) {
+                        $breadcrumbData['http.fragment'] = $request->getUri()->getFragment();
+                    }
 
                     if (null !== $response) {
                         $childSpan->setStatus(SpanStatus::createFromHttpStatusCode($response->getStatusCode()));

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -272,8 +272,6 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'url' => 'https://www.example.com',
                 'method' => 'GET',
                 'request_body_size' => 0,
-                'http.query' => '',
-                'http.fragment' => '',
                 'status_code' => 200,
                 'response_body_size' => 0,
             ],
@@ -300,8 +298,6 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'url' => 'https://www.example.com',
                 'method' => 'POST',
                 'request_body_size' => 10,
-                'http.query' => '',
-                'http.fragment' => '',
                 'status_code' => 403,
                 'response_body_size' => 6,
             ],
@@ -314,8 +310,6 @@ final class GuzzleTracingMiddlewareTest extends TestCase
                 'url' => 'https://www.example.com',
                 'method' => 'GET',
                 'request_body_size' => 0,
-                'http.query' => '',
-                'http.fragment' => '',
             ],
         ];
     }


### PR DESCRIPTION
The Sentry UI displays the fragment and query for each HTTP client breadcrumb, even if those elements are empty.  I suppose I could imagine a scenario where you want to highlight that the HTTP query was empty, but I would say in general, empty elements just make the view of breadcrumb data more cluttered, so here's a PR to only add them when not empty.