### PR TITLE
Merge EventHint extra parameter into Event

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -248,6 +248,10 @@ final class Client implements ClientInterface
             if (null !== $hint->stacktrace && null === $event->getStacktrace()) {
                 $event->setStacktrace($hint->stacktrace);
             }
+
+            if (!empty($hint->extra)) {
+                $event->setExtra(array_merge($event->getExtra(), $hint->extra));
+            }
         }
 
         $this->addMissingStacktraceToEvent($event);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -114,6 +114,7 @@ final class ClientTest extends TestCase
         $options = new Options([
             'before_send' => function (Event $event, ?EventHint $hintArg) use ($hint, &$beforeSendCallbackCalled) {
                 $this->assertSame($hint, $hintArg);
+                $this->assertSame($hint->extra, $event->getExtra());
 
                 $beforeSendCallbackCalled = true;
 


### PR DESCRIPTION
When using capture methods, the 'extra' parameter inside EventHint is ignored and so does not appear in Sentry reports.

```php
captureException($exception, EventHint::fromArray([
    'extra' => ['foo' => 'bar'],
]));
```