### PR TITLE
Remove obsolete `tags` option depreaction

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -977,13 +977,6 @@ final class Options
         $resolver->setAllowedValues('context_lines', \Closure::fromCallable([$this, 'validateContextLinesOption']));
 
         $resolver->setNormalizer('dsn', \Closure::fromCallable([$this, 'normalizeDsnOption']));
-        $resolver->setNormalizer('tags', static function (SymfonyOptions $options, array $value): array {
-            if (!empty($value)) {
-                @trigger_error('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.', \E_USER_DEPRECATED);
-            }
-
-            return $value;
-        });
 
         $resolver->setNormalizer('prefixes', function (SymfonyOptions $options, array $value) {
             return array_map([$this, 'normalizeAbsolutePath'], $value);

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -203,10 +203,6 @@ final class ClientTest extends TestCase
      */
     public function testCaptureEvent(array $options, Event $event, Event $expectedEvent): void
     {
-        if (isset($options['tags'])) {
-            $this->expectDeprecation('The option "tags" is deprecated since version 3.2 and will be removed in 4.0. Either set the tags on the scope or on the event.');
-        }
-
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
             ->method('send')


### PR DESCRIPTION
I missed this in https://github.com/getsentry/sentry-php/pull/1561