### PR TITLE
Run CI tests for PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,6 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist
         if: ${{ matrix.dependencies == 'highest' }}
 
-      - name: Restrict lowest Symfony version on PHP 8.1 & 8.2
-        run: composer require symfony/options-resolver:^4.4.30 --no-update
-        if: ${{ matrix.dependencies == 'lowest' && matrix.php == '8.1' || matrix.php == '8.2' }}
-
       - name: Install lowest dependencies
         run: composer update --no-progress --no-interaction --prefer-dist --prefer-lowest
         if: ${{ matrix.dependencies == 'lowest' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           - '8.0'
           - '8.1'
           - '8.2'
+          - '8.3'
         dependencies:
           - lowest
           - highest


### PR DESCRIPTION
With a few RC's released and the final release coming up in november, it might be a good thing to start running tests on the new PHP.

I did not encounter any issues or deprecations while testing, so everything seems to be all ready 😄 