### PR TITLE
New seralizer logic

### DIFF
--- a/src/Serializer/EnvelopItems/CheckInItem.php
+++ b/src/Serializer/EnvelopItems/CheckInItem.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer\EnvelopItems;
+
+use Sentry\Event;
+use Sentry\Util\JSON;
+
+/**
+ * @internal
+ */
+class CheckInItem implements EnvelopeItemInterface
+{
+    public static function toEnvelopeItem(Event $event): string
+    {
+        $header = [
+            'type' => (string) $event->getType(),
+            'content_type' => 'application/json',
+        ];
+
+        $payload = [];
+
+        $checkIn = $event->getCheckIn();
+        if ($checkIn !== null) {
+            $payload = [
+                'check_in_id' => $checkIn->getId(),
+                'monitor_slug' => $checkIn->getMonitorSlug(),
+                'status' => (string) $checkIn->getStatus(),
+                'duration' => $checkIn->getDuration(),
+                'release' => $checkIn->getRelease(),
+                'environment' => $checkIn->getEnvironment(),
+            ];
+
+            if ($checkIn->getMonitorConfig() !== null) {
+                $payload['monitor_config'] = $checkIn->getMonitorConfig()->toArray();
+            }
+
+            if (!empty($event->getContexts()['trace'])) {
+                $payload['contexts']['trace'] = $event->getContexts()['trace'];
+            }
+        }
+
+        return sprintf("%s\n%s", JSON::encode($header), JSON::encode($payload));
+    }
+}

--- a/src/Serializer/EnvelopItems/EnvelopeItemInterface.php
+++ b/src/Serializer/EnvelopItems/EnvelopeItemInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer\EnvelopItems;
+
+use Sentry\Event;
+
+/**
+ * @internal
+ */
+interface EnvelopeItemInterface
+{
+    public static function toEnvelopeItem(Event $event): string;
+}

--- a/src/Serializer/EnvelopItems/EventItem.php
+++ b/src/Serializer/EnvelopItems/EventItem.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer\EnvelopItems;
+
+use Sentry\Event;
+use Sentry\ExceptionDataBag;
+use Sentry\Frame;
+use Sentry\Serializer\Traits\BreadcrumbSeralizerTrait;
+use Sentry\Util\JSON;
+
+/**
+ * @internal
+ */
+class EventItem implements EnvelopeItemInterface
+{
+    use BreadcrumbSeralizerTrait;
+
+    public static function toEnvelopeItem(Event $event): string
+    {
+        $header = [
+            'type' => (string) $event->getType(),
+            'content_type' => 'application/json',
+        ];
+
+        $payload = [
+            'timestamp' => $event->getTimestamp(),
+            'platform' => 'php',
+            'sdk' => [
+                'name' => $event->getSdkIdentifier(),
+                'version' => $event->getSdkVersion(),
+            ],
+        ];
+
+        if ($event->getStartTimestamp() !== null) {
+            $payload['start_timestamp'] = $event->getStartTimestamp();
+        }
+
+        if ($event->getLevel() !== null) {
+            $payload['level'] = (string) $event->getLevel();
+        }
+
+        // TODO(michi) remove
+        // if ($event->getLogger() !== null) {
+        //     $payload['logger'] = $event->getLogger();
+        // }
+
+        if ($event->getTransaction() !== null) {
+            $payload['transaction'] = $event->getTransaction();
+        }
+
+        if ($event->getServerName() !== null) {
+            $payload['server_name'] = $event->getServerName();
+        }
+
+        if ($event->getRelease() !== null) {
+            $payload['release'] = $event->getRelease();
+        }
+
+        if ($event->getEnvironment() !== null) {
+            $payload['environment'] = $event->getEnvironment();
+        }
+
+        if (!empty($event->getFingerprint())) {
+            $payload['fingerprint'] = $event->getFingerprint();
+        }
+
+        if (!empty($event->getModules())) {
+            $payload['modules'] = $event->getModules();
+        }
+
+        if (!empty($event->getExtra())) {
+            $payload['extra'] = $event->getExtra();
+        }
+
+        if (!empty($event->getTags())) {
+            $payload['tags'] = $event->getTags();
+        }
+
+        $user = $event->getUser();
+        if ($user !== null) {
+            $payload['user'] = array_merge($user->getMetadata(), [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+                'ip_address' => $user->getIpAddress(),
+                'segment' => $user->getSegment(),
+            ]);
+        }
+
+        $osContext = $event->getOsContext();
+        if ($osContext !== null) {
+            $payload['contexts']['os'] = [
+                'name' => $osContext->getName(),
+                'version' => $osContext->getVersion(),
+                'build' => $osContext->getBuild(),
+                'kernel_version' => $osContext->getKernelVersion(),
+            ];
+        }
+
+        $runtimeContext = $event->getRuntimeContext();
+        if ($runtimeContext !== null) {
+            $payload['contexts']['runtime'] = [
+                'name' => $runtimeContext->getName(),
+                'version' => $runtimeContext->getVersion(),
+            ];
+        }
+
+        if (!empty($event->getContexts())) {
+            $payload['contexts'] = array_merge($payload['contexts'] ?? [], $event->getContexts());
+        }
+
+        if (!empty($event->getBreadcrumbs())) {
+            $payload['breadcrumbs']['values'] = array_map([self::class, 'serializeBreadcrumb'], $event->getBreadcrumbs());
+        }
+
+        if (!empty($event->getRequest())) {
+            $payload['request'] = $event->getRequest();
+        }
+
+        if ($event->getMessage() !== null) {
+            if (empty($event->getMessageParams())) {
+                $payload['message'] = $event->getMessage();
+            } else {
+                $payload['message'] = [
+                    'message' => $event->getMessage(),
+                    'params' => $event->getMessageParams(),
+                    'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
+                ];
+            }
+        }
+
+        $exceptions = $event->getExceptions();
+        for ($i = \count($exceptions) - 1; $i >= 0; --$i) {
+            $payload['exception']['values'][] = self::serializeException($exceptions[$i]);
+        }
+
+        $stacktrace = $event->getStacktrace();
+        if ($stacktrace !== null) {
+            $payload['stacktrace'] = [
+                'frames' => array_map([self::class, 'serializeStacktraceFrame'], $stacktrace->getFrames()),
+            ];
+        }
+
+        return sprintf("%s\n%s", JSON::encode($header), JSON::encode($payload));
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     type: string,
+     *     value: string,
+     *     stacktrace?: array{
+     *         frames: array<array<string, mixed>>
+     *     },
+     *     mechanism?: array{
+     *         type: string,
+     *         handled: boolean,
+     *         data?: array<string, mixed>
+     *     }
+     * }
+     */
+    protected static function serializeException(ExceptionDataBag $exception): array
+    {
+        $exceptionMechanism = $exception->getMechanism();
+        $exceptionStacktrace = $exception->getStacktrace();
+        $result = [
+            'type' => $exception->getType(),
+            'value' => $exception->getValue(),
+        ];
+
+        if ($exceptionStacktrace !== null) {
+            $result['stacktrace'] = [
+                'frames' => array_map([self::class, 'serializeStacktraceFrame'], $exceptionStacktrace->getFrames()),
+            ];
+        }
+
+        if ($exceptionMechanism !== null) {
+            $result['mechanism'] = [
+                'type' => $exceptionMechanism->getType(),
+                'handled' => $exceptionMechanism->isHandled(),
+            ];
+
+            if ($exceptionMechanism->getData() !== []) {
+                $result['mechanism']['data'] = $exceptionMechanism->getData();
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     filename: string,
+     *     lineno: int,
+     *     in_app: bool,
+     *     abs_path?: string,
+     *     function?: string,
+     *     raw_function?: string,
+     *     pre_context?: string[],
+     *     context_line?: string,
+     *     post_context?: string[],
+     *     vars?: array<string, mixed>
+     * }
+     */
+    protected static function serializeStacktraceFrame(Frame $frame): array
+    {
+        $result = [
+            'filename' => $frame->getFile(),
+            'lineno' => $frame->getLine(),
+            'in_app' => $frame->isInApp(),
+        ];
+
+        if ($frame->getAbsoluteFilePath() !== null) {
+            $result['abs_path'] = $frame->getAbsoluteFilePath();
+        }
+
+        if ($frame->getFunctionName() !== null) {
+            $result['function'] = $frame->getFunctionName();
+        }
+
+        if ($frame->getRawFunctionName() !== null) {
+            $result['raw_function'] = $frame->getRawFunctionName();
+        }
+
+        if (!empty($frame->getPreContext())) {
+            $result['pre_context'] = $frame->getPreContext();
+        }
+
+        if ($frame->getContextLine() !== null) {
+            $result['context_line'] = $frame->getContextLine();
+        }
+
+        if (!empty($frame->getPostContext())) {
+            $result['post_context'] = $frame->getPostContext();
+        }
+
+        if (!empty($frame->getVars())) {
+            $result['vars'] = $frame->getVars();
+        }
+
+        return $result;
+    }
+}

--- a/src/Serializer/EnvelopItems/EventItem.php
+++ b/src/Serializer/EnvelopItems/EventItem.php
@@ -41,11 +41,6 @@ class EventItem implements EnvelopeItemInterface
             $payload['level'] = (string) $event->getLevel();
         }
 
-        // TODO(michi) remove
-        // if ($event->getLogger() !== null) {
-        //     $payload['logger'] = $event->getLogger();
-        // }
-
         if ($event->getTransaction() !== null) {
             $payload['transaction'] = $event->getTransaction();
         }

--- a/src/Serializer/EnvelopItems/ProfileItem.php
+++ b/src/Serializer/EnvelopItems/ProfileItem.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer\EnvelopItems;
+
+use Sentry\Event;
+use Sentry\Profiling\Profile;
+use Sentry\Util\JSON;
+
+/**
+ * @internal
+ */
+class ProfileItem implements EnvelopeItemInterface
+{
+    public static function toEnvelopeItem(Event $event): string
+    {
+        $header = [
+            'type' => 'profile',
+            'content_type' => 'application/json',
+        ];
+
+        $profile = $event->getSdkMetadata('profile');
+        if (!$profile instanceof Profile) {
+            return '';
+        }
+
+        $payload = $profile->getFormattedData($event);
+        if ($payload === null) {
+            return '';
+        }
+
+        return sprintf("%s\n%s", JSON::encode($header), JSON::encode($payload));
+    }
+}

--- a/src/Serializer/EnvelopItems/TransactionItem.php
+++ b/src/Serializer/EnvelopItems/TransactionItem.php
@@ -41,11 +41,6 @@ class TransactionItem implements EnvelopeItemInterface
             $payload['level'] = (string) $event->getLevel();
         }
 
