### PR TITLE
[4.x] Ignore #1599 (PHPCS update) in blame view 

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Update PHPCS (#1599)
+f8b64d330d03cbf809795beb5846b2c48175cd62


### PR DESCRIPTION
See: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view