### PR TITLE
Remove internal annotation from MetricsUnit

### DIFF
--- a/src/Metrics/MetricsUnit.php
+++ b/src/Metrics/MetricsUnit.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\Metrics;
 
-/**
- * @internal
- */
 final class MetricsUnit implements \Stringable
 {
     /**


### PR DESCRIPTION
Otherwise:

![image](https://github.com/getsentry/sentry-php/assets/1090754/305eb29e-d73e-45fd-8655-82c62842b9f7)