### PR TITLE
Rollback to is_a() to ignore exceptions instead of in_array()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -327,13 +327,15 @@ final class Client implements ClientInterface
             }
 
             foreach ($exceptions as $exception) {
-                if (\in_array($exception->getType(), $this->options->getIgnoreExceptions(), true)) {
-                    $this->logger->info(
-                        'The event will be discarded because it matches an entry in "ignore_exceptions".',
-                        ['event' => $event]
-                    );
+                foreach ($this->options->getIgnoreExceptions() as $ignoredException) {
+                    if (is_a($exception->getType(), $ignoredException, true)) {
+                        $this->logger->info(
+                            'The event will be discarded because it matches an entry in "ignore_exceptions".',
+                            ['event' => $event]
+                        );
 
-                    return null;
+                        return null;
+                    }
                 }
             }
         }

--- a/tests/Fixtures/code/CustomException.php
+++ b/tests/Fixtures/code/CustomException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Fixtures\code;
+
+class CustomException extends \RuntimeException
+{
+}


### PR DESCRIPTION
Hello,

https://github.com/getsentry/sentry-php/pull/1503 reintroduced `ignore_exceptions` in config and deprecated `IgnoreErrorsIntegration`. As reported in https://github.com/getsentry/sentry-php/pull/1503#discussion_r1144412115 the behavior changed : before we could list interfaces or class hierarchy to ignore, after we must list all children exceptions (dozens or more in a decent project as stated by @stayallive).

It has been merged and released in the minor release 3.17. But deprecates a feature whithout upgrade path to have the exact 
same feature in a minor release is not sem ver compliant.

Can you merge my PR and release a new patch version to rollback as before 3.17 ?

Thanks