-        // TODO(michi) remove
-        // if ($event->getLogger() !== null) {
-        //     $payload['logger'] = $event->getLogger();
-        // }
-
         if ($event->getTransaction() !== null) {
             $payload['transaction'] = $event->getTransaction();
         }
@@ -118,19 +113,6 @@ class TransactionItem implements EnvelopeItemInterface
         if (!empty($event->getRequest())) {
             $payload['request'] = $event->getRequest();
         }
-
-        // TODO(michi) clarify
-        // if ($event->getMessage() !== null) {
-        //     if (empty($event->getMessageParams())) {
-        //         $payload['message'] = $event->getMessage();
-        //     } else {
-        //         $payload['message'] = [
-        //             'message' => $event->getMessage(),
-        //             'params' => $event->getMessageParams(),
-        //             'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
-        //         ];
-        //     }
-        // }
 
         $payload['spans'] = array_values(array_map([self::class, 'serializeSpan'], $event->getSpans()));
 

--- a/src/Serializer/EnvelopItems/TransactionItem.php
+++ b/src/Serializer/EnvelopItems/TransactionItem.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer\EnvelopItems;
+
+use Sentry\Event;
+use Sentry\Serializer\Traits\BreadcrumbSeralizerTrait;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\TransactionMetadata;
+use Sentry\Util\JSON;
+
+/**
+ * @internal
+ */
+class TransactionItem implements EnvelopeItemInterface
+{
+    use BreadcrumbSeralizerTrait;
+
+    public static function toEnvelopeItem(Event $event): string
+    {
+        $header = [
+            'type' => (string) $event->getType(),
+            'content_type' => 'application/json',
+        ];
+
+        $payload = [
+            'timestamp' => $event->getTimestamp(),
+            'platform' => 'php',
+            'sdk' => [
+                'name' => $event->getSdkIdentifier(),
+                'version' => $event->getSdkVersion(),
+            ],
+        ];
+
+        if ($event->getStartTimestamp() !== null) {
+            $payload['start_timestamp'] = $event->getStartTimestamp();
+        }
+
+        if ($event->getLevel() !== null) {
+            $payload['level'] = (string) $event->getLevel();
+        }
+
+        // TODO(michi) remove
+        // if ($event->getLogger() !== null) {
+        //     $payload['logger'] = $event->getLogger();
+        // }
+
+        if ($event->getTransaction() !== null) {
+            $payload['transaction'] = $event->getTransaction();
+        }
+
+        if ($event->getServerName() !== null) {
+            $payload['server_name'] = $event->getServerName();
+        }
+
+        if ($event->getRelease() !== null) {
+            $payload['release'] = $event->getRelease();
+        }
+
+        if ($event->getEnvironment() !== null) {
+            $payload['environment'] = $event->getEnvironment();
+        }
+
+        if (!empty($event->getFingerprint())) {
+            $payload['fingerprint'] = $event->getFingerprint();
+        }
+
+        if (!empty($event->getModules())) {
+            $payload['modules'] = $event->getModules();
+        }
+
+        if (!empty($event->getExtra())) {
+            $payload['extra'] = $event->getExtra();
+        }
+
+        if (!empty($event->getTags())) {
+            $payload['tags'] = $event->getTags();
+        }
+
+        $user = $event->getUser();
+        if ($user !== null) {
+            $payload['user'] = array_merge($user->getMetadata(), [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+                'ip_address' => $user->getIpAddress(),
+                'segment' => $user->getSegment(),
+            ]);
+        }
+
+        $osContext = $event->getOsContext();
+        if ($osContext !== null) {
+            $payload['contexts']['os'] = [
+                'name' => $osContext->getName(),
+                'version' => $osContext->getVersion(),
+                'build' => $osContext->getBuild(),
+                'kernel_version' => $osContext->getKernelVersion(),
+            ];
+        }
+
+        $runtimeContext = $event->getRuntimeContext();
+        if ($runtimeContext !== null) {
+            $payload['contexts']['runtime'] = [
+                'name' => $runtimeContext->getName(),
+                'version' => $runtimeContext->getVersion(),
+            ];
+        }
+
+        if (!empty($event->getContexts())) {
+            $payload['contexts'] = array_merge($payload['contexts'] ?? [], $event->getContexts());
+        }
+
+        if (!empty($event->getBreadcrumbs())) {
+            $payload['breadcrumbs']['values'] = array_map([self::class, 'serializeBreadcrumb'], $event->getBreadcrumbs());
+        }
+
+        if (!empty($event->getRequest())) {
+            $payload['request'] = $event->getRequest();
+        }
+
+        // TODO(michi) clarify
+        // if ($event->getMessage() !== null) {
+        //     if (empty($event->getMessageParams())) {
+        //         $payload['message'] = $event->getMessage();
+        //     } else {
+        //         $payload['message'] = [
+        //             'message' => $event->getMessage(),
+        //             'params' => $event->getMessageParams(),
+        //             'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
+        //         ];
+        //     }
+        // }
+
+        $payload['spans'] = array_values(array_map([self::class, 'serializeSpan'], $event->getSpans()));
+
+        $transactionMetadata = $event->getSdkMetadata('transaction_metadata');
+        if ($transactionMetadata instanceof TransactionMetadata) {
+            $payload['transaction_info']['source'] = (string) $transactionMetadata->getSource();
+        }
+
+        return sprintf("%s\n%s", JSON::encode($header), JSON::encode($payload));
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     span_id: string,
+     *     trace_id: string,
+     *     parent_span_id?: string,
+     *     start_timestamp: float,
+     *     timestamp?: float,
+     *     status?: string,
+     *     description?: string,
+     *     op?: string,
+     *     data?: array<string, mixed>,
+     *     tags?: array<string, string>
+     * }
+     */
+    protected static function serializeSpan(Span $span): array
+    {
+        $result = [
+            'span_id' => (string) $span->getSpanId(),
+            'trace_id' => (string) $span->getTraceId(),
+            'start_timestamp' => $span->getStartTimestamp(),
+        ];
+
+        if ($span->getParentSpanId() !== null) {
+            $result['parent_span_id'] = (string) $span->getParentSpanId();
+        }
+
+        if ($span->getEndTimestamp() !== null) {
+            $result['timestamp'] = $span->getEndTimestamp();
+        }
+
+        if ($span->getStatus() !== null) {
+            $result['status'] = (string) $span->getStatus();
+        }
+
+        if ($span->getDescription() !== null) {
+            $result['description'] = $span->getDescription();
+        }
+
+        if ($span->getOp() !== null) {
+            $result['op'] = $span->getOp();
+        }
+
+        if (!empty($span->getData())) {
+            $result['data'] = $span->getData();
+        }
+
+        if (!empty($span->getTags())) {
+            $result['tags'] = $span->getTags();
+        }
+
+        return $result;
+    }
+}

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace Sentry\Serializer;
 
