### PR TITLE
Allow fluent use of Transaction::setName() method

### DIFF
--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -70,10 +70,14 @@ final class Transaction extends Span
      * Sets the name of this transaction.
      *
      * @param string $name The name
+     *
+     * @return $this
      */
-    public function setName(string $name): void
+    public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**

--- a/tests/Tracing/TransactionTest.php
+++ b/tests/Tracing/TransactionTest.php
@@ -86,6 +86,18 @@ final class TransactionTest extends TestCase
         $transaction->finish();
     }
 
+    public function testFluentApi(): void
+    {
+        $transaction = new Transaction(TransactionContext::make());
+        $tags = ['foo' => 'bar'];
+        $name = 'baz';
+        $transaction->setTags($tags)
+          ->setName($name)
+          ->finish();
+        $this->assertSame($tags, $transaction->getTags());
+        $this->assertSame($name, $transaction->getName());
+    }
+
     /**
      * @dataProvider parentTransactionContextDataProvider
      */


### PR DESCRIPTION
For better developer experience, I'd say Transaction::setName() should also be a fluent method