### PR TITLE
Add missing `merge_target` to release action

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -9,6 +9,10 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
+        default: master
 
 permissions:
   contents: read
@@ -30,3 +34,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}


### PR DESCRIPTION
Expose the `merge_target` option on the release action.