### PR TITLE
Rename `$callable` to `$callback`

### DIFF
--- a/src/Metrics/Metrics.php
+++ b/src/Metrics/Metrics.php
@@ -131,20 +131,20 @@ final class Metrics
     /**
      * @template T
      *
-     * @param callable(): T         $callable
+     * @param callable(): T         $callback
      * @param array<string, string> $tags
      *
      * @return T
      */
     public function timing(
         string $key,
-        callable $callable,
+        callable $callback,
         array $tags = [],
         int $stackLevel = 0
     ) {
         $startTimestamp = microtime(true);
 
-        $result = $callable();
+        $result = $callback();
 
         $this->aggregator->add(
             DistributionType::TYPE,


### PR DESCRIPTION
We call this parameter `$callback` on all other occurrences in the codebase.
Mainly doing it so named arguments stay consistent. It's not BC, but we haven't released #1670 yet.