### PR TITLE
Fix tags not being serialized correctly for metrics payload

### DIFF
--- a/src/Serializer/EnvelopItems/MetricsItem.php
+++ b/src/Serializer/EnvelopItems/MetricsItem.php
@@ -53,14 +53,17 @@ class MetricsItem implements EnvelopeItemInterface
             // type - |c|, |d|, ...
             $line .= '|' . $metric->getType() . '|';
 
-            $tags = '';
+            $tags = [];
             foreach ($metric->getTags() as $key => $value) {
-                $tags .= preg_replace(self::KEY_PATTERN, '_', $key) .
+                $tags[] = preg_replace(self::KEY_PATTERN, '_', $key) .
                     ':' . preg_replace(self::VALUE_PATTERN, '', $value);
             }
 
-            // tags - #key:value,key:value...
-            $line .= '#' . $tags . '|';
+            if (!empty($tags)) {
+                // tags - #key:value,key:value...
+                $line .= '#' . implode(',', $tags) . '|';
+            }
+
             // timestamp - T123456789
             $line .= 'T' . $metric->getTimestamp();
 

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -424,7 +424,7 @@ TEXT
             $distribution,
             $gauge,
             $set,
-            $noTags
+            $noTags,
         ]);
 
         yield [

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -412,10 +412,11 @@ TEXT
             false,
         ];
 
-        $counter = new CounterType('counter', 1.0, MetricsUnit::second(), ['foo' => 'bar'], 1597790835);
+        $counter = new CounterType('counter', 1.0, MetricsUnit::second(), ['foo' => 'bar', 'baz' => 'qux'], 1597790835);
         $distribution = new DistributionType('distribution', 1.0, MetricsUnit::second(), ['$foo$' => '%bar%'], 1597790835);
         $gauge = new GaugeType('gauge', 1.0, MetricsUnit::second(), ['föö' => 'bär'], 1597790835);
         $set = new SetType('set', 1.0, MetricsUnit::second(), ['%{key}' => '$value$'], 1597790835);
+        $noTags = new CounterType('no_tags', 1.0, MetricsUnit::second(), [], 1597790835);
 
         $event = Event::createMetrics(new EventId('fc9442f5aef34234bb22b9a615e30ccd'));
         $event->setMetrics([
@@ -423,17 +424,19 @@ TEXT
             $distribution,
             $gauge,
             $set,
+            $noTags
         ]);
 
         yield [
             $event,
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
-{"type":"statsd","length":172}
-counter@second:1|c|#foo:bar|T1597790835
+{"type":"statsd","length":211}
+counter@second:1|c|#foo:bar,baz:qux|T1597790835
 distribution@second:1|d|#_foo_:bar|T1597790835
 gauge@second:1:1:1:1:1|g|#f_:br|T1597790835
 set@second:1|s|#_key_:\$value\$|T1597790835
+no_tags@second:1|c|T1597790835
 TEXT
             ,
             false,


### PR DESCRIPTION
We were missing the seperator, tags are also optional so I made that change too although in practice we always have a tag.

Format docs: https://getsentry.github.io/relay/relay_metrics/struct.Bucket.html#structfield.tags