### PR TITLE
Refactor `tracePropagationTargets`

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -1009,7 +1009,7 @@ final class Options
             'before_send_transaction' => static function (Event $transaction): Event {
                 return $transaction;
             },
-            'trace_propagation_targets' => [],
+            'trace_propagation_targets' => null,
             'tags' => [],
             'error_types' => null,
             'max_breadcrumbs' => self::DEFAULT_MAX_BREADCRUMBS,

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -125,12 +125,8 @@ final class GuzzleTracingMiddleware
 
             // Check if the request destination is allow listed in the trace_propagation_targets option.
             if (
-                $sdkOptions->getTracePropagationTargets() !== null
-                // Due to BC, we treat an empty array (the default) as all hosts are allow listed
-                && (
-                    $sdkOptions->getTracePropagationTargets() === []
-                    || \in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())
-                )
+                $sdkOptions->getTracePropagationTargets() === null
+                || \in_array($request->getUri()->getHost(), $sdkOptions->getTracePropagationTargets())
             ) {
                 return true;
             }

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -141,7 +141,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
             new Request('GET', 'https://www.example.com'),
             new Options([
                 'traces_sample_rate' => 1,
-                'trace_propagation_targets' => [],
+                'trace_propagation_targets' => null,
             ]),
             true,
         ];
@@ -161,7 +161,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
             new Request('GET', 'https://www.example.com'),
             new Options([
                 'traces_sample_rate' => 1,
-                'trace_propagation_targets' => null,
+                'trace_propagation_targets' => [],
             ]),
             false,
         ];


### PR DESCRIPTION
The new default of `trace_propagation_targets` is now `null`, which means trace headers are added. To opt out, a user can now set an empty array.