### PR TITLE
Add support for Spotlight

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -221,6 +221,11 @@ parameters:
 			path: src/Options.php
 
 		-
+			message: "#^Method Sentry\\\\Options\\:\\:isSpotlightEnabled\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Method Sentry\\\\Options\\:\\:shouldAttachStacktrace\\(\\) should return bool but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php

--- a/src/HttpClient/Request.php
+++ b/src/HttpClient/Request.php
@@ -14,6 +14,11 @@ final class Request
      */
     private $stringBody;
 
+    public function hasStringBody(): bool
+    {
+        return $this->stringBody !== null;
+    }
+
     public function getStringBody(): ?string
     {
         return $this->stringBody;

--- a/src/Options.php
+++ b/src/Options.php
@@ -329,6 +329,20 @@ final class Options
         return $this;
     }
 
+    public function isSpotlightEnabled(): bool
+    {
+        return $this->options['spotlight'];
+    }
+
+    public function enableSpotlight(bool $enable): self
+    {
+        $options = array_merge($this->options, ['spotlight' => $enable]);
+
+        $this->options = $this->resolver->resolve($options);
+
+        return $this;
+    }
+
     /**
      * Gets the release tag to be passed with every event sent to Sentry.
      */
@@ -984,6 +998,7 @@ final class Options
             'context_lines' => 5,
             'environment' => $_SERVER['SENTRY_ENVIRONMENT'] ?? null,
             'logger' => null,
+            'spotlight' => false,
             'release' => $_SERVER['SENTRY_RELEASE'] ?? null,
             'dsn' => $_SERVER['SENTRY_DSN'] ?? null,
             'server_name' => gethostname(),
@@ -1031,6 +1046,7 @@ final class Options
         $resolver->setAllowedTypes('in_app_exclude', 'string[]');
         $resolver->setAllowedTypes('in_app_include', 'string[]');
         $resolver->setAllowedTypes('logger', ['null', LoggerInterface::class]);
+        $resolver->setAllowedTypes('spotlight', 'bool');
         $resolver->setAllowedTypes('release', ['null', 'string']);
         $resolver->setAllowedTypes('dsn', ['null', 'string', 'bool', Dsn::class]);
         $resolver->setAllowedTypes('server_name', 'string');

