### PR TITLE
Improve flakiness of HTTP E2E tests

### DIFF
--- a/tests/testserver/index.php
+++ b/tests/testserver/index.php
@@ -8,6 +8,14 @@ $outputFile = __DIR__ . '/output.json';
 // We use the project ID to determine the status code so we need to extract it from the path
 $path = trim(parse_url($_SERVER['REQUEST_URI'], \PHP_URL_PATH), '/');
 
+if (strpos($path, 'ping') === 0) {
+    http_response_code(200);
+
+    echo 'pong';
+
+    return;
+}
+
 if (!preg_match('/api\/\d+\/envelope/', $path)) {
     http_response_code(204);
 


### PR DESCRIPTION
We test a little harder and validate a little more before assuming the testserver has been brought up and is ready for answering HTTP requests which is what we are using it for.

No changelog entry needed, only relevant for our tests.