-use Sentry\Breadcrumb;
 use Sentry\Event;
 use Sentry\EventType;
-use Sentry\ExceptionDataBag;
-use Sentry\Frame;
 use Sentry\Options;
-use Sentry\Profiling\Profile;
+use Sentry\Serializer\EnvelopItems\CheckInItem;
+use Sentry\Serializer\EnvelopItems\EventItem;
+use Sentry\Serializer\EnvelopItems\ProfileItem;
+use Sentry\Serializer\EnvelopItems\TransactionItem;
 use Sentry\Tracing\DynamicSamplingContext;
-use Sentry\Tracing\Span;
-use Sentry\Tracing\TransactionMetadata;
 use Sentry\Util\JSON;
 
 /**
@@ -39,199 +37,6 @@ final class PayloadSerializer implements PayloadSerializerInterface
      */
     public function serialize(Event $event): string
     {
-        if (EventType::transaction() === $event->getType()) {
-            $transactionEnvelope = $this->serializeAsEnvelope($event);
-
-            // Attach a new envelope item containing the profile data
-            if ($event->getSdkMetadata('profile') !== null) {
-                $profileEnvelope = $this->seralizeProfileAsEnvelope($event);
-                if ($profileEnvelope !== null) {
-                    return sprintf("%s\n%s", $transactionEnvelope, $profileEnvelope);
-                }
-            }
-
-            return $transactionEnvelope;
-        }
-
-        return $this->serializeAsEnvelope($event);
-    }
-
-    private function serializeAsEvent(Event $event): string
-    {
-        $result = $this->toArray($event);
-
-        return JSON::encode($result);
-    }
-
-    private function serializeAsCheckInEvent(Event $event): string
-    {
-        $result = [];
-
-        $checkIn = $event->getCheckIn();
-        if ($checkIn !== null) {
-            $result = [
-                'check_in_id' => $checkIn->getId(),
-                'monitor_slug' => $checkIn->getMonitorSlug(),
-                'status' => (string) $checkIn->getStatus(),
-                'duration' => $checkIn->getDuration(),
-                'release' => $checkIn->getRelease(),
-                'environment' => $checkIn->getEnvironment(),
-            ];
-
-            if ($checkIn->getMonitorConfig() !== null) {
-                $result['monitor_config'] = $checkIn->getMonitorConfig()->toArray();
-            }
-
-            if (!empty($event->getContexts()['trace'])) {
-                $result['contexts']['trace'] = $event->getContexts()['trace'];
-            }
-        }
-
-        return JSON::encode($result);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function toArray(Event $event): array
-    {
-        $result = [
-            'event_id' => (string) $event->getId(),
-            'timestamp' => $event->getTimestamp(),
-            'platform' => 'php',
-            'sdk' => [
-                'name' => $event->getSdkIdentifier(),
-                'version' => $event->getSdkVersion(),
-            ],
-        ];
-
-        if ($event->getStartTimestamp() !== null) {
-            $result['start_timestamp'] = $event->getStartTimestamp();
-        }
-
-        if ($event->getLevel() !== null) {
-            $result['level'] = (string) $event->getLevel();
-        }
-
-        if ($event->getLogger() !== null) {
-            $result['logger'] = $event->getLogger();
-        }
-
-        if ($event->getTransaction() !== null) {
-            $result['transaction'] = $event->getTransaction();
-        }
-
-        if ($event->getServerName() !== null) {
-            $result['server_name'] = $event->getServerName();
-        }
-
-        if ($event->getRelease() !== null) {
-            $result['release'] = $event->getRelease();
-        }
-
-        if ($event->getEnvironment() !== null) {
-            $result['environment'] = $event->getEnvironment();
-        }
-
-        if (!empty($event->getFingerprint())) {
-            $result['fingerprint'] = $event->getFingerprint();
-        }
-
-        if (!empty($event->getModules())) {
-            $result['modules'] = $event->getModules();
-        }
-
-        if (!empty($event->getExtra())) {
-            $result['extra'] = $event->getExtra();
-        }
-
-        if (!empty($event->getTags())) {
-            $result['tags'] = $event->getTags();
-        }
-
-        $user = $event->getUser();
-
-        if ($user !== null) {
-            $result['user'] = array_merge($user->getMetadata(), [
-                'id' => $user->getId(),
-                'username' => $user->getUsername(),
-                'email' => $user->getEmail(),
-                'ip_address' => $user->getIpAddress(),
-                'segment' => $user->getSegment(),
-            ]);
-        }
-
-        $osContext = $event->getOsContext();
-        $runtimeContext = $event->getRuntimeContext();
-
-        if ($osContext !== null) {
-            $result['contexts']['os'] = [
-                'name' => $osContext->getName(),
-                'version' => $osContext->getVersion(),
-                'build' => $osContext->getBuild(),
-                'kernel_version' => $osContext->getKernelVersion(),
-            ];
-        }
-
-        if ($runtimeContext !== null) {
-            $result['contexts']['runtime'] = [
-                'name' => $runtimeContext->getName(),
-                'version' => $runtimeContext->getVersion(),
-            ];
-        }
-
-        if (!empty($event->getContexts())) {
-            $result['contexts'] = array_merge($result['contexts'] ?? [], $event->getContexts());
-        }
-
-        if (!empty($event->getBreadcrumbs())) {
-            $result['breadcrumbs']['values'] = array_map([$this, 'serializeBreadcrumb'], $event->getBreadcrumbs());
-        }
-
-        if (!empty($event->getRequest())) {
-            $result['request'] = $event->getRequest();
-        }
-
-        if ($event->getMessage() !== null) {
-            if (empty($event->getMessageParams())) {
-                $result['message'] = $event->getMessage();
-            } else {
-                $result['message'] = [
-                    'message' => $event->getMessage(),
-                    'params' => $event->getMessageParams(),
-                    'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
-                ];
-            }
-        }
-
-        $exceptions = $event->getExceptions();
-
-        for ($i = \count($exceptions) - 1; $i >= 0; --$i) {
-            $result['exception']['values'][] = $this->serializeException($exceptions[$i]);
-        }
-
-        if (EventType::transaction() === $event->getType()) {
-            $result['spans'] = array_values(array_map([$this, 'serializeSpan'], $event->getSpans()));
-
-            $transactionMetadata = $event->getSdkMetadata('transaction_metadata');
-            if ($transactionMetadata instanceof TransactionMetadata) {
-                $result['transaction_info']['source'] = (string) $transactionMetadata->getSource();
-            }
-        }
-
-        $stacktrace = $event->getStacktrace();
-
-        if ($stacktrace !== null) {
-            $result['stacktrace'] = [
-                'frames' => array_map([$this, 'serializeStacktraceFrame'], $stacktrace->getFrames()),
-            ];
-        }
-
-        return $result;
-    }
-
-    private function serializeAsEnvelope(Event $event): string
-    {
         // @see https://develop.sentry.dev/sdk/envelopes/#envelope-headers
         $envelopeHeader = [
             'event_id' => (string) $event->getId(),
@@ -244,7 +49,6 @@ final class PayloadSerializer implements PayloadSerializerInterface
         ];
 
         $dynamicSamplingContext = $event->getSdkMetadata('dynamic_sampling_context');
-
         if ($dynamicSamplingContext instanceof DynamicSamplingContext) {
             $entries = $dynamicSamplingContext->getEntries();
 
@@ -253,224 +57,28 @@ final class PayloadSerializer implements PayloadSerializerInterface
             }
         }
 
-        $itemHeader = [
-            'type' => (string) $event->getType(),
-            'content_type' => 'application/json',
-        ];
+        $items = '';
 
-        if (EventType::checkIn() === $event->getType()) {
-            $seralizedEvent = $this->serializeAsCheckInEvent($event);
-        } else {
-            $seralizedEvent = $this->serializeAsEvent($event);
+        switch ($event->getType()) {
+            case EventType::event():
+                $items = EventItem::toEnvelopeItem($event);
+                break;
+            case EventType::transaction():
+                $transactionItem = TransactionItem::toEnvelopeItem($event);
+                if ($event->getSdkMetadata('profile') !== null) {
+                    $profileItem = ProfileItem::toEnvelopeItem($event);
+                    if ($profileItem !== '') {
+                        $items = sprintf("%s\n%s", $transactionItem, $profileItem);
+                        break;
+                    }
+                }
+                $items = $transactionItem;
+                break;
+            case EventType::checkIn():
+                $items = CheckInItem::toEnvelopeItem($event);
+                break;
         }
 
-        return sprintf("%s\n%s\n%s", JSON::encode($envelopeHeader), JSON::encode($itemHeader), $seralizedEvent);
-    }
-
-    private function seralizeProfileAsEnvelope(Event $event): ?string
-    {
-        $itemHeader = [
-            'type' => 'profile',
-            'content_type' => 'application/json',
-        ];
-
-        $profile = $event->getSdkMetadata('profile');
-        if (!$profile instanceof Profile) {
-            return null;
-        }
-
-        $profileData = $profile->getFormattedData($event);
-        if ($profileData === null) {
-            return null;
-        }
-
-        return sprintf("%s\n%s", JSON::encode($itemHeader), JSON::encode($profileData));
-    }
-
-    /**
-     * @return array<string, mixed>
-     *
-     * @psalm-return array{
-     *     type: string,
-     *     category: string,
-     *     level: string,
-     *     timestamp: float,
-     *     message?: string,
-     *     data?: array<string, mixed>
-     * }
-     */
-    private function serializeBreadcrumb(Breadcrumb $breadcrumb): array
-    {
-        $result = [
-            'type' => $breadcrumb->getType(),
-            'category' => $breadcrumb->getCategory(),
-            'level' => $breadcrumb->getLevel(),
-            'timestamp' => $breadcrumb->getTimestamp(),
-        ];
-
-        if ($breadcrumb->getMessage() !== null) {
-            $result['message'] = $breadcrumb->getMessage();
-        }
-
-        if (!empty($breadcrumb->getMetadata())) {
-            $result['data'] = $breadcrumb->getMetadata();
-        }
-
-        return $result;
-    }
-
-    /**
-     * @return array<string, mixed>
-     *
-     * @psalm-return array{
-     *     type: string,
-     *     value: string,
-     *     stacktrace?: array{
-     *         frames: array<array<string, mixed>>
-     *     },
-     *     mechanism?: array{
-     *         type: string,
-     *         handled: boolean,
-     *         data?: array<string, mixed>
-     *     }
-     * }
-     */
-    private function serializeException(ExceptionDataBag $exception): array
-    {
-        $exceptionMechanism = $exception->getMechanism();
-        $exceptionStacktrace = $exception->getStacktrace();
-        $result = [
-            'type' => $exception->getType(),
-            'value' => $exception->getValue(),
-        ];
-
-        if ($exceptionStacktrace !== null) {
-            $result['stacktrace'] = [
-                'frames' => array_map([$this, 'serializeStacktraceFrame'], $exceptionStacktrace->getFrames()),
-            ];
-        }
-
-        if ($exceptionMechanism !== null) {
-            $result['mechanism'] = [
-                'type' => $exceptionMechanism->getType(),
-                'handled' => $exceptionMechanism->isHandled(),
-            ];
-
-            if ($exceptionMechanism->getData() !== []) {
-                $result['mechanism']['data'] = $exceptionMechanism->getData();
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * @return array<string, mixed>
-     *
-     * @psalm-return array{
-     *     filename: string,
-     *     lineno: int,
-     *     in_app: bool,
-     *     abs_path?: string,
-     *     function?: string,
-     *     raw_function?: string,
-     *     pre_context?: string[],
-     *     context_line?: string,
-     *     post_context?: string[],
-     *     vars?: array<string, mixed>
-     * }
-     */
-    private function serializeStacktraceFrame(Frame $frame): array
-    {
-        $result = [
-            'filename' => $frame->getFile(),
-            'lineno' => $frame->getLine(),
-            'in_app' => $frame->isInApp(),
-        ];
-
-        if ($frame->getAbsoluteFilePath() !== null) {
-            $result['abs_path'] = $frame->getAbsoluteFilePath();
-        }
-
-        if ($frame->getFunctionName() !== null) {
-            $result['function'] = $frame->getFunctionName();
-        }
-
-        if ($frame->getRawFunctionName() !== null) {
-            $result['raw_function'] = $frame->getRawFunctionName();
-        }
-
-        if (!empty($frame->getPreContext())) {
-            $result['pre_context'] = $frame->getPreContext();
-        }
-
-        if ($frame->getContextLine() !== null) {
-            $result['context_line'] = $frame->getContextLine();
-        }
-
-        if (!empty($frame->getPostContext())) {
-            $result['post_context'] = $frame->getPostContext();
-        }
-
-        if (!empty($frame->getVars())) {
-            $result['vars'] = $frame->getVars();
-        }
-
-        return $result;
-    }
-
-    /**
-     * @return array<string, mixed>
-     *
-     * @psalm-return array{
-     *     span_id: string,
-     *     trace_id: string,
-     *     parent_span_id?: string,
-     *     start_timestamp: float,
-     *     timestamp?: float,
-     *     status?: string,
-     *     description?: string,
-     *     op?: string,
-     *     data?: array<string, mixed>,
-     *     tags?: array<string, string>
-     * }
-     */
-    private function serializeSpan(Span $span): array
-    {
-        $result = [
-            'span_id' => (string) $span->getSpanId(),
-            'trace_id' => (string) $span->getTraceId(),
-            'start_timestamp' => $span->getStartTimestamp(),
-        ];
-
-        if ($span->getParentSpanId() !== null) {
-            $result['parent_span_id'] = (string) $span->getParentSpanId();
-        }
-
-        if ($span->getEndTimestamp() !== null) {
-            $result['timestamp'] = $span->getEndTimestamp();
-        }
-
-        if ($span->getStatus() !== null) {
-            $result['status'] = (string) $span->getStatus();
-        }
-
-        if ($span->getDescription() !== null) {
-            $result['description'] = $span->getDescription();
-        }
-
-        if ($span->getOp() !== null) {
-            $result['op'] = $span->getOp();
-        }
-
-        if (!empty($span->getData())) {
-            $result['data'] = $span->getData();
-        }
-
-        if (!empty($span->getTags())) {
-            $result['tags'] = $span->getTags();
-        }
-
-        return $result;
+        return sprintf("%s\n%s", JSON::encode($envelopeHeader), $items);
     }
 }

--- a/src/Serializer/PayloadSerializer.php
+++ b/src/Serializer/PayloadSerializer.php
@@ -53,15 +53,7 @@ final class PayloadSerializer implements PayloadSerializerInterface
             return $transactionEnvelope;
         }
 
-        if (EventType::checkIn() === $event->getType()) {
-            return $this->serializeAsEnvelope($event);
-        }
-
-        if ($this->options->isTracingEnabled()) {
-            return $this->serializeAsEnvelope($event);
-        }
-
-        return $this->serializeAsEvent($event);
+        return $this->serializeAsEnvelope($event);
     }
 
     private function serializeAsEvent(Event $event): string
@@ -224,26 +216,6 @@ final class PayloadSerializer implements PayloadSerializerInterface
             $transactionMetadata = $event->getSdkMetadata('transaction_metadata');
             if ($transactionMetadata instanceof TransactionMetadata) {
                 $result['transaction_info']['source'] = (string) $transactionMetadata->getSource();
-            }
-        }
-
-        /**
-         * In case of error events, with tracing being disabled, we set the Replay ID
-         * as a context into the payload.
-         */
-        if (
-            EventType::event() === $event->getType()
-            && !$this->options->isTracingEnabled()
-        ) {
-            $dynamicSamplingContext = $event->getSdkMetadata('dynamic_sampling_context');
-            if ($dynamicSamplingContext instanceof DynamicSamplingContext) {
-                $replayId = $dynamicSamplingContext->get('replay_id');
-
-                if ($replayId !== null) {
-                    $result['contexts']['replay'] = [
-                        'replay_id' => $replayId,
-                    ];
-                }
             }
         }
 

