### PR TITLE
Cleanup the DSN

### DIFF
--- a/src/Dsn.php
+++ b/src/Dsn.php
@@ -33,11 +33,6 @@ final class Dsn implements \Stringable
     private $publicKey;
 
     /**
-     * @var string|null The secret key to authenticate the SDK
-     */
-    private $secretKey;
-
-    /**
      * @var string The ID of the resource to access
      */
     private $projectId;
@@ -50,21 +45,19 @@ final class Dsn implements \Stringable
     /**
      * Class constructor.
      *
-     * @param string      $scheme    The protocol to be used to access the resource
-     * @param string      $host      The host that holds the resource
-     * @param int         $port      The port on which the resource is exposed
-     * @param string      $projectId The ID of the resource to access
-     * @param string      $path      The specific resource that the web client wants to access
-     * @param string      $publicKey The public key to authenticate the SDK
-     * @param string|null $secretKey The secret key to authenticate the SDK
+     * @param string $scheme    The protocol to be used to access the resource
+     * @param string $host      The host that holds the resource
+     * @param int    $port      The port on which the resource is exposed
+     * @param string $projectId The ID of the resource to access
+     * @param string $path      The specific resource that the web client wants to access
+     * @param string $publicKey The public key to authenticate the SDK
      */
-    private function __construct(string $scheme, string $host, int $port, string $projectId, string $path, string $publicKey, ?string $secretKey)
+    private function __construct(string $scheme, string $host, int $port, string $projectId, string $path, string $publicKey)
     {
         $this->scheme = $scheme;
         $this->host = $host;
         $this->port = $port;
         $this->publicKey = $publicKey;
-        $this->secretKey = $secretKey;
         $this->path = $path;
         $this->projectId = $projectId;
     }
@@ -88,10 +81,6 @@ final class Dsn implements \Stringable
             }
         }
 
-        if (isset($parsedDsn['pass']) && empty($parsedDsn['pass'])) {
-            throw new \InvalidArgumentException(sprintf('The "%s" DSN must contain a valid secret key.', $value));
-        }
-
         if (!\in_array($parsedDsn['scheme'], ['http', 'https'], true)) {
             throw new \InvalidArgumentException(sprintf('The scheme of the "%s" DSN must be either "http" or "https".', $value));
         }
@@ -111,8 +100,7 @@ final class Dsn implements \Stringable
             $parsedDsn['port'] ?? ($parsedDsn['scheme'] === 'http' ? 80 : 443),
             $projectId,
             $path,
-            $parsedDsn['user'],
-            $parsedDsn['pass'] ?? null
+            $parsedDsn['user']
         );
     }
 
@@ -165,22 +153,6 @@ final class Dsn implements \Stringable
     }
 
     /**
-     * Gets the secret key to authenticate the SDK.
-     */
-    public function getSecretKey(): ?string
-    {
-        return $this->secretKey;
-    }
-
-    /**
-     * Returns the URL of the API for the store endpoint.
-     */
-    public function getStoreApiEndpointUrl(): string
-    {
-        return $this->getBaseEndpointUrl() . '/store/';
-    }
-
-    /**
      * Returns the URL of the API for the envelope endpoint.
      */
     public function getEnvelopeApiEndpointUrl(): string
@@ -202,10 +174,6 @@ final class Dsn implements \Stringable
     public function __toString(): string
     {
         $url = $this->scheme . '://' . $this->publicKey;
-
-        if ($this->secretKey !== null) {
-            $url .= ':' . $this->secretKey;
-        }
 
         $url .= '@' . $this->host;
 

--- a/src/Util/Http.php
+++ b/src/Util/Http.php
@@ -17,20 +17,11 @@ final class Http
      */
     public static function getRequestHeaders(Dsn $dsn, string $sdkIdentifier, string $sdkVersion): array
     {
-        $data = [
-            'sentry_version' => Client::PROTOCOL_VERSION,
-            'sentry_client' => $sdkIdentifier . '/' . $sdkVersion,
-            'sentry_key' => $dsn->getPublicKey(),
+        $authHeader = [
+            'sentry_version=' . Client::PROTOCOL_VERSION,
+            'sentry_client=' . $sdkIdentifier . '/' . $sdkVersion,
+            'sentry_key=' . $dsn->getPublicKey(),
         ];
-
-        if ($dsn->getSecretKey() !== null) {
-            $data['sentry_secret'] = $dsn->getSecretKey();
-        }
-
-        $authHeader = [];
-        foreach ($data as $headerKey => $headerValue) {
-            $authHeader[] = $headerKey . '=' . $headerValue;
-        }
 
         return [
             'Content-Type' => 'application/x-sentry-envelope',

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -21,7 +21,6 @@ final class DsnTest extends TestCase
         string $expectedHost,
         int $expectedPort,
         string $expectedPublicKey,
-        ?string $expectedSecretKey,
         string $expectedProjectId,
         string $expectedPath
     ): void {
@@ -31,7 +30,6 @@ final class DsnTest extends TestCase
         $this->assertSame($expectedHost, $dsn->getHost());
         $this->assertSame($expectedPort, $dsn->getPort());
         $this->assertSame($expectedPublicKey, $dsn->getPublicKey());
-        $this->assertSame($expectedSecretKey, $dsn->getSecretKey());
         $this->assertSame($expectedProjectId, $dsn->getProjectId(true));
         $this->assertSame($expectedPath, $dsn->getPath());
     }
@@ -44,7 +42,6 @@ final class DsnTest extends TestCase
             'example.com',
             80,
             'public',
-            null,
             '1',
             '/sentry',
         ];
@@ -55,7 +52,6 @@ final class DsnTest extends TestCase
             'example.com',
             80,
             'public',
-            null,
             '1',
             '',
         ];
@@ -66,7 +62,6 @@ final class DsnTest extends TestCase
             'example.com',
             80,
             'public',
-            'secret',
             '1',
             '',
         ];
