### PR TITLE
Search for curl_init() only in root namespace

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -40,6 +40,10 @@ class HttpClient implements HttpClientInterface
             throw new \RuntimeException('The request data is empty.');
         }
 
+        if (!\extension_loaded('curl')) {
+            throw new \RuntimeException('The cURL PHP extension must be enabled to use the HttpClient.');
+        }
+
         $curlHandle = curl_init();
 
         $requestHeaders = Http::getRequestHeaders($dsn, $this->sdkIdentifier, $this->sdkVersion);


### PR DESCRIPTION
If curl is missing at runtime, the curl_init() function call searches the Sentry\HttpClient namespace, which results in a confusing error message: "Call to undefined function Sentry\HttpClient\curl_init()". We only want to search the root namespace.