--- a/src/Serializer/Traits/BreadcrumbSeralizerTrait.php
+++ b/src/Serializer/Traits/BreadcrumbSeralizerTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Serializer\Traits;
+
+use Sentry\Breadcrumb;
+
+/**
+ * @internal
+ */
+trait BreadcrumbSeralizerTrait
+{
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-return array{
+     *     type: string,
+     *     category: string,
+     *     level: string,
+     *     timestamp: float,
+     *     message?: string,
+     *     data?: array<string, mixed>
+     * }
+     */
+    protected static function serializeBreadcrumb(Breadcrumb $breadcrumb): array
+    {
+        $result = [
+            'type' => $breadcrumb->getType(),
+            'category' => $breadcrumb->getCategory(),
+            'level' => $breadcrumb->getLevel(),
+            'timestamp' => $breadcrumb->getTimestamp(),
+        ];
+
+        if ($breadcrumb->getMessage() !== null) {
+            $result['message'] = $breadcrumb->getMessage();
+        }
+
+        if (!empty($breadcrumb->getMetadata())) {
+            $result['data'] = $breadcrumb->getMetadata();
+        }
+
+        return $result;
+    }
+}

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -13,7 +13,6 @@ use Sentry\Context\OsContext;
 use Sentry\Context\RuntimeContext;
 use Sentry\Event;
 use Sentry\EventId;