--- a/src/Spotlight/SpotlightClient.php
+++ b/src/Spotlight/SpotlightClient.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Spotlight;
+
+use Sentry\HttpClient\Request;
+use Sentry\HttpClient\Response;
+
+/**
+ * @internal
+ */
+class SpotlightClient
+{
+    public static function sendRequest(Request $request, string $url): Response
+    {
+        if (!\extension_loaded('curl')) {
+            throw new \RuntimeException('The cURL PHP extension must be enabled to use the SpotlightClient.');
+        }
+
+        $requestData = $request->getStringBody();
+        if ($requestData === null) {
+            throw new \RuntimeException('The request data is empty.');
+        }
+
+        $curlHandle = curl_init();
+
+        curl_setopt($curlHandle, \CURLOPT_URL, $url);
+        curl_setopt($curlHandle, \CURLOPT_HTTPHEADER, [
+            'Content-Type: application/x-sentry-envelope',
+        ]);
+        curl_setopt($curlHandle, \CURLOPT_TIMEOUT, 2.0);
+        curl_setopt($curlHandle, \CURLOPT_CONNECTTIMEOUT, 1.0);
+        curl_setopt($curlHandle, \CURLOPT_ENCODING, '');
+        curl_setopt($curlHandle, \CURLOPT_POST, true);
+        curl_setopt($curlHandle, \CURLOPT_POSTFIELDS, $requestData);
+        curl_setopt($curlHandle, \CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curlHandle, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_1_1);
+
+        $body = curl_exec($curlHandle);
+
+        if ($body === false) {
+            $errorCode = curl_errno($curlHandle);
+            $error = curl_error($curlHandle);
+            curl_close($curlHandle);
+
+            $message = 'cURL Error (' . $errorCode . ') ' . $error;
+
+            return new Response(0, [], $message);
+        }
+
+        $statusCode = curl_getinfo($curlHandle, \CURLINFO_HTTP_CODE);
+
+        curl_close($curlHandle);
+
+        return new Response($statusCode, [], '');
+    }
+}

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -122,28 +122,30 @@ class HttpTransport implements TransportInterface
 
     private function sendRequestToSpotlight(Event $event): void
     {
-        if ($this->options->isSpotlightEnabled()) {
-            $request = new Request();
-            $request->setStringBody($this->payloadSerializer->serialize($event));
+        if (!$this->options->isSpotlightEnabled()) {
+            return;
+        }
 
-            try {
-                $spotLightResponse = SpotlightClient::sendRequest(
-                    $request,
-                    'http://localhost:8969/stream'
-                );
+        $request = new Request();
+        $request->setStringBody($this->payloadSerializer->serialize($event));
 
-                if ($spotLightResponse->hasError()) {
-                    $this->logger->info(
-                        sprintf('Failed to send the event to Sentry. Reason: "%s".', $spotLightResponse->getError()),
-                        ['event' => $event]
-                    );
-                }
-            } catch (\Throwable $exception) {
+        try {
+            $spotLightResponse = SpotlightClient::sendRequest(
+                $request,
+                'http://localhost:8969/stream'
+            );
+
+            if ($spotLightResponse->hasError()) {
                 $this->logger->info(
-                    sprintf('Failed to send the event to Spotlight. Reason: "%s".', $exception->getMessage()),
-                    ['exception' => $exception, 'event' => $event]
+                    sprintf('Failed to send the event to Spotlight. Reason: "%s".', $spotLightResponse->getError()),
+                    ['event' => $event]
                 );
             }
+        } catch (\Throwable $exception) {
+            $this->logger->info(
+                sprintf('Failed to send the event to Spotlight. Reason: "%s".', $exception->getMessage()),
+                ['exception' => $exception, 'event' => $event]
+            );
         }
     }
 }

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -11,6 +11,7 @@ use Sentry\HttpClient\HttpClientInterface;
 use Sentry\HttpClient\Request;
 use Sentry\Options;
 use Sentry\Serializer\PayloadSerializerInterface;
+use Sentry\Spotlight\SpotlightClient;
 
 /**
  * @internal
@@ -66,6 +67,8 @@ class HttpTransport implements TransportInterface
      */
     public function send(Event $event): Result
     {
+        $this->sendRequestToSpotlight($event);
+
         if ($this->options->getDsn() === null) {
             return new Result(ResultStatus::skipped(), $event);
         }
@@ -115,5 +118,32 @@ class HttpTransport implements TransportInterface
     public function close(?int $timeout = null): Result
     {
         return new Result(ResultStatus::success());
+    }
+
+    private function sendRequestToSpotlight(Event $event): void
+    {
+        if ($this->options->isSpotlightEnabled()) {
+            $request = new Request();
+            $request->setStringBody($this->payloadSerializer->serialize($event));
+
+            try {
+                $spotLightResponse = SpotlightClient::sendRequest(
+                    $request,
+                    'http://localhost:8969/stream'
+                );
+
+                if ($spotLightResponse->hasError()) {
+                    $this->logger->info(
+                        sprintf('Failed to send the event to Sentry. Reason: "%s".', $spotLightResponse->getError()),
+                        ['event' => $event]
+                    );
+                }
+            } catch (\Throwable $exception) {
+                $this->logger->info(
+                    sprintf('Failed to send the event to Spotlight. Reason: "%s".', $exception->getMessage()),
+                    ['exception' => $exception, 'event' => $event]
+                );
+            }
+        }
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -167,6 +167,13 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'spotlight',
+            true,
+            'isSpotlightEnabled',
+            'EnableSpotlight',
+        ];
+
+        yield [
             'release',
             'dev',
             'getRelease',


### PR DESCRIPTION
> Spotlight is Sentry for Development. Inspired by an old project Django Debug Toolbar. Spotlight brings a rich debug overlay into development environments, and it does it by leveraging the existing power of Sentry's SDKs.

Opted to add a new HTTP client for this, as it diverges heavily from our regular one.

![image](https://github.com/getsentry/sentry-php/assets/6617432/3ae9ff81-08dc-4a86-af0b-b4765a6e84ba)

![image](https://github.com/getsentry/sentry-php/assets/6617432/de9c7cde-90c5-4a9a-b18d-b20a8feb3530)

Blocked by https://github.com/getsentry/spotlight/issues/111
 