@@ -77,7 +72,6 @@ final class DsnTest extends TestCase
             'example.com',
             80,
             'public',
-            null,
             '1',
             '',
         ];
@@ -88,7 +82,6 @@ final class DsnTest extends TestCase
             'example.com',
             8080,
             'public',
-            null,
             '1',
             '',
         ];
@@ -99,7 +92,6 @@ final class DsnTest extends TestCase
             'example.com',
             443,
             'public',
-            null,
             '1',
             '',
         ];
@@ -110,7 +102,6 @@ final class DsnTest extends TestCase
             'example.com',
             443,
             'public',
-            null,
             '1',
             '',
         ];
@@ -121,7 +112,6 @@ final class DsnTest extends TestCase
             'example.com',
             4343,
             'public',
-            null,
             '1',
             '',
         ];
@@ -155,11 +145,6 @@ final class DsnTest extends TestCase
             'The "http://:secret@example.com/sentry/1" DSN must contain a scheme, a host, a user and a path component.',
         ];
 
-        yield 'missing secret key' => [
-            'http://public:@example.com/sentry/1',
-            'The "http://public:@example.com/sentry/1" DSN must contain a valid secret key.',
-        ];
-
         yield 'missing host' => [
             '/sentry/1',
             'The "/sentry/1" DSN must contain a scheme, a host, a user and a path component.',
@@ -174,16 +159,6 @@ final class DsnTest extends TestCase
             'tcp://public:secret@example.com/1',
             'The scheme of the "tcp://public:secret@example.com/1" DSN must be either "http" or "https".',
         ];
-    }
-
-    /**
-     * @dataProvider getStoreApiEndpointUrlDataProvider
-     */
-    public function testGetStoreApiEndpointUrl(string $value, string $expectedUrl): void
-    {
-        $dsn = Dsn::createFromString($value);
-
-        $this->assertSame($expectedUrl, $dsn->getStoreApiEndpointUrl());
     }
 
     public static function getStoreApiEndpointUrlDataProvider(): \Generator
@@ -264,7 +239,6 @@ final class DsnTest extends TestCase
     {
         return [
             ['http://public@example.com/sentry/1'],
-            ['http://public:secret@example.com/sentry/1'],
             ['http://public@example.com/1'],
             ['http://public@example.com:8080/sentry/1'],
             ['https://public@example.com/sentry/1'],

--- a/tests/Util/HttpTest.php
+++ b/tests/Util/HttpTest.php
@@ -29,16 +29,6 @@ final class HttpTest extends TestCase
                 'X-Sentry-Auth' => 'Sentry sentry_version=7, sentry_client=sentry.sdk.identifier/1.2.3, sentry_key=public',
             ],
         ];
-
-        yield [
-            Dsn::createFromString('http://public:secret@example.com/1'),
-            'sentry.sdk.identifier',
-            '1.2.3',
-            [
-                'Content-Type' => 'application/x-sentry-envelope',
-                'X-Sentry-Auth' => 'Sentry sentry_version=7, sentry_client=sentry.sdk.identifier/1.2.3, sentry_key=public, sentry_secret=secret',
-            ],
-        ];
     }
 
     /**


### PR DESCRIPTION
The private key in DSNs is not supported on the `/envelope` endpoint, and DSNs do not contain this part for a very long time now.