### PR TITLE
Deprecate user segment

### DIFF
--- a/src/Tracing/DynamicSamplingContext.php
+++ b/src/Tracing/DynamicSamplingContext.php
@@ -182,12 +182,6 @@ final class DynamicSamplingContext
             }
         }
 
-        $hub->configureScope(static function (Scope $scope) use ($samplingContext): void {
-            if ($scope->getUser() !== null && $scope->getUser()->getSegment() !== null) {
-                $samplingContext->set('user_segment', $scope->getUser()->getSegment());
-            }
-        });
-
         if ($transaction->getSampled() !== null) {
             $samplingContext->set('sampled', $transaction->getSampled() ? 'true' : 'false');
         }
@@ -216,10 +210,6 @@ final class DynamicSamplingContext
 
         if ($options->getEnvironment() !== null) {
             $samplingContext->set('environment', $options->getEnvironment());
-        }
-
-        if ($scope->getUser() !== null && $scope->getUser()->getSegment() !== null) {
-            $samplingContext->set('user_segment', $scope->getUser()->getSegment());
         }
 
         $samplingContext->freeze();

--- a/src/UserDataBag.php
+++ b/src/UserDataBag.php
@@ -183,6 +183,8 @@ final class UserDataBag
 
     /**
      * Gets the segement of the user.
+     *
+     * @deprecated since version 4.4. To be removed in version 5.0
      */
     public function getSegment(): ?string
     {
@@ -193,6 +195,8 @@ final class UserDataBag
      * Sets the segment of the user.
      *
      * @param string|null $segment The segment
+     *
+     * @deprecated since version 4.4. To be removed in version 5.0. You may use a custom tag or context instead.
      */
     public function setSegment(?string $segment): self
     {


### PR DESCRIPTION
We removed all logic for `user.segment` from the product, hence we can deprecate it.
The segment is no longer used for Dynamic Sampling either, so we can also remove it from the trace envelope header.

Related issue https://github.com/getsentry/sentry/issues/58767