### PR TITLE
Allow whitespace in metric tag values

### DIFF
--- a/src/Serializer/EnvelopItems/MetricsItem.php
+++ b/src/Serializer/EnvelopItems/MetricsItem.php
@@ -24,7 +24,7 @@ class MetricsItem implements EnvelopeItemInterface
     /**
      * @var string
      */
-    private const VALUE_PATTERN = '/[^\w\d_:\/@\.{}\[\]$-]+/i';
+    private const VALUE_PATTERN = '/[^\w\d\s_:\/@\.{}\[\]$-]+/i';
 
     public static function toEnvelopeItem(Event $event): string
     {

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -412,7 +412,7 @@ TEXT
             ,
         ];
 
-        $counter = new CounterType('counter', 1.0, MetricsUnit::second(), ['foo' => 'bar', 'baz' => 'qux'], 1597790835);
+        $counter = new CounterType('counter', 1.0, MetricsUnit::second(), ['foo' => 'bar', 'route' => 'GET /foo'], 1597790835);
         $distribution = new DistributionType('distribution', 1.0, MetricsUnit::second(), ['$foo$' => '%bar%'], 1597790835);
         $gauge = new GaugeType('gauge', 1.0, MetricsUnit::second(), ['föö' => 'bär'], 1597790835);
         $set = new SetType('set', 1.0, MetricsUnit::second(), ['%{key}' => '$value$'], 1597790835);
@@ -431,8 +431,8 @@ TEXT
             $event,
             <<<TEXT
 {"event_id":"fc9442f5aef34234bb22b9a615e30ccd","sent_at":"2020-08-18T22:47:15Z","dsn":"http:\/\/public@example.com\/sentry\/1","sdk":{"name":"sentry.php","version":"$sdkVersion"}}
-{"type":"statsd","length":211}
-counter@second:1|c|#foo:bar,baz:qux|T1597790835
+{"type":"statsd","length":218}
+counter@second:1|c|#foo:bar,route:GET /foo|T1597790835
 distribution@second:1|d|#_foo_:bar|T1597790835
 gauge@second:1:1:1:1:1|g|#f_:br|T1597790835
 set@second:1|s|#_key_:\$value\$|T1597790835


### PR DESCRIPTION
This fixes an issue when applying the transaction name as a tag, as something like `GET /index` was turned into `GET/index`, which breaks the transaction samples lookup in the Metrics UI.