### PR TITLE
Add a config option to allow overriding Spotlight url

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -186,6 +186,11 @@ parameters:
 			path: src/Options.php
 
 		-
+			message: "#^Method Sentry\\\\Options\\:\\:getSpotlightUrl\\(\\) should return string but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Method Sentry\\\\Options\\:\\:getTags\\(\\) should return array\\<string, string\\> but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php

--- a/src/Options.php
+++ b/src/Options.php
@@ -348,6 +348,15 @@ final class Options
         return $this->options['spotlight_url'];
     }
 
+    public function setSpotlightUrl(string $url): self
+    {
+        $options = array_merge($this->options, ['spotlight_url' => $url]);
+
+        $this->options = $this->resolver->resolve($options);
+
+        return $this;
+    }
+
     /**
      * Gets the release tag to be passed with every event sent to Sentry.
      */

--- a/src/Options.php
+++ b/src/Options.php
@@ -343,6 +343,11 @@ final class Options
         return $this;
     }
 
+    public function getSpotlightUrl(): string
+    {
+        return $this->options['spotlight_url'];
+    }
+
     /**
      * Gets the release tag to be passed with every event sent to Sentry.
      */
@@ -999,6 +1004,7 @@ final class Options
             'environment' => $_SERVER['SENTRY_ENVIRONMENT'] ?? null,
             'logger' => null,
             'spotlight' => false,
+            'spotlight_url' => 'http://localhost:8969',
             'release' => $_SERVER['SENTRY_RELEASE'] ?? null,
             'dsn' => $_SERVER['SENTRY_DSN'] ?? null,
             'server_name' => gethostname(),
@@ -1047,6 +1053,7 @@ final class Options
         $resolver->setAllowedTypes('in_app_include', 'string[]');
         $resolver->setAllowedTypes('logger', ['null', LoggerInterface::class]);
         $resolver->setAllowedTypes('spotlight', 'bool');
+        $resolver->setAllowedTypes('spotlight_url', 'string');
         $resolver->setAllowedTypes('release', ['null', 'string']);
         $resolver->setAllowedTypes('dsn', ['null', 'string', 'bool', Dsn::class]);
         $resolver->setAllowedTypes('server_name', 'string');

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -132,7 +132,7 @@ class HttpTransport implements TransportInterface
         try {
             $spotLightResponse = SpotlightClient::sendRequest(
                 $request,
-                $this->options->getSpotlightUrl().'/stream'
+                $this->options->getSpotlightUrl() . '/stream'
             );
 
             if ($spotLightResponse->hasError()) {

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -132,7 +132,7 @@ class HttpTransport implements TransportInterface
         try {
             $spotLightResponse = SpotlightClient::sendRequest(
                 $request,
-                'http://localhost:8969/stream'
+                $this->options->getSpotlightUrl().'/stream'
             );
 
             if ($spotLightResponse->hasError()) {

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -174,6 +174,13 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'spotlight_url',
+            'http://google.com',
+            'getSpotlightUrl',
+            'setSpotlightUrl',
+        ];
+
+        yield [
             'release',
             'dev',
             'getRelease',


### PR DESCRIPTION
This PR follows issue https://github.com/getsentry/sentry-php/issues/1658 and adds a "spotlight_url" config option, to allow overriding the sidecar url used by Spotlight.

I think I've done everything needed - I've run all the tests I found in the composer scripts except Psalm (I had extension issues that wouldn't let it run...), and tried to follow the existing patterns I could see. I copied these changes into my project, and it worked as I expected it to!