### PR TITLE
Fix request fetcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-curl": "*",
+        "guzzlehttp/psr7": "^1.8.4|^2.1.1",
         "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0"
@@ -31,7 +32,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.4",
         "guzzlehttp/promises": "^1.0|^2.0",
-        "guzzlehttp/psr7": "^1.8.4|^2.1.1",
         "http-interop/http-factory-guzzle": "^1.0",
         "monolog/monolog": "^1.6|^2.0|^3.0",
         "nikic/php-parser": "^4.10.3",

--- a/src/Integration/RequestFetcher.php
+++ b/src/Integration/RequestFetcher.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Integration;
 
-use Http\Discovery\Psr17Factory;
+use GuzzleHttp\Psr7\ServerRequest;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
@@ -22,6 +22,6 @@ final class RequestFetcher implements RequestFetcherInterface
             return null;
         }
 
-        return (new Psr17Factory())->createServerRequestFromGlobals();
+        return ServerRequest::fromGlobals();
     }
 }


### PR DESCRIPTION
While we wanted to use https://github.com/Nyholm/psr7, their server package https://github.com/Nyholm/psr7-server seems not to be maintained anymore, hence opting for https://github.com/guzzle/psr7.