### PR TITLE
Fix setting cURL request headers

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -44,7 +44,7 @@ class HttpClient implements HttpClientInterface
             && $options->isHttpCompressionEnabled()
         ) {
             $requestData = gzcompress($requestData, -1, \ZLIB_ENCODING_GZIP);
-            $requestHeaders['Content-Encoding'] = 'gzip';
+            $requestHeaders[] = 'Content-Encoding: gzip';
         }
 
         $responseHeaders = [];

--- a/src/Util/Http.php
+++ b/src/Util/Http.php
@@ -24,8 +24,8 @@ final class Http
         ];
 
         return [
-            'Content-Type' => 'application/x-sentry-envelope',
-            'X-Sentry-Auth' => 'Sentry ' . implode(', ', $authHeader),
+            'Content-Type: application/x-sentry-envelope',
+            'X-Sentry-Auth: Sentry ' . implode(', ', $authHeader),
         ];
     }
 

--- a/tests/Util/HttpTest.php
+++ b/tests/Util/HttpTest.php
@@ -25,8 +25,8 @@ final class HttpTest extends TestCase
             'sentry.sdk.identifier',
             '1.2.3',
             [
-                'Content-Type' => 'application/x-sentry-envelope',
-                'X-Sentry-Auth' => 'Sentry sentry_version=7, sentry_client=sentry.sdk.identifier/1.2.3, sentry_key=public',
+                'Content-Type: application/x-sentry-envelope',
+                'X-Sentry-Auth: Sentry sentry_version=7, sentry_client=sentry.sdk.identifier/1.2.3, sentry_key=public',
             ],
         ];
     }


### PR DESCRIPTION
It turns out cURL does not expect an associative array when setting custom request headers.