### PR TITLE
Forbid serializing the HubAdapter in the first place

### DIFF
--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -210,4 +210,12 @@ final class HubAdapter implements HubInterface
     {
         throw new \BadMethodCallException('Unserializing instances of this class is forbidden.');
     }
+
+    /**
+     * @see https://www.php.net/manual/en/language.oop5.magic.php#object.sleep
+     */
+    public function __sleep()
+    {
+        throw new \BadMethodCallException('Serializing instances of this class is forbidden.');
+    }
 }


### PR DESCRIPTION
The symfony cache takes the hint when something isn't serializable. But it will fail if something successfully serializes and then fails to deserialize.

This small change makes the HubAdapter still work, when it accidentally get's caught in the Metadata Cache of Doctrine. This happens, for example, when you use a logger in doctrine events.