### PR TITLE
Refactor `logger` option

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,16 @@ parameters:
 			path: src/Integration/RequestIntegration.php
 
 		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Logger/DebugFileLogger.php
+
+		-
+			message: "#^Parameter \\#2 \\.\\.\\.\\$values of function sprintf expects bool\\|float\\|int\\|string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Logger/DebugStdOutLogger.php
+
+		-
 			message: "#^Parameter \\#1 \\$level of method Monolog\\\\Handler\\\\AbstractHandler\\:\\:__construct\\(\\) expects 100\\|200\\|250\\|300\\|400\\|500\\|550\\|600\\|'ALERT'\\|'alert'\\|'CRITICAL'\\|'critical'\\|'DEBUG'\\|'debug'\\|'EMERGENCY'\\|'emergency'\\|'ERROR'\\|'error'\\|'INFO'\\|'info'\\|'NOTICE'\\|'notice'\\|'WARNING'\\|'warning'\\|Monolog\\\\Level, int\\|Monolog\\\\Level\\|string given\\.$#"
 			count: 1
 			path: src/Monolog/BreadcrumbHandler.php
@@ -136,7 +146,7 @@ parameters:
 			path: src/Options.php
 
 		-
-			message: "#^Method Sentry\\\\Options\\:\\:getLogger\\(\\) should return string but returns mixed\\.$#"
+			message: "#^Method Sentry\\\\Options\\:\\:getLogger\\(\\) should return Psr\\\\Log\\\\LoggerInterface\\|null but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -93,11 +93,12 @@ final class Client implements ClientInterface
     ) {
         $this->options = $options;
         $this->transport = $transport;
-        $this->logger = $logger ?? new NullLogger();
-        $this->integrations = IntegrationRegistry::getInstance()->setupIntegrations($options, $this->logger);
-        $this->stacktraceBuilder = new StacktraceBuilder($options, $representationSerializer ?? new RepresentationSerializer($this->options));
         $this->sdkIdentifier = $sdkIdentifier ?? self::SDK_IDENTIFIER;
         $this->sdkVersion = $sdkVersion ?? self::SDK_VERSION;
+        $this->stacktraceBuilder = new StacktraceBuilder($options, $representationSerializer ?? new RepresentationSerializer($this->options));
+        $this->logger = $logger ?? new NullLogger();
+
+        $this->integrations = IntegrationRegistry::getInstance()->setupIntegrations($options, $this->logger);
     }
 
     /**
@@ -267,10 +268,6 @@ final class Client implements ClientInterface
 
         if ($event->getEnvironment() === null) {
             $event->setEnvironment($this->options->getEnvironment() ?? Event::DEFAULT_ENVIRONMENT);
-        }
-
-        if ($event->getLogger() === null) {
-            $event->setLogger($this->options->getLogger(false));
         }
 
         $isTransaction = EventType::transaction() === $event->getType();

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -63,6 +63,8 @@ final class ClientBuilder
     {
         $this->options = $options ?? new Options();
 
+        $this->logger = $this->options->getLogger() ?? null;
+
         $this->httpClient = $this->options->getHttpClient() ?? new HttpClient($this->sdkIdentifier, $this->sdkVersion);
         $this->transport = $this->options->getTransport() ?? new HttpTransport(
             $this->options,
@@ -90,6 +92,11 @@ final class ClientBuilder
         $this->representationSerializer = $representationSerializer;
 
         return $this;
+    }
+
+    public function getLogger(): ?LoggerInterface
+    {
+        return $this->logger;
     }
 
     public function setLogger(LoggerInterface $logger): self

--- a/src/Logger/DebugFileLogger.php
+++ b/src/Logger/DebugFileLogger.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Logger;
+
+use Psr\Log\AbstractLogger;
+
+class DebugFileLogger extends AbstractLogger
+{
+    /**
+     * @var string
+     */
+    private $filePath;
+
+    public function __construct(string $filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    /**
+     * @param mixed   $level
+     * @param mixed[] $context
+     */
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        file_put_contents($this->filePath, sprintf("sentry/sentry: [%s] %s\n", $level, (string) $message), \FILE_APPEND);
+    }
+}

