### PR TITLE
http_ssl_verify_peer sets CURLOPT_SSL_VERIFYPEER correctly

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -74,8 +74,8 @@ class HttpClient implements HttpClientInterface
         curl_setopt($curlHandle, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_1_1);
 
         $httpSslVerifyPeer = $options->getHttpSslVerifyPeer();
-        if ($httpSslVerifyPeer) {
-            curl_setopt($curlHandle, \CURLOPT_SSL_VERIFYPEER, true);
+        if (!$httpSslVerifyPeer) {
+            curl_setopt($curlHandle, \CURLOPT_SSL_VERIFYPEER, false);
         }
 
         $httpProxy = $options->getHttpProxy();


### PR DESCRIPTION
CURLOPT_SSL_VERIFYPEER is by default true. Set to false when http_ssl_verify_peer is false instead to override the default.