### PR TITLE
Lazy initialize default values in client builder

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -230,6 +230,22 @@ class Client implements ClientInterface
     }
 
     /**
+     * @internal
+     */
+    public function getLogger(): LoggerInterface
+    {
+        return $this->logger;
+    }
+
+    /**
+     * @internal
+     */
+    public function getTransport(): TransportInterface
+    {
+        return $this->transport;
+    }
+
+    /**
      * Assembles an event and prepares it to be sent of to Sentry.
      *
      * @param Event          $event The payload that will be converted to an Event

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -23,12 +23,12 @@ final class ClientBuilder
     private $options;
 
     /**
-     * @var TransportInterface The transport
+     * @var TransportInterface|null The transport
      */
     private $transport;
 
     /**
-     * @var HttpClientInterface The HTTP client
+     * @var HttpClientInterface|null The HTTP client
      */
     private $httpClient;
 
@@ -60,16 +60,6 @@ final class ClientBuilder
     public function __construct(?Options $options = null)
     {
         $this->options = $options ?? new Options();
-
-        $this->logger = $this->options->getLogger() ?? null;
-
-        $this->httpClient = $this->options->getHttpClient() ?? new HttpClient($this->sdkIdentifier, $this->sdkVersion);
-        $this->transport = $this->options->getTransport() ?? new HttpTransport(
-            $this->options,
-            $this->httpClient,
-            new PayloadSerializer($this->options),
-            $this->logger
-        );
     }
 
     /**
@@ -94,7 +84,7 @@ final class ClientBuilder
 
     public function getLogger(): ?LoggerInterface
     {
-        return $this->logger;
+        return $this->logger ?? $this->options->getLogger();
     }
 
     public function setLogger(LoggerInterface $logger): self
@@ -120,7 +110,12 @@ final class ClientBuilder
 
     public function getTransport(): TransportInterface
     {
-        return $this->transport;
+        return $this->transport ?? $this->options->getTransport() ?? new HttpTransport(
+            $this->options,
+            $this->getHttpClient(),
+            new PayloadSerializer($this->options),
+            $this->getLogger()
+        );
     }
 
     public function setTransport(TransportInterface $transport): self
@@ -132,7 +127,7 @@ final class ClientBuilder
 
     public function getHttpClient(): HttpClientInterface
     {
-        return $this->httpClient;
+        return $this->httpClient ?? $this->options->getHttpClient() ?? new HttpClient($this->sdkIdentifier, $this->sdkVersion);
     }
 
     public function setHttpClient(HttpClientInterface $httpClient): self
@@ -146,11 +141,11 @@ final class ClientBuilder
     {
         return new Client(
             $this->options,
-            $this->transport,
+            $this->getTransport(),
             $this->sdkIdentifier,
             $this->sdkVersion,
             $this->representationSerializer,
-            $this->logger
+            $this->getLogger()
         );
     }
 }

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -110,12 +110,14 @@ final class ClientBuilder
 
     public function getTransport(): TransportInterface
     {
-        return $this->transport ?? $this->options->getTransport() ?? new HttpTransport(
-            $this->options,
-            $this->getHttpClient(),
-            new PayloadSerializer($this->options),
-            $this->getLogger()
-        );
+        return $this->transport
+            ?? $this->options->getTransport()
+            ?? new HttpTransport(
+                $this->options,
+                $this->getHttpClient(),
+                new PayloadSerializer($this->options),
+                $this->getLogger()
+            );
     }
 
     public function setTransport(TransportInterface $transport): self
@@ -127,7 +129,9 @@ final class ClientBuilder
 
     public function getHttpClient(): HttpClientInterface
     {
-        return $this->httpClient ?? $this->options->getHttpClient() ?? new HttpClient($this->sdkIdentifier, $this->sdkVersion);
+        return $this->httpClient
+            ?? $this->options->getHttpClient()
+            ?? new HttpClient($this->sdkIdentifier, $this->sdkVersion);
     }
 
     public function setHttpClient(HttpClientInterface $httpClient): self

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -120,6 +120,14 @@ class HttpTransport implements TransportInterface
         return new Result(ResultStatus::success());
     }
 
+    /**
+     * @internal
+     */
+    public function getHttpClient(): HttpClientInterface
+    {
+        return $this->httpClient;
+    }
+
     private function sendRequestToSpotlight(Event $event): void
     {
         if (!$this->options->isSpotlightEnabled()) {


### PR DESCRIPTION
There are a few reasons to do this, but my main change is so the custom values actually take effect since they were not actually used if they were not set on the options. ~~I quickly looked into writing tests for it but realized why we are not doing that already since it a major hassle.~~ We have tests for the setters and getters on the builder but they were not actually working as expected since setting values on the builder like the logger and http transport/client didn't apply unless they were set on the `Options`, setting them on the client builder had no effect, added tests for that now! 😅