--- a/src/Logger/DebugStdOutLogger.php
+++ b/src/Logger/DebugStdOutLogger.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Logger;
+
+use Psr\Log\AbstractLogger;
+
+class DebugStdOutLogger extends AbstractLogger
+{
+    /**
+     * @param mixed   $level
+     * @param mixed[] $context
+     */
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        file_put_contents('php://stdout', sprintf("sentry/sentry: [%s] %s\n", $level, (string) $message));
+    }
+}

--- a/src/Transport/Result.php
+++ b/src/Transport/Result.php
@@ -9,8 +9,10 @@ use Sentry\Event;
 /**
  * This class contains the details of the sending operation of an event, e.g.
  * if it was sent successfully or if it was skipped because of some reason.
+ *
+ * @internal
  */
-final class Result
+class Result
 {
     /**
      * @var ResultStatus The status of the sending operation of the event

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -217,7 +217,6 @@ final class ClientTest extends TestCase
     {
         $event = Event::createEvent();
         $expectedEvent = clone $event;
-        $expectedEvent->setLogger('php');
         $expectedEvent->setServerName('example.com');
         $expectedEvent->setRelease('0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33');
         $expectedEvent->setEnvironment('development');
@@ -241,7 +240,6 @@ final class ClientTest extends TestCase
         $event->setTags(['context' => 'production']);
 
         $expectedEvent = clone $event;
-        $expectedEvent->setLogger('php');
         $expectedEvent->setTags(['context' => 'production', 'ios_version' => '14.0']);
 
         yield 'Options set && event properties set => event properties override options' => [
@@ -259,7 +257,6 @@ final class ClientTest extends TestCase
         $event->setServerName('example.com');
 
         $expectedEvent = clone $event;
-        $expectedEvent->setLogger('php');
         $expectedEvent->setEnvironment('production');
 
         yield 'Environment option set to null && no event property set => fallback to default value' => [
@@ -274,7 +271,6 @@ final class ClientTest extends TestCase
         $event->setExceptions([new ExceptionDataBag(new \ErrorException())]);
 
         $expectedEvent = clone $event;
-        $expectedEvent->setLogger('php');
         $expectedEvent->setEnvironment('production');
 
         yield 'Error level is set && exception is instance of ErrorException => preserve the error level set by the user' => [

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Sentry\Dsn;
 use Sentry\HttpClient\HttpClient;
 use Sentry\Options;
@@ -45,13 +46,8 @@ final class OptionsTest extends TestCase
         string $option,
         $value,
         string $getterMethod,
-        ?string $setterMethod,
-        ?string $expectedGetterDeprecationMessage
+        ?string $setterMethod
     ): void {
-        if ($expectedGetterDeprecationMessage !== null) {
-            $this->expectDeprecation($expectedGetterDeprecationMessage);
-        }
-
         $options = new Options([$option => $value]);
 
         $this->assertEquals($value, $options->$getterMethod());
@@ -66,18 +62,8 @@ final class OptionsTest extends TestCase
         string $option,
         $value,
         string $getterMethod,
-        ?string $setterMethod,
-        ?string $expectedGetterDeprecationMessage,
-        ?string $expectedSetterDeprecationMessage
+        ?string $setterMethod
     ): void {
-        if ($expectedSetterDeprecationMessage !== null) {
-            $this->expectDeprecation($expectedSetterDeprecationMessage);
-        }
-
-        if ($expectedGetterDeprecationMessage !== null) {
-            $this->expectDeprecation($expectedGetterDeprecationMessage);
-        }
-
         $options = new Options();
 
         if ($setterMethod !== null) {
@@ -94,8 +80,6 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getPrefixes',
             'setPrefixes',
-            null,
-            null,
         ];
 
         yield [
@@ -103,8 +87,6 @@ final class OptionsTest extends TestCase
             0.5,
             'getSampleRate',
             'setSampleRate',
-            null,
-            null,
         ];
 
         yield [
@@ -112,8 +94,6 @@ final class OptionsTest extends TestCase
             0.5,
             'getTracesSampleRate',
             'setTracesSampleRate',
-            null,
-            null,
         ];
 
         yield [
@@ -121,8 +101,6 @@ final class OptionsTest extends TestCase
             null,
             'getTracesSampleRate',
             'setTracesSampleRate',
-            null,
-            null,
         ];
 
         yield [
@@ -130,8 +108,6 @@ final class OptionsTest extends TestCase
             static function (): void {},
             'getTracesSampler',
             'setTracesSampler',
-            null,
-            null,
         ];
 
         yield [
@@ -139,8 +115,6 @@ final class OptionsTest extends TestCase
             true,
             'getEnableTracing',
             'setEnableTracing',
-            null,
-            null,
         ];
 
         yield [
@@ -148,8 +122,6 @@ final class OptionsTest extends TestCase
             0.5,
             'getProfilesSampleRate',
             'setProfilesSampleRate',
-            null,
-            null,
         ];
 
         yield [
@@ -157,8 +129,6 @@ final class OptionsTest extends TestCase
             false,
             'shouldAttachStacktrace',
             'setAttachStacktrace',
-            null,
-            null,
         ];
 
         yield [
@@ -166,8 +136,6 @@ final class OptionsTest extends TestCase
             3,
             'getContextLines',
             'setContextLines',
-            null,
-            null,
         ];
 
         yield [
@@ -175,8 +143,6 @@ final class OptionsTest extends TestCase
             'foo',
             'getEnvironment',
             'setEnvironment',
-            null,
-            null,
         ];
 
         yield [
@@ -184,8 +150,6 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getInAppExcludedPaths',
             'setInAppExcludedPaths',
-            null,
-            null,
         ];
 
         yield [
@@ -193,17 +157,13 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getInAppIncludedPaths',
             'setInAppIncludedPaths',
-            null,
-            null,
         ];
 
         yield [
             'logger',
-            'foo',
+            new NullLogger(),
             'getLogger',
             'setLogger',
-            'Method Sentry\\Options::getLogger() is deprecated since version 3.2 and will be removed in 4.0.',
-            'Method Sentry\\Options::setLogger() is deprecated since version 3.2 and will be removed in 4.0.',
         ];
 
         yield [
@@ -211,8 +171,6 @@ final class OptionsTest extends TestCase
             'dev',
             'getRelease',
             'setRelease',
-            null,
-            null,
         ];
 
         yield [
@@ -220,8 +178,6 @@ final class OptionsTest extends TestCase
             'foo',
             'getServerName',
             'setServerName',
-            null,
-            null,
         ];
 
         yield [
@@ -229,8 +185,6 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getTags',
             'setTags',
-            null,
-            null,
         ];
 
         yield [
@@ -238,8 +192,6 @@ final class OptionsTest extends TestCase
             0,
             'getErrorTypes',
             'setErrorTypes',
-            null,
-            null,
         ];
 
         yield [
@@ -247,8 +199,6 @@ final class OptionsTest extends TestCase
             50,
             'getMaxBreadcrumbs',
             'setMaxBreadcrumbs',
-            null,
-            null,
         ];
 
         yield [
@@ -256,8 +206,6 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getIgnoreExceptions',
             'setIgnoreExceptions',
-            null,
-            null,
         ];
 
         yield [
@@ -265,8 +213,6 @@ final class OptionsTest extends TestCase
             ['foo', 'bar'],
             'getIgnoreTransactions',
             'setIgnoreTransactions',
-            null,
-            null,
         ];
 
         yield [
@@ -274,8 +220,6 @@ final class OptionsTest extends TestCase
             static function (): void {},
             'getBeforeSendCallback',
             'setBeforeSendCallback',
-            null,
-            null,
         ];
 
         yield [
@@ -283,8 +227,6 @@ final class OptionsTest extends TestCase
             static function (): void {},
             'getBeforeSendTransactionCallback',
             'setBeforeSendTransactionCallback',
-            null,
-            null,
         ];
 
         yield [
@@ -292,8 +234,6 @@ final class OptionsTest extends TestCase
             ['www.example.com'],
             'getTracePropagationTargets',
             'setTracePropagationTargets',
-            null,
-            null,
         ];
 
         yield [
@@ -301,8 +241,6 @@ final class OptionsTest extends TestCase
             static function (): void {},
             'getBeforeBreadcrumbCallback',
             'setBeforeBreadcrumbCallback',
-            null,
-            null,
         ];
 
         yield [
@@ -310,8 +248,6 @@ final class OptionsTest extends TestCase
             true,
             'shouldSendDefaultPii',
             'setSendDefaultPii',
-            null,
-            null,
         ];
 
         yield [
@@ -319,8 +255,6 @@ final class OptionsTest extends TestCase
             false,
             'hasDefaultIntegrations',
             'setDefaultIntegrations',
-            null,
-            null,
         ];
 
         yield [
@@ -328,8 +262,6 @@ final class OptionsTest extends TestCase
             50,
             'getMaxValueLength',
             'setMaxValueLength',
-            null,
-            null,
         ];
 
         yield [
@@ -337,8 +269,6 @@ final class OptionsTest extends TestCase
             new HttpTransport(new Options(), new HttpClient('foo', 'bar'), new PayloadSerializer(new Options())),
             'getTransport',
             'setTransport',
-            null,
-            null,
         ];
 
         yield [
@@ -346,8 +276,6 @@ final class OptionsTest extends TestCase
             new HttpClient('foo', 'bar'),
             'getHttpClient',
             'setHttpClient',
-            null,
-            null,
         ];
 
         yield [
@@ -355,8 +283,6 @@ final class OptionsTest extends TestCase
             '127.0.0.1',
             'getHttpProxy',
             'setHttpProxy',
-            null,
-            null,
         ];
 
         yield [
@@ -364,8 +290,6 @@ final class OptionsTest extends TestCase
             'username:password',
             'getHttpProxyAuthentication',
             'setHttpProxyAuthentication',
-            null,
-            null,
         ];
 
         yield [
@@ -373,8 +297,6 @@ final class OptionsTest extends TestCase
             1,
             'getHttpTimeout',
             'setHttpTimeout',
-            null,
-            null,
         ];
 
         yield [
@@ -382,8 +304,6 @@ final class OptionsTest extends TestCase
             1.2,
             'getHttpTimeout',
             'setHttpTimeout',
-            null,
-            null,
         ];
 
         yield [
@@ -391,8 +311,6 @@ final class OptionsTest extends TestCase
             1,
             'getHttpConnectTimeout',
             'setHttpConnectTimeout',
-            null,
-            null,
         ];
 
         yield [
@@ -400,8 +318,6 @@ final class OptionsTest extends TestCase
             1.2,
             'getHttpConnectTimeout',
             'setHttpConnectTimeout',
-            null,
-            null,
         ];
 
         yield [
@@ -409,8 +325,6 @@ final class OptionsTest extends TestCase
             false,
             'getHttpSslVerifyPeer',
             'setHttpSslVerifyPeer',
-            null,
-            null,
         ];
 
         yield [
@@ -418,8 +332,6 @@ final class OptionsTest extends TestCase
             false,
             'isHttpCompressionEnabled',
             'setEnableHttpCompression',
-            null,
-            null,
         ];
 
         yield [
@@ -427,8 +339,6 @@ final class OptionsTest extends TestCase
             true,
             'shouldCaptureSilencedErrors',
             'setCaptureSilencedErrors',
-            null,
-            null,
         ];
 
         yield [
@@ -436,8 +346,6 @@ final class OptionsTest extends TestCase
             'small',
             'getMaxRequestBodySize',
             'setMaxRequestBodySize',
-            null,
-            null,
         ];
     }
 


### PR DESCRIPTION
This changes the `logger` option to accept a `LoggerInterface` instance.
This simplifies debugging the SDK, as you can now pass in one of the provided loggers, either `DebugFileLogger` or `DebugStdOutLogger`.

```php
Sentry\init([
    ...
    'logger' => new DebugFileLogger(filePath: ROOT . DS . 'sentry.log'),
    ...
]);
```

```bash
sentry/sentry: [debug] The "Sentry\Integration\RequestIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\TransactionIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\FrameContextifierIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\EnvironmentIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\ModulesIntegration" integration has been installed.
sentry/sentry: [error] Failed to send the event to Sentry. Reason: "The DSN option must be set to use the HttpClient.".
```

As a follow-up, we should add more logging statements across the SDK to ease debugging and provide more context on what is happening internally.