-use Sentry\EventType;
 use Sentry\ExceptionDataBag;
 use Sentry\ExceptionMechanism;
 use Sentry\Frame;
@@ -40,34 +39,6 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 final class PayloadSerializerTest extends TestCase
 {
     /**
-     * @dataProvider serializeAsJsonDataProvider
-     */
-    public function testSerializeAsJson(Event $event, string $expectedResult, bool $isOutputJson): void
-    {
-        ClockMock::withClockMock(1597790835);
-
-        $serializer = new PayloadSerializer(new Options([
-            'dsn' => 'http://public@example.com/sentry/1',
-        ]));
-
-        $result = $serializer->serialize($event);
-
-        if (
-            EventType::transaction() !== $event->getType()
-            && EventType::checkIn() !== $event->getType()
-        ) {
-            $resultArray = $serializer->toArray($event);
-            $this->assertJsonStringEqualsJsonString($result, json_encode($resultArray));
-        }
-
-        if ($isOutputJson) {
-            $this->assertJsonStringEqualsJsonString($expectedResult, $result);
-        } else {
-            $this->assertSame($expectedResult, $result);
-        }
-    }
-
-    /**
      * @dataProvider serializeAsEnvelopeDataProvider
      */
     public function testSerializeAsEnvelope(Event $event, string $expectedResult): void
@@ -76,577 +47,11 @@ final class PayloadSerializerTest extends TestCase
 
         $serializer = new PayloadSerializer(new Options([
             'dsn' => 'http://public@example.com/sentry/1',
-            'enable_tracing' => true,
         ]));
 
         $result = $serializer->serialize($event);
 
         $this->assertSame($expectedResult, $result);
-    }
-
-    public static function serializeAsJsonDataProvider(): iterable
-    {
-        ClockMock::withClockMock(1597790835);
-
-        $sdkVersion = Client::SDK_VERSION;
-
-        yield [
-            Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd')),
-            <<<JSON
-{
-    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
-    "timestamp": 1597790835,
-    "platform": "php",
-    "sdk": {
-        "name": "sentry.php",
-        "version": "$sdkVersion"
-    }
-}
-JSON
-            ,
-            true,
-        ];
-
-        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setLevel(Severity::error());
-        $event->setLogger('app.php');
-        $event->setTransaction('/users/<username>/');
-        $event->setServerName('foo.example.com');
-        $event->setRelease('721e41770371db95eee98ca2707686226b993eda');
-        $event->setEnvironment('production');
-        $event->setFingerprint(['myrpc', 'POST', '/foo.bar']);
-        $event->setModules(['my.module.name' => '1.0']);
-        $event->setStartTimestamp(1597790835);
-        $event->setBreadcrumb([
-            new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::TYPE_USER, 'log'),
-            new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::TYPE_NAVIGATION, 'log', null, ['from' => '/login', 'to' => '/dashboard']),
-        ]);
-
-        $event->setSdkMetadata('dynamic_sampling_context', DynamicSamplingContext::fromHeader('sentry-public_key=public,sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-replay_id=12312012123120121231201212312012'));
-
-        $event->setUser(UserDataBag::createFromArray([
-            'id' => 'unique_id',
-            'username' => 'my_user',
-            'email' => 'foo@example.com',
-            'ip_address' => '127.0.0.1',
-            'segment' => 'my_segment',
-        ]));
-
-        $event->setTags([
-            'ios_version' => '4.0',
-            'context' => 'production',
-        ]);
-
-        $event->setExtra([
-            'my_key' => 1,
-            'some_other_value' => 'foo bar',
-        ]);
-
-        $event->setRequest([
-            'method' => 'POST',
-            'url' => 'http://absolute.uri/foo',
-            'query_string' => 'query=foobar&page=2',
-            'data' => [
-                'foo' => 'bar',
-            ],
-            'cookies' => [
-                'PHPSESSID' => '298zf09hf012fh2',
-            ],
-            'headers' => [
-                'content-type' => 'text/html',
-            ],
-            'env' => [
-                'REMOTE_ADDR' => '127.0.0.1',
-            ],
-        ]);
-
-        $event->setOsContext(new OsContext(
-            'Linux',
-            '4.19.104-microsoft-standard',
-            '#1 SMP Wed Feb 19 06:37:35 UTC 2020',
-            'Linux 7944782cd697 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64'
-        ));
-
-        $event->setRuntimeContext(new RuntimeContext(
-            'php',
-            '7.4.3'
-        ));
-
-        $event->setContext('electron', [
-            'type' => 'runtime',
-            'name' => 'Electron',
-            'version' => '4.0',
-        ]);
-
-        $frame1 = new Frame(null, 'file/name.py', 3);
-        $frame2 = new Frame('myfunction', 'file/name.py', 3, 'raw_function_name', 'absolute/file/name.py', ['my_var' => 'value'], false);
-        $frame2->setContextLine('  raise ValueError()');
-        $frame2->setPreContext([
-            'def foo():',
-            '  my_var = \'foo\'',
-        ]);
-
-        $frame2->setPostContext([
-            '',
-            'def main():',
-        ]);
-
-        $event->setExceptions([
-            new ExceptionDataBag(new \Exception('initial exception')),
-            new ExceptionDataBag(
-                new \Exception('chained exception'),
-                new Stacktrace([
-                    $frame1,
-                    $frame2,
-                ]),
-                new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true, ['code' => 123])
-            ),
-        ]);
-
-        yield [
-            $event,
-            <<<JSON
-{
-    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
-    "timestamp": 1597790835,
-    "platform": "php",
-    "sdk": {
-        "name": "sentry.php",
-        "version": "$sdkVersion"
-    },
-    "start_timestamp": 1597790835,
-    "level": "error",
-    "logger": "app.php",
-    "transaction": "/users/<username>/",
-    "server_name": "foo.example.com",
-    "release": "721e41770371db95eee98ca2707686226b993eda",
-    "environment": "production",
-    "fingerprint": [
-        "myrpc",
-        "POST",
-        "/foo.bar"
-    ],
-    "modules": {
-        "my.module.name": "1.0"
-    },
-    "extra": {
-        "my_key": 1,
-        "some_other_value": "foo bar"
-    },
-    "tags": {
-        "ios_version": "4.0",
-        "context": "production"
-    },
-    "user": {
-        "id": "unique_id",
-        "username": "my_user",
-        "email": "foo@example.com",
-        "ip_address": "127.0.0.1",
-        "segment": "my_segment"
-    },
-    "contexts": {
-        "os": {
-            "name": "Linux",
-            "version": "4.19.104-microsoft-standard",
-            "build": "#1 SMP Wed Feb 19 06:37:35 UTC 2020",
-            "kernel_version": "Linux 7944782cd697 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64"
-        },
-        "runtime": {
-            "name": "php",
-            "version": "7.4.3"
-        },
-        "electron": {
-            "type": "runtime",
-            "name": "Electron",
-            "version": "4.0"
-        },
-        "replay": {
-            "replay_id": "12312012123120121231201212312012"
-        }
-    },
-    "breadcrumbs": {
-        "values": [
-            {
-                "type": "user",
-                "category": "log",
-                "level": "info",
-                "timestamp": 1597790835
-            },
-            {
-                "type": "navigation",
-                "category": "log",
-                "level": "info",
-                "timestamp": 1597790835,
-                "data": {
-                    "from": "/login",
-                    "to": "/dashboard"
-                }
-            }
-        ]
-    },
-    "request": {
-        "method": "POST",
-        "url": "http://absolute.uri/foo",
-        "query_string": "query=foobar&page=2",
-        "data": {
-            "foo": "bar"
-        },
-        "cookies": {
-            "PHPSESSID": "298zf09hf012fh2"
-        },
-        "headers": {
-            "content-type": "text/html"
-        },
-        "env": {
-            "REMOTE_ADDR": "127.0.0.1"
-        }
-    },
-    "exception": {
-        "values": [
-            {
-                "type": "Exception",
-                "value": "chained exception",
-                "stacktrace": {
-                    "frames": [
-                        {
-                            "filename": "file/name.py",
-                            "lineno": 3,
-                            "in_app": true
-                        },
-                        {
-                            "filename": "file/name.py",
-                            "lineno": 3,
-                            "in_app": false,
-                            "abs_path": "absolute/file/name.py",
-                            "function": "myfunction",
-                            "raw_function": "raw_function_name",
-                            "pre_context": [
-                                "def foo():",
-                                "  my_var = 'foo'"
-                            ],
-                            "context_line": "  raise ValueError()",
-                            "post_context": [
-                                "",
-                                "def main():"
-                            ],
-                            "vars": {
-                                "my_var": "value"
-                            }
-                        }
-                    ]
-                },
-                "mechanism": {
-                    "type": "generic",
-                    "handled": true,
-                    "data": {
-                        "code": 123
-                    }
-                }
-            },
-            {
-                "type": "Exception",
-                "value": "initial exception"
-            }
-        ]
-    }
-}
-JSON
-            ,
-            true,
-        ];
-
-        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setMessage('My raw message with interpreted strings like this', []);
-
-        yield [
-            $event,
-            <<<JSON
-{
-    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
-    "timestamp": 1597790835,
-    "platform": "php",
-    "sdk": {
-        "name": "sentry.php",
-        "version": "$sdkVersion"
-    },
-    "message": "My raw message with interpreted strings like this"
-}
-JSON
-            ,
-            true,
-        ];
-
-        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setMessage('My raw message with interpreted strings like %s', ['this']);
-
-        yield [
-            $event,
-            <<<JSON
-{
-    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
-    "timestamp": 1597790835,
-    "platform": "php",
-    "sdk": {
-        "name": "sentry.php",
-        "version": "$sdkVersion"
-    },
-    "message": {
-        "message": "My raw message with interpreted strings like %s",
-        "params": ["this"],
-        "formatted": "My raw message with interpreted strings like this"
-    }
-}
-JSON
-            ,
-            true,
-        ];
-
-        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setMessage('My raw message with interpreted strings like %s', ['this'], 'My raw message with interpreted strings like that');
-
-        yield [
-            $event,
-            <<<JSON
-{
-    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
-    "timestamp": 1597790835,
-    "platform": "php",
-    "sdk": {
-        "name": "sentry.php",
-        "version": "$sdkVersion"
-    },
-    "message": {
-        "message": "My raw message with interpreted strings like %s",
-        "params": ["this"],
-        "formatted": "My raw message with interpreted strings like that"
-    }
-}
-JSON
-            ,
-            true,
-        ];
-
-        $span1 = new Span();
-        $span1->setSpanId(new SpanId('5dd538dc297544cc'));
-        $span1->setTraceId(new TraceId('21160e9b836d479f81611368b2aa3d2c'));
-
-        $span2 = new Span();
-        $span2->setSpanId(new SpanId('b01b9f6349558cd1'));
-        $span2->setParentSpanId(new SpanId('b0e6f15b45c36b12'));
-        $span2->setTraceId(new TraceId('1e57b752bc6e4544bbaa246cd1d05dee'));
-        $span2->setOp('http');
-        $span2->setDescription('GET /sockjs-node/info');
-        $span2->setStatus(SpanStatus::ok());
-        $span2->setStartTimestamp(1597790835);
-        $span2->setTags(['http.status_code' => '200']);
-        $span2->setData([
-            'url' => 'http://localhost:8080/sockjs-node/info?t=1588601703755',
-            'status_code' => 200,
-            'type' => 'xhr',
-            'method' => 'GET',
-        ]);
-
-        $span2->finish(1598659060);
-
-        $event = Event::createTransaction(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setSpans([$span1, $span2]);
-        $event->setRelease('1.0.0');
-        $event->setEnvironment('dev');
-        $event->setTransaction('GET /');
-        $event->setContext('trace', [
-            'trace_id' => '21160e9b836d479f81611368b2aa3d2c',
-            'span_id' => '5dd538dc297544cc',
-        ]);
-        $event->setRuntimeContext(new RuntimeContext(
-            'php',
-            '8.2.3'
-        ));
-        $event->setOsContext(new OsContext(
-            'macOS',
-            '13.2.1',
-            '22D68',
-            'Darwin Kernel Version 22.2.0',
-            'aarch64'
-        ));
-
-        $excimerLog = [
-            [
-                'trace' => [
-                    [
-                        'file' => '/var/www/html/index.php',
-                        'line' => 42,
-                    ],
-                ],
-                'timestamp' => 0.001,
-            ],
-            [
-                'trace' => [
-                    [
-                        'file' => '/var/www/html/index.php',
-                        'line' => 42,
-                    ],
-                    [
-                        'class' => 'Function',
-                        'function' => 'doStuff',
-                        'file' => '/var/www/html/function.php',
-                        'line' => 84,
-                    ],
-                ],
-                'timestamp' => 0.002,
-            ],
-        ];
-
-        $profile = new Profile();
-        // 2022-02-28T09:41:00Z
-        $profile->setStartTimeStamp(1677573660.0000);
-        $profile->setExcimerLog($excimerLog);
-        $profile->setEventId($event->getId());
-
-        $event->setSdkMetadata('profile', $profile);
-
-        yield [
-            $event,
-            <<<TEXT
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
-{"type":"transaction","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"transaction":"GET \/","release":"1.0.0","environment":"dev","contexts":{"os":{"name":"macOS","version":"13.2.1","build":"22D68","kernel_version":"Darwin Kernel Version 22.2.0"},"runtime":{"name":"php","version":"8.2.3"},"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}},"spans":[{"span_id":"5dd538dc297544cc","trace_id":"21160e9b836d479f81611368b2aa3d2c","start_timestamp":1597790835},{"span_id":"b01b9f6349558cd1","trace_id":"1e57b752bc6e4544bbaa246cd1d05dee","start_timestamp":1597790835,"parent_span_id":"b0e6f15b45c36b12","timestamp":1598659060,"status":"ok","description":"GET \/sockjs-node\/info","op":"http","data":{"url":"http:\/\/localhost:8080\/sockjs-node\/info?t=1588601703755","status_code":200,"type":"xhr","method":"GET"},"tags":{"http.status_code":"200"}}]}
-{"type":"profile","content_type":"application\/json"}
-{"device":{"architecture":"aarch64"},"event_id":"fc9442f5aef34234bb22b9a615e30ccd","os":{"name":"macOS","version":"13.2.1","build_number":"22D68"},"platform":"php","release":"1.0.0","environment":"dev","runtime":{"name":"php","version":"8.2.3"},"timestamp":"2023-02-28T08:41:00.000+00:00","transaction":{"id":"fc9442f5aef34234bb22b9a615e30ccd","name":"GET \/","trace_id":"21160e9b836d479f81611368b2aa3d2c","active_thread_id":"0"},"version":"1","profile":{"frames":[{"filename":"\/var\/www\/html\/index.php","abs_path":"\/var\/www\/html\/index.php","module":null,"function":"\/var\/www\/html\/index.php","lineno":42},{"filename":"\/var\/www\/html\/function.php","abs_path":"\/var\/www\/html\/function.php","module":"Function","function":"Function::doStuff","lineno":84}],"samples":[{"stack_id":0,"thread_id":"0","elapsed_since_start_ns":1000000},{"stack_id":1,"thread_id":"0","elapsed_since_start_ns":2000000}],"stacks":[[0],[0,1]]}}
-TEXT
-            ,
-            false,
-        ];
-
-        $event = Event::createTransaction(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setSdkMetadata('dynamic_sampling_context', DynamicSamplingContext::fromHeader('sentry-public_key=public,sentry-trace_id=d49d9bf66f13450b81f65bc51cf49c03,sentry-sample_rate=1'));
-        $event->setSdkMetadata('transaction_metadata', new TransactionMetadata());
-
-        yield [
-            $event,
-            <<<TEXT
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"},"trace":{"public_key":"public","trace_id":"d49d9bf66f13450b81f65bc51cf49c03","sample_rate":"1"}}
-{"type":"transaction","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"spans":[],"transaction_info":{"source":"custom"}}
-TEXT
-            ,
-            false,
-        ];
-
-        $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setStacktrace(new Stacktrace([new Frame(null, '', 0)]));
-
-        yield [
-            $event,
-            <<<JSON
-{
-    "event_id": "fc9442f5aef34234bb22b9a615e30ccd",
-    "timestamp": 1597790835,
-    "platform": "php",
-    "sdk": {
-        "name": "sentry.php",
-        "version": "$sdkVersion"
-    },
-    "stacktrace": {
-        "frames": [
-            {
-                "filename": "",
-                "lineno": 0,
-                "in_app": true
-            }
-        ]
-    }
-}
-JSON
-            ,
-            true,
-        ];
-
-        $checkinId = SentryUid::generate();
-        $checkIn = new CheckIn(
-            'my-monitor',
-            CheckInStatus::ok(),
-            $checkinId,
-            '1.0.0',
-            'dev',
-            10
-        );
-
-        $event = Event::createCheckIn(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setCheckIn($checkIn);
-        $event->setContext('trace', [
-            'trace_id' => '21160e9b836d479f81611368b2aa3d2c',
-            'span_id' => '5dd538dc297544cc',
-        ]);
-
-        yield [
-            $event,
-            <<<TEXT
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
-{"type":"check_in","content_type":"application\/json"}
-{"check_in_id":"$checkinId","monitor_slug":"my-monitor","status":"ok","duration":10,"release":"1.0.0","environment":"dev","contexts":{"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}}}
-TEXT
-            ,
-            false,
-        ];
-
-        $checkinId = SentryUid::generate();
-        $checkIn = new CheckIn(
-            'my-monitor',
-            CheckInStatus::inProgress(),
-            $checkinId
-        );
-
-        $event = Event::createCheckIn(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setCheckIn($checkIn);
-        $event->setContext('trace', [
-            'trace_id' => '21160e9b836d479f81611368b2aa3d2c',
-            'span_id' => '5dd538dc297544cc',
-        ]);
-
-        yield [
-            $event,
-            <<<TEXT
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
-{"type":"check_in","content_type":"application\/json"}
-{"check_in_id":"$checkinId","monitor_slug":"my-monitor","status":"in_progress","duration":null,"release":"","environment":"production","contexts":{"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}}}
-TEXT
-            ,
-            false,
-        ];
-
-        $checkinId = SentryUid::generate();
-        $checkIn = new CheckIn(
-            'my-monitor',
-            CheckInStatus::ok(),
-            $checkinId,
-            '1.0.0',
-            'dev',
-            10,
-            new MonitorConfig(
-                MonitorSchedule::crontab('0 0 * * *'),
-                10,
-                12,
-                'Europe/Amsterdam'
-            )
-        );
-
-        $event = Event::createCheckIn(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
-        $event->setCheckIn($checkIn);
-        $event->setContext('trace', [
-            'trace_id' => '21160e9b836d479f81611368b2aa3d2c',
-            'span_id' => '5dd538dc297544cc',
-        ]);
-
-        yield [
-            $event,
-            <<<TEXT
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
-{"type":"check_in","content_type":"application\/json"}
-{"check_in_id":"$checkinId","monitor_slug":"my-monitor","status":"ok","duration":10,"release":"1.0.0","environment":"dev","monitor_config":{"schedule":{"type":"crontab","value":"0 0 * * *","unit":""},"checkin_margin":10,"max_runtime":12,"timezone":"Europe\/Amsterdam"},"contexts":{"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}}}
-TEXT
-            ,
-            false,
-        ];
     }
 
     public static function serializeAsEnvelopeDataProvider(): iterable
@@ -965,6 +370,40 @@ TEXT
 {"check_in_id":"$checkinId","monitor_slug":"my-monitor","status":"in_progress","duration":null,"release":"","environment":"production"}
 TEXT
             ,
+        ];
+
+        $checkinId = SentryUid::generate();
+        $checkIn = new CheckIn(
+            'my-monitor',
+            CheckInStatus::ok(),
+            $checkinId,
+            '1.0.0',
+            'dev',
+            10,
+            new MonitorConfig(
+                MonitorSchedule::crontab('0 0 * * *'),
+                10,
+                12,
+                'Europe/Amsterdam'
+            )
+        );
+
+        $event = Event::createCheckIn(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
+        $event->setCheckIn($checkIn);
+        $event->setContext('trace', [
+            'trace_id' => '21160e9b836d479f81611368b2aa3d2c',
+            'span_id' => '5dd538dc297544cc',
+        ]);
+
+        yield [
+            $event,
+            <<<TEXT
+{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
+{"type":"check_in","content_type":"application\/json"}
+{"check_in_id":"$checkinId","monitor_slug":"my-monitor","status":"ok","duration":10,"release":"1.0.0","environment":"dev","monitor_config":{"schedule":{"type":"crontab","value":"0 0 * * *","unit":""},"checkin_margin":10,"max_runtime":12,"timezone":"Europe\/Amsterdam"},"contexts":{"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}}}
+TEXT
+            ,
+            false,
         ];
     }
 }

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -65,14 +65,13 @@ final class PayloadSerializerTest extends TestCase
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"event","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 TEXT
             ,
         ];
 
         $event = Event::createEvent(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setLevel(Severity::error());
-        $event->setLogger('app.php');
         $event->setTransaction('/users/<username>/');
         $event->setServerName('foo.example.com');
         $event->setRelease('721e41770371db95eee98ca2707686226b993eda');
@@ -169,7 +168,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"event","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"start_timestamp":1597790835,"level":"error","logger":"app.php","transaction":"\/users\/<username>\/","server_name":"foo.example.com","release":"721e41770371db95eee98ca2707686226b993eda","environment":"production","fingerprint":["myrpc","POST","\/foo.bar"],"modules":{"my.module.name":"1.0"},"extra":{"my_key":1,"some_other_value":"foo bar"},"tags":{"ios_version":"4.0","context":"production"},"user":{"id":"unique_id","username":"my_user","email":"foo@example.com","ip_address":"127.0.0.1","segment":"my_segment"},"contexts":{"os":{"name":"Linux","version":"4.19.104-microsoft-standard","build":"#1 SMP Wed Feb 19 06:37:35 UTC 2020","kernel_version":"Linux 7944782cd697 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64"},"runtime":{"name":"php","version":"7.4.3"},"electron":{"type":"runtime","name":"Electron","version":"4.0"}},"breadcrumbs":{"values":[{"type":"user","category":"log","level":"info","timestamp":1597790835},{"type":"navigation","category":"log","level":"info","timestamp":1597790835,"data":{"from":"\/login","to":"\/dashboard"}}]},"request":{"method":"POST","url":"http:\/\/absolute.uri\/foo","query_string":"query=foobar&page=2","data":{"foo":"bar"},"cookies":{"PHPSESSID":"298zf09hf012fh2"},"headers":{"content-type":"text\/html"},"env":{"REMOTE_ADDR":"127.0.0.1"}},"exception":{"values":[{"type":"Exception","value":"chained exception","stacktrace":{"frames":[{"filename":"file\/name.py","lineno":3,"in_app":true},{"filename":"file\/name.py","lineno":3,"in_app":false,"abs_path":"absolute\/file\/name.py","function":"myfunction","raw_function":"raw_function_name","pre_context":["def foo():","  my_var = 'foo'"],"context_line":"  raise ValueError()","post_context":["","def main():"],"vars":{"my_var":"value"}}]},"mechanism":{"type":"generic","handled":true,"data":{"code":123}}},{"type":"Exception","value":"initial exception"}]}}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"start_timestamp":1597790835,"level":"error","transaction":"\/users\/<username>\/","server_name":"foo.example.com","release":"721e41770371db95eee98ca2707686226b993eda","environment":"production","fingerprint":["myrpc","POST","\/foo.bar"],"modules":{"my.module.name":"1.0"},"extra":{"my_key":1,"some_other_value":"foo bar"},"tags":{"ios_version":"4.0","context":"production"},"user":{"id":"unique_id","username":"my_user","email":"foo@example.com","ip_address":"127.0.0.1","segment":"my_segment"},"contexts":{"os":{"name":"Linux","version":"4.19.104-microsoft-standard","build":"#1 SMP Wed Feb 19 06:37:35 UTC 2020","kernel_version":"Linux 7944782cd697 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64"},"runtime":{"name":"php","version":"7.4.3"},"electron":{"type":"runtime","name":"Electron","version":"4.0"}},"breadcrumbs":{"values":[{"type":"user","category":"log","level":"info","timestamp":1597790835},{"type":"navigation","category":"log","level":"info","timestamp":1597790835,"data":{"from":"\/login","to":"\/dashboard"}}]},"request":{"method":"POST","url":"http:\/\/absolute.uri\/foo","query_string":"query=foobar&page=2","data":{"foo":"bar"},"cookies":{"PHPSESSID":"298zf09hf012fh2"},"headers":{"content-type":"text\/html"},"env":{"REMOTE_ADDR":"127.0.0.1"}},"exception":{"values":[{"type":"Exception","value":"chained exception","stacktrace":{"frames":[{"filename":"file\/name.py","lineno":3,"in_app":true},{"filename":"file\/name.py","lineno":3,"in_app":false,"abs_path":"absolute\/file\/name.py","function":"myfunction","raw_function":"raw_function_name","pre_context":["def foo():","  my_var = 'foo'"],"context_line":"  raise ValueError()","post_context":["","def main():"],"vars":{"my_var":"value"}}]},"mechanism":{"type":"generic","handled":true,"data":{"code":123}}},{"type":"Exception","value":"initial exception"}]}}
 TEXT
         ];
 
@@ -181,7 +180,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"event","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"message":"My raw message with interpreted strings like this"}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"message":"My raw message with interpreted strings like this"}
 TEXT
             ,
         ];
@@ -194,7 +193,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"event","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"message":{"message":"My raw message with interpreted strings like %s","params":["this"],"formatted":"My raw message with interpreted strings like this"}}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"message":{"message":"My raw message with interpreted strings like %s","params":["this"],"formatted":"My raw message with interpreted strings like this"}}
 TEXT
         ];
 
@@ -206,7 +205,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"event","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"message":{"message":"My raw message with interpreted strings like %s","params":["this"],"formatted":"My raw message with interpreted strings like that"}}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"message":{"message":"My raw message with interpreted strings like %s","params":["this"],"formatted":"My raw message with interpreted strings like that"}}
 TEXT
             ,
         ];
@@ -294,7 +293,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"transaction","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"transaction":"GET \/","release":"1.0.0","environment":"dev","contexts":{"os":{"name":"macOS","version":"13.2.1","build":"22D68","kernel_version":"Darwin Kernel Version 22.2.0"},"runtime":{"name":"php","version":"8.2.3"},"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}},"spans":[{"span_id":"5dd538dc297544cc","trace_id":"21160e9b836d479f81611368b2aa3d2c","start_timestamp":1597790835},{"span_id":"b01b9f6349558cd1","trace_id":"1e57b752bc6e4544bbaa246cd1d05dee","start_timestamp":1597790835,"parent_span_id":"b0e6f15b45c36b12","timestamp":1598659060,"status":"ok","description":"GET \/sockjs-node\/info","op":"http","data":{"url":"http:\/\/localhost:8080\/sockjs-node\/info?t=1588601703755","status_code":200,"type":"xhr","method":"GET"},"tags":{"http.status_code":"200"}}]}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"transaction":"GET \/","release":"1.0.0","environment":"dev","contexts":{"os":{"name":"macOS","version":"13.2.1","build":"22D68","kernel_version":"Darwin Kernel Version 22.2.0"},"runtime":{"name":"php","version":"8.2.3"},"trace":{"trace_id":"21160e9b836d479f81611368b2aa3d2c","span_id":"5dd538dc297544cc"}},"spans":[{"span_id":"5dd538dc297544cc","trace_id":"21160e9b836d479f81611368b2aa3d2c","start_timestamp":1597790835},{"span_id":"b01b9f6349558cd1","trace_id":"1e57b752bc6e4544bbaa246cd1d05dee","start_timestamp":1597790835,"parent_span_id":"b0e6f15b45c36b12","timestamp":1598659060,"status":"ok","description":"GET \/sockjs-node\/info","op":"http","data":{"url":"http:\/\/localhost:8080\/sockjs-node\/info?t=1588601703755","status_code":200,"type":"xhr","method":"GET"},"tags":{"http.status_code":"200"}}]}
 {"type":"profile","content_type":"application\/json"}
 {"device":{"architecture":"aarch64"},"event_id":"fc9442f5aef34234bb22b9a615e30ccd","os":{"name":"macOS","version":"13.2.1","build_number":"22D68"},"platform":"php","release":"1.0.0","environment":"dev","runtime":{"name":"php","version":"8.2.3"},"timestamp":"2023-02-28T08:41:00.000+00:00","transaction":{"id":"fc9442f5aef34234bb22b9a615e30ccd","name":"GET \/","trace_id":"21160e9b836d479f81611368b2aa3d2c","active_thread_id":"0"},"version":"1","profile":{"frames":[{"filename":"\/var\/www\/html\/index.php","abs_path":"\/var\/www\/html\/index.php","module":null,"function":"\/var\/www\/html\/index.php","lineno":42},{"filename":"\/var\/www\/html\/function.php","abs_path":"\/var\/www\/html\/function.php","module":"Function","function":"Function::doStuff","lineno":84}],"samples":[{"stack_id":0,"thread_id":"0","elapsed_since_start_ns":1000000},{"stack_id":1,"thread_id":"0","elapsed_since_start_ns":2000000}],"stacks":[[0],[0,1]]}}
 TEXT
@@ -310,7 +309,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"},"trace":{"public_key":"public","trace_id":"d49d9bf66f13450b81f65bc51cf49c03","sample_rate":"1"}}
 {"type":"transaction","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"spans":[],"transaction_info":{"source":"custom"}}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"spans":[],"transaction_info":{"source":"custom"}}
 TEXT
             ,
             false,
@@ -324,7 +323,7 @@ TEXT
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
 {"type":"event","content_type":"application\/json"}
-{"event_id":"fc9442f5aef34234bb22b9a615e30ccd","timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"stacktrace":{"frames":[{"filename":"","lineno":0,"in_app":true}]}}
+{"timestamp":1597790835,"platform":"php","sdk":{"name":"sentry.php","version":"$sdkVersion"},"stacktrace":{"frames":[{"filename":"","lineno":0,"in_app":true}]}}
 TEXT
             ,
         ];


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry-php/pull/1612

This declutters the `PayloadSeralizer` and adds distinct `EnvelopeItem` types based on the event type.
While this is not strictly DRY, transactions will soon diverge heavily from errors, hence already laying the groundwork.