### PR TITLE
Improve debugging experience

### DIFF
--- a/src/EventType.php
+++ b/src/EventType.php
@@ -47,6 +47,21 @@ final class EventType implements \Stringable
         return self::getInstance('metrics');
     }
 
+    /**
+     * List of all cases on the enum.
+     *
+     * @return self[]
+     */
+    public static function cases(): array
+    {
+        return [
+            self::event(),
+            self::transaction(),
+            self::checkIn(),
+            self::metrics(),
+        ];
+    }
+
     public function __toString(): string
     {
         return $this->value;

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -51,29 +51,38 @@ final class IntegrationRegistry
     public function setupIntegrations(Options $options, LoggerInterface $logger): array
     {
         $integrations = [];
+        $installed = [];
 
         foreach ($this->getIntegrationsToSetup($options) as $integration) {
-            $integrations[\get_class($integration)] = $integration;
+            $integrationName = \get_class($integration);
 
-            $this->setupIntegration($integration, $logger);
+            $integrations[$integrationName] = $integration;
+
+            if ($this->setupIntegration($integration)) {
+                $installed[] = $integrationName;
+            }
+        }
+
+        if (\count($installed) > 0) {
+            $logger->debug(sprintf('The "%s" integration(s) have been installed.', implode(', ', $installed)));
         }
 
         return $integrations;
     }
 
-    private function setupIntegration(IntegrationInterface $integration, LoggerInterface $logger): void
+    private function setupIntegration(IntegrationInterface $integration): bool
     {
         $integrationName = \get_class($integration);
 
         if (isset($this->integrations[$integrationName])) {
-            return;
+            return false;
         }
 
         $integration->setupOnce();
 
         $this->integrations[$integrationName] = true;
 
-        $logger->debug(sprintf('The "%s" integration has been installed.', $integrationName));
+        return true;
     }
 
     /**

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -64,7 +64,7 @@ final class IntegrationRegistry
         }
 
         if (\count($installed) > 0) {
-            $logger->debug(sprintf('The "%s" integration(s) have been installed.', implode(', ', $installed)));
+            $logger->info(sprintf('The "%s" integration(s) have been installed.', implode(', ', $installed)));
         }
 
         return $integrations;

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -64,7 +64,7 @@ final class IntegrationRegistry
         }
 
         if (\count($installed) > 0) {
-            $logger->info(sprintf('The "%s" integration(s) have been installed.', implode(', ', $installed)));
+            $logger->debug(sprintf('The "%s" integration(s) have been installed.', implode(', ', $installed)));
         }
 
         return $integrations;

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry;
 
-use Psr\Log\NullLogger;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sentry\HttpClient\HttpClientInterface;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\IntegrationInterface;

--- a/src/Options.php
+++ b/src/Options.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Psr\Log\NullLogger;
 use Psr\Log\LoggerInterface;
 use Sentry\HttpClient\HttpClientInterface;
 use Sentry\Integration\ErrorListenerIntegration;
@@ -335,6 +336,14 @@ final class Options
     public function getLogger(): ?LoggerInterface
     {
         return $this->options['logger'];
+    }
+
+    /**
+     * Helper to always get a logger instance even if it was not set.
+     */
+    public function getLoggerOrNullLogger(): LoggerInterface
+    {
+        return $this->getLogger() ?? new NullLogger();
     }
 
     /**

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -73,12 +73,6 @@ final class Profiler
 
     private function initProfiler(): void
     {
-        if (\PHP_VERSION_ID < 70300) {
-            $this->logger->warning('The profiler was started but is not available because it requires PHP 7.3 or higher.');
-
-            return;
-        }
-
         if (!\extension_loaded('excimer')) {
             $this->logger->warning('The profiler was started but is not available because the "excimer" extension is not loaded.');
 

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Sentry\Profiling;
 
-use Sentry\Options;
-use Psr\Log\NullLogger;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Sentry\Options;
 
 /**
  * @internal

--- a/src/Profiling/Profiler.php
+++ b/src/Profiling/Profiler.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Sentry\Profiling;
 
 use Sentry\Options;
+use Psr\Log\NullLogger;
+use Psr\Log\LoggerInterface;
 
 /**
  * @internal
@@ -22,6 +24,11 @@ final class Profiler
     private $profile;
 
     /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
      * @var float The sample rate (10.01ms/101 Hz)
      */
     private const SAMPLE_RATE = 0.0101;
@@ -33,6 +40,7 @@ final class Profiler
 
     public function __construct(?Options $options = null)
     {
+        $this->logger = $options !== null ? $options->getLoggerOrNullLogger() : new NullLogger();
         $this->profile = new Profile($options);
 
         $this->initProfiler();
@@ -65,13 +73,23 @@ final class Profiler
 
     private function initProfiler(): void
     {
-        if (\extension_loaded('excimer') && \PHP_VERSION_ID >= 70300) {
-            $this->profiler = new \ExcimerProfiler();
-            $this->profile->setStartTimeStamp(microtime(true));
+        if (\PHP_VERSION_ID < 70300) {
+            $this->logger->warning('The profiler was started but is not available because it requires PHP 7.3 or higher.');
 
-            $this->profiler->setEventType(EXCIMER_REAL);
-            $this->profiler->setPeriod(self::SAMPLE_RATE);
-            $this->profiler->setMaxDepth(self::MAX_STACK_DEPTH);
+            return;
         }
+
+        if (!\extension_loaded('excimer')) {
+            $this->logger->warning('The profiler was started but is not available because the "excimer" extension is not loaded.');
+
+            return;
+        }
+
+        $this->profiler = new \ExcimerProfiler();
+        $this->profile->setStartTimeStamp(microtime(true));
+
+        $this->profiler->setEventType(EXCIMER_REAL);
+        $this->profiler->setPeriod(self::SAMPLE_RATE);
+        $this->profiler->setMaxDepth(self::MAX_STACK_DEPTH);
     }
 }

--- a/src/StacktraceBuilder.php
+++ b/src/StacktraceBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry;
 
 use Sentry\Serializer\RepresentationSerializerInterface;
+use Sentry\Util\PHPConfiguration;
 
 /**
  * This class builds {@see Stacktrace} objects from an instance of an exception
@@ -28,6 +29,10 @@ final class StacktraceBuilder
     public function __construct(Options $options, RepresentationSerializerInterface $representationSerializer)
     {
         $this->frameBuilder = new FrameBuilder($options, $representationSerializer);
+
+        if (PHPConfiguration::isBooleanIniOptionEnabled('zend.exception_ignore_args')) {
+            $options->getLoggerOrNullLogger()->warning('The "zend.exception_ignore_args" PHP setting is enabled which results in missing stack trace arguments, see: https://docs.sentry.io/platforms/php/troubleshooting/#missing-variables-in-stack-traces.');
+        }
     }
 
     /**

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\State;
 
+use Psr\Log\NullLogger;
 use Sentry\Breadcrumb;
 use Sentry\CheckIn;
 use Sentry\CheckInStatus;
@@ -254,13 +255,12 @@ class Hub implements HubInterface
         $transaction = new Transaction($context, $this);
         $client = $this->getClient();
         $options = $client !== null ? $client->getOptions() : null;
+        $logger = $options !== null ? $options->getLoggerOrNullLogger() : new NullLogger();
 
         if ($options === null || !$options->isTracingEnabled()) {
             $transaction->setSampled(false);
 
-            if ($options !== null) {
-                $options->getLoggerOrNullLogger()->debug('Transaction was started but tracing is not enabled.');
-            }
+            $logger->warning(sprintf('Transaction [%s] was started but tracing is not enabled.', (string) $transaction->getTraceId()), ['context' => $context]);
 
             return $transaction;
         }
@@ -268,20 +268,28 @@ class Hub implements HubInterface
         $samplingContext = SamplingContext::getDefault($context);
         $samplingContext->setAdditionalContext($customSamplingContext);
 
-        $tracesSampler = $options->getTracesSampler();
+        $sampleSource = 'context';
 
         if ($transaction->getSampled() === null) {
+            $tracesSampler = $options->getTracesSampler();
+
             if ($tracesSampler !== null) {
                 $sampleRate = $tracesSampler($samplingContext);
+
+                $sampleSource = 'config:traces_sampler';
             } else {
                 $sampleRate = $this->getSampleRate(
                     $samplingContext->getParentSampled(),
                     $options->getTracesSampleRate() ?? 0
                 );
+
+                $sampleSource = $samplingContext->getParentSampled() ? 'parent' : 'config:traces_sample_rate';
             }
 
             if (!$this->isValidSampleRate($sampleRate)) {
                 $transaction->setSampled(false);
+
+                $logger->warning(sprintf('Transaction [%s] was started but not sampled because sample rate (decided by %s) is invalid.', (string) $transaction->getTraceId(), $sampleSource), ['context' => $context]);
 
                 return $transaction;
             }
@@ -291,6 +299,8 @@ class Hub implements HubInterface
             if ($sampleRate === 0.0) {
                 $transaction->setSampled(false);
 
+                $logger->info(sprintf('Transaction [%s] was started but not sampled because sample rate (decided by %s) is %s.', (string) $transaction->getTraceId(), $sampleSource, $sampleRate), ['context' => $context]);
+
                 return $transaction;
             }
 
@@ -298,18 +308,24 @@ class Hub implements HubInterface
         }
 
         if (!$transaction->getSampled()) {
+            $logger->info(sprintf('Transaction [%s] was started but not sampled, decided by %s.', (string) $transaction->getTraceId(), $sampleSource), ['context' => $context]);
+
             return $transaction;
         }
+
+        $logger->info(sprintf('Transaction [%s] was started and sampled, decided by %s.', (string) $transaction->getTraceId(), $sampleSource), ['context' => $context]);
 
         $transaction->initSpanRecorder();
 
         $profilesSampleRate = $options->getProfilesSampleRate();
-        if ($this->sample($profilesSampleRate)) {
-            $transaction->initProfiler();
-            $profiler = $transaction->getProfiler();
-            if ($profiler !== null) {
-                $profiler->start();
-            }
+        if ($profilesSampleRate === null) {
+            $logger->info(sprintf('Transaction [%s] is not profiling because `profiles_sample_rate` option is not set.', (string) $transaction->getTraceId()));
+        } elseif ($this->sample($profilesSampleRate)) {
+            $logger->info(sprintf('Transaction [%s] started profiling because it was sampled.', (string) $transaction->getTraceId()));
+
+            $transaction->initProfiler()->start();
+        } else {
+            $logger->info(sprintf('Transaction [%s] is not profiling because it was not sampled.', (string) $transaction->getTraceId()));
         }
 
         return $transaction;
@@ -375,7 +391,7 @@ class Hub implements HubInterface
      */
     private function sample($sampleRate): bool
     {
-        if ($sampleRate === 0.0) {
+        if ($sampleRate === 0.0 || $sampleRate === null) {
             return false;
         }
 

--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -258,6 +258,10 @@ class Hub implements HubInterface
         if ($options === null || !$options->isTracingEnabled()) {
             $transaction->setSampled(false);
 
+            if ($options !== null) {
+                $options->getLoggerOrNullLogger()->debug('Transaction was started but tracing is not enabled.');
+            }
+
             return $transaction;
         }
 

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -119,7 +119,7 @@ final class Transaction extends Span
         return $this;
     }
 
-    public function initProfiler(): self
+    public function initProfiler(): Profiler
     {
         if ($this->profiler === null) {
             $client = $this->hub->getClient();
@@ -128,7 +128,7 @@ final class Transaction extends Span
             $this->profiler = new Profiler($options);
         }
 
-        return $this;
+        return $this->profiler;
     }
 
     public function getProfiler(): ?Profiler

--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -77,7 +77,7 @@ class HttpTransport implements TransportInterface
         );
 
         if ($this->options->getDsn() === null) {
-            $this->logger->debug(sprintf('Skipping %s, because no DSN is set.', $eventDescription), ['event' => $event]);
+            $this->logger->info(sprintf('Skipping %s, because no DSN is set.', $eventDescription), ['event' => $event]);
 
             return new Result(ResultStatus::skipped(), $event);
         }
@@ -88,7 +88,7 @@ class HttpTransport implements TransportInterface
             $this->options->getDsn()->getProjectId()
         );
 
-        $this->logger->debug(sprintf('Sending %s to %s.', $eventDescription, $targetDescription), ['event' => $event]);
+        $this->logger->info(sprintf('Sending %s to %s.', $eventDescription, $targetDescription), ['event' => $event]);
 
         $eventType = $event->getType();
         if ($this->rateLimiter->isRateLimited($eventType)) {
@@ -135,7 +135,7 @@ class HttpTransport implements TransportInterface
 
         $resultStatus = ResultStatus::createFromHttpStatusCode($response->getStatusCode());
 
-        $this->logger->debug(
+        $this->logger->info(
             sprintf('Sent %s to %s. Result: "%s" (status: %s).', $eventDescription, $targetDescription, strtolower((string) $resultStatus), $response->getStatusCode()),
             ['response' => $response, 'event' => $event]
         );

--- a/src/Util/PHPConfiguration.php
+++ b/src/Util/PHPConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Util;
+
+class PHPConfiguration
+{
+    public static function isBooleanIniOptionEnabled(string $option): bool
+    {
+        $value = \ini_get($option);
+
+        if (empty($value)) {
+            return false;
+        }
+
+        // https://www.php.net/manual/en/function.ini-get.php#refsect1-function.ini-get-notes
+        return \in_array(strtolower($value), ['1', 'on', 'true'], true);
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Tests;
 
+use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -36,11 +37,11 @@ final class ClientTest extends TestCase
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('debug');
+               ->method('debug');
 
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because one of the event processors returned "null".');
+               ->method('info')
+               ->with(new StringMatchesFormatDescription('The event [%s] will be discarded because one of the event processors returned "null".'));
 
         $integration = new class($integrationCalled) implements IntegrationInterface {
             private $integrationCalled;
@@ -82,20 +83,20 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $this->assertSame('foo', $event->getMessage());
-                $this->assertEquals(Severity::fatal(), $event->getLevel());
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $this->assertSame('foo', $event->getMessage());
+                      $this->assertEquals(Severity::fatal(), $event->getLevel());
 
-                return true;
-            }))
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                      return true;
+                  }))
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create()
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $this->assertNotNull($client->captureMessage('foo', Severity::fatal()));
     }
@@ -129,24 +130,24 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event) use ($exception): bool {
-                $this->assertCount(1, $event->getExceptions());
+                  ->method('send')
+                  ->with($this->callback(function (Event $event) use ($exception): bool {
+                      $this->assertCount(1, $event->getExceptions());
 
-                $exceptionData = $event->getExceptions()[0];
+                      $exceptionData = $event->getExceptions()[0];
 
-                $this->assertSame(\get_class($exception), $exceptionData->getType());
-                $this->assertSame($exception->getMessage(), $exceptionData->getValue());
+                      $this->assertSame(\get_class($exception), $exceptionData->getType());
+                      $this->assertSame($exception->getMessage(), $exceptionData->getValue());
 
-                return true;
-            }))
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                      return true;
+                  }))
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create()
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $this->assertNotNull($client->captureException($exception));
     }
@@ -192,7 +193,7 @@ final class ClientTest extends TestCase
     }
 
     /**
-     * @group legacy
+     * @group        legacy
      *
      * @dataProvider captureEventDataProvider
      */
@@ -200,15 +201,15 @@ final class ClientTest extends TestCase
     {
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($expectedEvent)
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                  ->method('send')
+                  ->with($expectedEvent)
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create($options)
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $this->assertSame($event->getId(), $client->captureEvent($event));
     }
@@ -310,25 +311,25 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(static function (Event $event) use ($shouldAttachStacktrace): bool {
-                if ($shouldAttachStacktrace && $event->getStacktrace() === null) {
-                    return false;
-                }
+                  ->method('send')
+                  ->with($this->callback(static function (Event $event) use ($shouldAttachStacktrace): bool {
+                      if ($shouldAttachStacktrace && $event->getStacktrace() === null) {
+                          return false;
+                      }
 
-                if (!$shouldAttachStacktrace && $event->getStacktrace() !== null) {
-                    return false;
-                }
+                      if (!$shouldAttachStacktrace && $event->getStacktrace() !== null) {
+                          return false;
+                      }
 
-                return true;
-            }))
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                      return true;
+                  }))
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create(['attach_stacktrace' => $attachStacktraceOption])
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $this->assertNotNull($client->captureEvent(Event::createEvent(), $hint));
     }
@@ -373,17 +374,17 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(static function (Event $event) use ($stacktrace): bool {
-                return $stacktrace === $event->getStacktrace();
-            }))
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                  ->method('send')
+                  ->with($this->callback(static function (Event $event) use ($stacktrace): bool {
+                      return $stacktrace === $event->getStacktrace();
+                  }))
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create(['attach_stacktrace' => true])
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $this->assertNotNull($client->captureEvent(Event::createEvent(), EventHint::fromArray([
             'stacktrace' => $stacktrace,
@@ -395,22 +396,22 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $exception = $event->getExceptions()[0];
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $exception = $event->getExceptions()[0];
 
-                $this->assertEquals('ErrorException', $exception->getType());
-                $this->assertEquals('foo', $exception->getValue());
+                      $this->assertEquals('ErrorException', $exception->getType());
+                      $this->assertEquals('foo', $exception->getValue());
 
-                return true;
-            }))
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                      return true;
+                  }))
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/1'])
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         @trigger_error('foo', \E_USER_NOTICE);
 
@@ -451,12 +452,12 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->never())
-            ->method('send')
-            ->with($this->anything());
+                  ->method('send')
+                  ->with($this->anything());
 
         $client = ClientBuilder::create(['dsn' => 'http://public:secret@example.com/1'])
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         error_clear_last();
 
@@ -639,20 +640,23 @@ final class ClientTest extends TestCase
     {
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->never())
-            ->method('send')
-            ->with($this->anything());
+                  ->method('send')
+                  ->with($this->anything());
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because it has been sampled.', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The event [%s] will be discarded because it has been sampled.'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $client = ClientBuilder::create(['sample_rate' => 0])
-            ->setTransport($transport)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureEvent(Event::createEvent());
     }
@@ -661,12 +665,12 @@ final class ClientTest extends TestCase
     {
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->anything());
+                  ->method('send')
+                  ->with($this->anything());
 
         $client = ClientBuilder::create(['sample_rate' => 1])
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $client->captureEvent(Event::createEvent());
     }
@@ -678,16 +682,16 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because it matches an entry in "ignore_exceptions".');
+               ->method('info')
+               ->with('The exception will be discarded because it matches an entry in "ignore_exceptions".');
 
         $options = [
             'ignore_exceptions' => [\Exception::class],
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureException($exception);
     }
@@ -699,16 +703,16 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because it matches an entry in "ignore_exceptions".');
+               ->method('info')
+               ->with('The exception will be discarded because it matches an entry in "ignore_exceptions".');
 
         $options = [
             'ignore_exceptions' => [\RuntimeException::class],
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureException($exception);
     }
@@ -721,18 +725,21 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because it matches a entry in "ignore_transactions".', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The transaction [%s] will be discarded because it matches a entry in "ignore_transactions".'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $options = [
             'ignore_transactions' => ['GET /foo'],
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureEvent($event);
     }
@@ -742,10 +749,13 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because the "before_send" callback returned "null".', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The event [%s] will be discarded because the "before_send" callback returned "null".'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $options = [
             'before_send' => static function () {
@@ -754,8 +764,8 @@ final class ClientTest extends TestCase
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureEvent(Event::createEvent());
     }
@@ -765,10 +775,13 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because the "before_send_transaction" callback returned "null".', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The transaction [%s] will be discarded because the "before_send_transaction" callback returned "null".'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $options = [
             'before_send_transaction' => static function () {
@@ -777,8 +790,8 @@ final class ClientTest extends TestCase
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureEvent(Event::createTransaction());
     }
@@ -788,10 +801,13 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because the "before_send_check_in" callback returned "null".', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The check_in [%s] will be discarded because the "before_send_check_in" callback returned "null".'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $options = [
             'before_send_check_in' => static function () {
@@ -800,8 +816,8 @@ final class ClientTest extends TestCase
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureEvent(Event::createCheckIn());
     }
@@ -811,10 +827,13 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because the "before_send_metrics" callback returned "null".', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The metrics [%s] will be discarded because the "before_send_metrics" callback returned "null".'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $options = [
             'before_send_metrics' => static function () {
@@ -823,8 +842,8 @@ final class ClientTest extends TestCase
         ];
 
         $client = ClientBuilder::create($options)
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $client->captureEvent(Event::createMetrics());
     }
@@ -834,14 +853,17 @@ final class ClientTest extends TestCase
         /** @var LoggerInterface&MockObject $logger */
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
-            ->method('info')
-            ->with('The event will be discarded because one of the event processors returned "null".', $this->callback(static function (array $context): bool {
-                return isset($context['event']) && $context['event'] instanceof Event;
-            }));
+               ->method('info')
+               ->with(
+                   new StringMatchesFormatDescription('The debug event [%s] will be discarded because one of the event processors returned "null".'),
+                   $this->callback(static function (array $context): bool {
+                       return isset($context['event']) && $context['event'] instanceof Event;
+                   })
+               );
 
         $client = ClientBuilder::create([])
-            ->setLogger($logger)
-            ->getClient();
+                               ->setLogger($logger)
+                               ->getClient();
 
         $scope = new Scope();
         $scope->addEventProcessor(static function () {
@@ -856,19 +878,19 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $result = $event->getStacktrace();
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $result = $event->getStacktrace();
 
-                return $result !== null;
-            }))
-            ->willReturnCallback(static function (Event $event): Result {
-                return new Result(ResultStatus::success(), $event);
-            });
+                      return $result !== null;
+                  }))
+                  ->willReturnCallback(static function (Event $event): Result {
+                      return new Result(ResultStatus::success(), $event);
+                  });
 
         $client = ClientBuilder::create(['attach_stacktrace' => true])
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $this->assertNotNull($client->captureMessage('test'));
     }
@@ -878,13 +900,13 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('close')
-            ->with(10)
-            ->willReturn(new Result(ResultStatus::success()));
+                  ->method('close')
+                  ->with(10)
+                  ->willReturn(new Result(ResultStatus::success()));
 
         $client = ClientBuilder::create()
-            ->setTransport($transport)
-            ->getClient();
+                               ->setTransport($transport)
+                               ->getClient();
 
         $response = $client->flush(10);
 
@@ -896,12 +918,12 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $this->assertNull($event->getTransaction());
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $this->assertNull($event->getTransaction());
 
-                return true;
-            }));
+                      return true;
+                  }));
 
         $client = new Client(
             new Options(),
@@ -923,23 +945,23 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $capturedExceptions = $event->getExceptions();
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $capturedExceptions = $event->getExceptions();
 
-                $this->assertCount(2, $capturedExceptions);
-                $this->assertNotNull($capturedExceptions[0]->getStacktrace());
-                $this->assertEquals(new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true, ['code' => 1]), $capturedExceptions[0]->getMechanism());
-                $this->assertSame(\Exception::class, $capturedExceptions[0]->getType());
-                $this->assertSame('testMessage', $capturedExceptions[0]->getValue());
+                      $this->assertCount(2, $capturedExceptions);
+                      $this->assertNotNull($capturedExceptions[0]->getStacktrace());
+                      $this->assertEquals(new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true, ['code' => 1]), $capturedExceptions[0]->getMechanism());
+                      $this->assertSame(\Exception::class, $capturedExceptions[0]->getType());
+                      $this->assertSame('testMessage', $capturedExceptions[0]->getValue());
 
-                $this->assertNotNull($capturedExceptions[1]->getStacktrace());
-                $this->assertEquals(new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true, ['code' => 0]), $capturedExceptions[1]->getMechanism());
-                $this->assertSame(\RuntimeException::class, $capturedExceptions[1]->getType());
-                $this->assertSame('testMessage2', $capturedExceptions[1]->getValue());
+                      $this->assertNotNull($capturedExceptions[1]->getStacktrace());
+                      $this->assertEquals(new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true, ['code' => 0]), $capturedExceptions[1]->getMechanism());
+                      $this->assertSame(\RuntimeException::class, $capturedExceptions[1]->getType());
+                      $this->assertSame('testMessage2', $capturedExceptions[1]->getValue());
 
-                return true;
-            }));
+                      return true;
+                  }));
 
         $client = new Client(
             $options,
@@ -962,18 +984,18 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $capturedExceptions = $event->getExceptions();
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $capturedExceptions = $event->getExceptions();
 
-                $this->assertCount(1, $capturedExceptions);
-                $this->assertNotNull($capturedExceptions[0]->getStacktrace());
-                $this->assertEquals(new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, false), $capturedExceptions[0]->getMechanism());
-                $this->assertSame(\Exception::class, $capturedExceptions[0]->getType());
-                $this->assertSame('testMessage', $capturedExceptions[0]->getValue());
+                      $this->assertCount(1, $capturedExceptions);
+                      $this->assertNotNull($capturedExceptions[0]->getStacktrace());
+                      $this->assertEquals(new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, false), $capturedExceptions[0]->getMechanism());
+                      $this->assertSame(\Exception::class, $capturedExceptions[0]->getType());
+                      $this->assertSame('testMessage', $capturedExceptions[0]->getValue());
 
-                return true;
-            }));
+                      return true;
+                  }));
 
         $client = new Client(
             $options,
@@ -996,12 +1018,12 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $this->assertTrue(Severity::error()->isEqualTo($event->getLevel()));
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $this->assertTrue(Severity::error()->isEqualTo($event->getLevel()));
 
-                return true;
-            }));
+                      return true;
+                  }));
 
         $client = new Client(
             $options,
@@ -1024,22 +1046,22 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $stacktrace = $event->getStacktrace();
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $stacktrace = $event->getStacktrace();
 
-                $this->assertInstanceOf(Stacktrace::class, $stacktrace);
+                      $this->assertInstanceOf(Stacktrace::class, $stacktrace);
 
-                /** @var Frame $lastFrame */
-                $lastFrame = array_reverse($stacktrace->getFrames())[0];
+                      /** @var Frame $lastFrame */
+                      $lastFrame = array_reverse($stacktrace->getFrames())[0];
 
-                $this->assertSame(
-                    'Client.php',
-                    basename($lastFrame->getFile())
-                );
+                      $this->assertSame(
+                          'Client.php',
+                          basename($lastFrame->getFile())
+                      );
 
-                return true;
-            }));
+                      return true;
+                  }));
 
         $client = new Client(
             $options,
@@ -1059,22 +1081,22 @@ final class ClientTest extends TestCase
         /** @var TransportInterface&MockObject $transport */
         $transport = $this->createMock(TransportInterface::class);
         $transport->expects($this->once())
-            ->method('send')
-            ->with($this->callback(function (Event $event): bool {
-                $stacktrace = $event->getStacktrace();
+                  ->method('send')
+                  ->with($this->callback(function (Event $event): bool {
+                      $stacktrace = $event->getStacktrace();
 
-                $this->assertNotNull($stacktrace);
+                      $this->assertNotNull($stacktrace);
 
-                /** @var Frame $lastFrame */
-                $lastFrame = array_reverse($stacktrace->getFrames())[0];
+                      /** @var Frame $lastFrame */
+                      $lastFrame = array_reverse($stacktrace->getFrames())[0];
 
-                $this->assertSame(
-                    'MyApp.php',
-                    $lastFrame->getFile()
-                );
+                      $this->assertSame(
+                          'MyApp.php',
+                          $lastFrame->getFile()
+                      );
 
-                return true;
-            }));
+                      return true;
+                  }));
 
         $client = new Client(
             $options,

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -29,7 +29,7 @@ final class HttpTransportTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->httpClient        = $this->createMock(HttpClientInterface::class);
+        $this->httpClient = $this->createMock(HttpClientInterface::class);
         $this->payloadSerializer = $this->createMock(PayloadSerializerInterface::class);
     }
 
@@ -100,7 +100,7 @@ final class HttpTransportTest extends TestCase
     public function testSendFailsDueToHttpClientException(): void
     {
         $exception = new \Exception('foo');
-        $event     = Event::createEvent();
+        $event = Event::createEvent();
 
         $this->payloadSerializer->expects($this->once())
                                 ->method('serialize')

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\Transport;
 
+use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sentry\Event;
 use Sentry\HttpClient\HttpClientInterface;
 use Sentry\HttpClient\Response;
@@ -18,6 +20,11 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 final class HttpTransportTest extends TestCase
 {
     /**
+     * @var LoggerInterface&MockObject
+     */
+    private $logger;
+
+    /**
      * @var MockObject&HttpAsyncClientInterface
      */
     private $httpClient;
@@ -29,6 +36,7 @@ final class HttpTransportTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->httpClient = $this->createMock(HttpClientInterface::class);
         $this->payloadSerializer = $this->createMock(PayloadSerializerInterface::class);
     }
@@ -36,25 +44,36 @@ final class HttpTransportTest extends TestCase
     /**
      * @dataProvider sendDataProvider
      */
-    public function testSend(Response $response, ResultStatus $expectedResultStatus, bool $expectEventReturned): void
+    public function testSend(Response $response, ResultStatus $expectedResultStatus, bool $expectEventReturned, array $expectedLogMessages): void
     {
         $event = Event::createEvent();
 
         $this->payloadSerializer->expects($this->once())
-                                ->method('serialize')
-                                ->with($event)
-                                ->willReturn('{"foo":"bar"}');
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
 
         $this->httpClient->expects($this->once())
-                         ->method('sendRequest')
-                         ->willReturn($response);
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        foreach ($expectedLogMessages as $level => $messages) {
+            $this->logger->expects($this->exactly(\count($messages)))
+                ->method($level)
+                ->with($this->logicalOr(
+                    ...array_map(function (string $message) {
+                        return new StringMatchesFormatDescription($message);
+                    }, $messages)
+                ));
+        }
 
         $transport = new HttpTransport(
             new Options([
                 'dsn' => 'http://public@example.com/1',
             ]),
             $this->httpClient,
-            $this->payloadSerializer
+            $this->payloadSerializer,
+            $this->logger
         );
 
         // We need to mock the time to ensure that the rate limiter works as expected and we can easily assert the log messages
@@ -74,12 +93,24 @@ final class HttpTransportTest extends TestCase
             new Response(200, [], ''),
             ResultStatus::success(),
             true,
+            [
+                'info' => [
+                    'Sending event [%s] to %s [project:%s].',
+                    'Sent event [%s] to %s [project:%s]. Result: "success" (status: 200).',
+                ],
+            ],
         ];
 
         yield [
             new Response(401, [], ''),
             ResultStatus::invalid(),
             false,
+            [
+                'info' => [
+                    'Sending event [%s] to %s [project:%s].',
+                    'Sent event [%s] to %s [project:%s]. Result: "invalid" (status: 401).',
+                ],
+            ],
         ];
 
         ClockMock::withClockMock(1644105600);
@@ -88,12 +119,27 @@ final class HttpTransportTest extends TestCase
             new Response(429, ['Retry-After' => ['60']], ''),
             ResultStatus::rateLimit(),
             false,
+            [
+                'info' => [
+                    'Sending event [%s] to %s [project:%s].',
+                    'Sent event [%s] to %s [project:%s]. Result: "rate_limit" (status: 429).',
+                ],
+                'warning' => [
+                    'Rate limited exceeded for requests of type "event", backing off until "2022-02-06T00:01:00+00:00".',
+                ],
+            ],
         ];
 
         yield [
             new Response(500, [], ''),
             ResultStatus::failed(),
             false,
+            [
+                'info' => [
+                    'Sending event [%s] to %s [project:%s].',
+                    'Sent event [%s] to %s [project:%s]. Result: "failed" (status: 500).',
+                ],
+            ],
         ];
     }
 
@@ -102,21 +148,31 @@ final class HttpTransportTest extends TestCase
         $exception = new \Exception('foo');
         $event = Event::createEvent();
 
+        /** @var LoggerInterface&MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                new StringMatchesFormatDescription('Failed to send event [%s] to %s [project:%s]. Reason: "foo".'),
+                ['exception' => $exception, 'event' => $event]
+            );
+
         $this->payloadSerializer->expects($this->once())
-                                ->method('serialize')
-                                ->with($event)
-                                ->willReturn('{"foo":"bar"}');
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
 
         $this->httpClient->expects($this->once())
-                         ->method('sendRequest')
-                         ->will($this->throwException($exception));
+            ->method('sendRequest')
+            ->will($this->throwException($exception));
 
         $transport = new HttpTransport(
             new Options([
                 'dsn' => 'http://public@example.com/1',
             ]),
             $this->httpClient,
-            $this->payloadSerializer
+            $this->payloadSerializer,
+            $logger
         );
 
         $result = $transport->send($event);
@@ -128,21 +184,31 @@ final class HttpTransportTest extends TestCase
     {
         $event = Event::createEvent();
 
+        /** @var LoggerInterface&MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('error')
+            ->with(
+                new StringMatchesFormatDescription('Failed to send event [%s] to %s [project:%s]. Reason: "cURL Error (6) Could not resolve host: example.com".'),
+                ['event' => $event]
+            );
+
         $this->payloadSerializer->expects($this->once())
-                                ->method('serialize')
-                                ->with($event)
-                                ->willReturn('{"foo":"bar"}');
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
 
         $this->httpClient->expects($this->once())
-                         ->method('sendRequest')
-                         ->willReturn(new Response(0, [], 'cURL Error (6) Could not resolve host: example.com'));
+            ->method('sendRequest')
+            ->willReturn(new Response(0, [], 'cURL Error (6) Could not resolve host: example.com'));
 
         $transport = new HttpTransport(
             new Options([
                 'dsn' => 'http://public@example.com/1',
             ]),
             $this->httpClient,
-            $this->payloadSerializer
+            $this->payloadSerializer,
+            $logger
         );
 
         $result = $transport->send($event);
@@ -159,21 +225,31 @@ final class HttpTransportTest extends TestCase
 
         $event = Event::createEvent();
 
+        /** @var LoggerInterface&MockObject $logger */
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->exactly(2))
+            ->method('warning')
+            ->withConsecutive(
+                ['Rate limited exceeded for requests of type "event", backing off until "2022-02-06T00:01:00+00:00".', ['event' => $event]],
+                ['Rate limit exceeded for sending requests of type "event".', ['event' => $event]]
+            );
+
         $this->payloadSerializer->expects($this->once())
-                                ->method('serialize')
-                                ->with($event)
-                                ->willReturn('{"foo":"bar"}');
+            ->method('serialize')
+            ->with($event)
+            ->willReturn('{"foo":"bar"}');
 
         $this->httpClient->expects($this->once())
-                         ->method('sendRequest')
-                         ->willReturn(new Response(429, ['Retry-After' => ['60']], ''));
+            ->method('sendRequest')
+            ->willReturn(new Response(429, ['Retry-After' => ['60']], ''));
 
         $transport = new HttpTransport(
             new Options([
                 'dsn' => 'http://public@example.com/1',
             ]),
             $this->httpClient,
-            $this->payloadSerializer
+            $this->payloadSerializer,
+            $logger
         );
 
         // Event should be sent, but the server should reply with a HTTP 429

--- a/tests/Transport/RateLimiterTest.php
+++ b/tests/Transport/RateLimiterTest.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\Transport;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
-use Sentry\Event;
 use Sentry\EventType;
 use Sentry\HttpClient\Response;
 use Sentry\Transport\RateLimiter;
@@ -19,73 +16,68 @@ use Symfony\Bridge\PhpUnit\ClockMock;
 final class RateLimiterTest extends TestCase
 {
     /**
-     * @var LoggerInterface&MockObject
-     */
-    private $logger;
-
-    /**
      * @var RateLimiter
      */
     private $rateLimiter;
 
     protected function setUp(): void
     {
-        $this->logger = $this->createMock(LoggerInterface::class);
-        $this->rateLimiter = new RateLimiter($this->logger);
+        $this->rateLimiter = new RateLimiter();
     }
 
     /**
      * @dataProvider handleResponseDataProvider
      */
-    public function testHandleResponse(Event $event, Response $response, int $responseStatusCode): void
+    public function testHandleResponse(Response $response, bool $shouldBeHandled, array $eventTypesLimited = []): void
     {
         ClockMock::withClockMock(1644105600);
 
-        $this->logger->expects($response->isSuccess() ? $this->never() : $this->once())
-            ->method('warning')
-            ->with('Rate limited exceeded for requests of type "event", backing off until "2022-02-06T00:01:00+00:00".', ['event' => $event]);
+        $rateLimiterResponse = $this->rateLimiter->handleResponse($response);
 
-        $rateLimiterResponse = $this->rateLimiter->handleResponse($event, $response);
-
-        $this->assertSame($responseStatusCode, $rateLimiterResponse->getStatusCode());
+        $this->assertSame($shouldBeHandled, $rateLimiterResponse);
+        $this->assertEventTypesAreRateLimited($eventTypesLimited);
     }
 
     public static function handleResponseDataProvider(): \Generator
     {
         yield 'Rate limits headers missing' => [
-            Event::createEvent(),
             new Response(200, [], ''),
-            200,
+            false,
         ];
 
         yield 'Back-off using X-Sentry-Rate-Limits header with single category' => [
-            Event::createEvent(),
             new Response(429, ['X-Sentry-Rate-Limits' => ['60:error:org']], ''),
-            429,
+            true,
+            [
+                EventType::event(),
+            ],
         ];
 
         yield 'Back-off using X-Sentry-Rate-Limits header with multiple categories' => [
-            Event::createEvent(),
             new Response(429, ['X-Sentry-Rate-Limits' => ['60:error;transaction:org']], ''),
-            429,
+            true,
+            [
+                EventType::event(),
+                EventType::transaction(),
+            ],
         ];
 
         yield 'Back-off using X-Sentry-Rate-Limits header with missing categories should lock them all' => [
-            Event::createEvent(),
             new Response(429, ['X-Sentry-Rate-Limits' => ['60::org']], ''),
-            429,
+            true,
+            EventType::cases(),
         ];
 
         yield 'Back-off using Retry-After header with number-based value' => [
-            Event::createEvent(),
             new Response(429, ['Retry-After' => ['60']], ''),
-            429,
+            true,
+            EventType::cases(),
         ];
 
         yield 'Back-off using Retry-After header with date-based value' => [
-            Event::createEvent(),
             new Response(429, ['Retry-After' => ['Sun, 02 February 2022 00:01:00 GMT']], ''),
-            429,
+            true,
+            EventType::cases(),
         ];
     }
 
@@ -94,34 +86,39 @@ final class RateLimiterTest extends TestCase
         // Events should not be rate-limited at all
         ClockMock::withClockMock(1644105600);
 
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::event()));
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+        $this->assertEventTypesAreRateLimited([]);
 
-        // Events should be rate-limited for 60 seconds, but transactions should
-        // still be allowed to be sent
-        $this->rateLimiter->handleResponse(Event::createEvent(), new Response(429, ['X-Sentry-Rate-Limits' => ['60:error:org']], ''));
+        // Events should be rate-limited for 60 seconds, but transactions should still be allowed to be sent
+        $this->rateLimiter->handleResponse(new Response(429, ['X-Sentry-Rate-Limits' => ['60:error:org']], ''));
 
-        $this->assertTrue($this->rateLimiter->isRateLimited(EventType::event()));
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+        $this->assertEventTypesAreRateLimited([EventType::event()]);
 
         // Events should not be rate-limited anymore once the deadline expired
         ClockMock::withClockMock(1644105660);
 
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::event()));
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+        $this->assertEventTypesAreRateLimited([]);
 
-        // Both events and transactions should be rate-limited if all categories
-        // are
-        $this->rateLimiter->handleResponse(Event::createTransaction(), new Response(429, ['X-Sentry-Rate-Limits' => ['60:all:org']], ''));
+        // Both events and transactions should be rate-limited if all categories are
+        $this->rateLimiter->handleResponse(new Response(429, ['X-Sentry-Rate-Limits' => ['60:all:org']], ''));
 
-        $this->assertTrue($this->rateLimiter->isRateLimited(EventType::event()));
-        $this->assertTrue($this->rateLimiter->isRateLimited(EventType::transaction()));
+        $this->assertEventTypesAreRateLimited(EventType::cases());
 
-        // Both events and transactions should not be rate-limited anymore once
-        // the deadline expired
+        // Both events and transactions should not be rate-limited anymore once the deadline expired
         ClockMock::withClockMock(1644105720);
 
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::event()));
-        $this->assertFalse($this->rateLimiter->isRateLimited(EventType::transaction()));
+        $this->assertEventTypesAreRateLimited([]);
+    }
+
+    private function assertEventTypesAreRateLimited(array $eventTypesLimited): void
+    {
+        foreach ($eventTypesLimited as $eventType) {
+            $this->assertTrue($this->rateLimiter->isRateLimited($eventType));
+        }
+
+        $eventTypesNotLimited = array_diff(EventType::cases(), $eventTypesLimited);
+
+        foreach ($eventTypesNotLimited as $eventType) {
+            $this->assertFalse($this->rateLimiter->isRateLimited($eventType));
+        }
     }
 }


### PR DESCRIPTION
Improves the following:

- [x] Coalesce installed integration messages to a single line
- [x] Successful transmission of all event types
- [x] More detailed send logs (event type, error level)
- [x] Transactions started with tracing disabled
- [x] Transactions are not sampled/not started
- [x] Profiler starts/ends
- [x] Message if a profile was started without the excimer extension being present
- [x] The profile was too short (less than 20ms/two samples)
- [x] The profile was too long (more than 30s)
- [x] `zend.exception_ignore_args` is On


<details>
<summary>Example from go</summary>

```
[Sentry] 2024/02/20 11:21:56 Skipping transaction profiling: ProfilesSampleRate is: 0.000000
[Sentry] 2024/02/20 11:21:56 Sending info event [84846f6937534d0c9db663f363cb5a7b] to o123.ingest.sentry.io project: 123
[Sentry] 2024/02/20 11:21:56 Sending transaction [02b7142ef1e4410f821bc5f9d8d253af] to o123.ingest.sentry.io project: 123
```
</details>

<details>
<summary>Example output from changes in this PR</summary>

It is hard to show them all but to give you an idea:

```
sentry/sentry: [debug] The "Sentry\Integration\RequestIntegration, Sentry\Integration\TransactionIntegration, Sentry\Integration\FrameContextifierIntegration, Sentry\Integration\EnvironmentIntegration, Sentry\Integration\ModulesIntegration" integration(s) have been installed.
sentry/sentry: [info] Skipping fatal event [852155aa253643e0baf81e707f78be59], because no DSN is set.
sentry/sentry: [info] Skipping event [fd2b238ae2cb492c99e17f3415e882a5], because no DSN is set.
sentry/sentry: [info] Transaction [1180ef33b78e48ec82ee27e79cc3bb9a] was started and sampled, decided by config:traces_sample_rate.
sentry/sentry: [info] Transaction [1180ef33b78e48ec82ee27e79cc3bb9a] is not profiling because it was not sampled.
sentry/sentry: [info] Skipping transaction [d136c35956104e69a827bd23af1e67f8], because no DSN is set.
```

Previously (master):

```
sentry/sentry: [debug] The "Sentry\Integration\RequestIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\TransactionIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\FrameContextifierIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\EnvironmentIntegration" integration has been installed.
sentry/sentry: [debug] The "Sentry\Integration\ModulesIntegration" integration has been installed.
```

</details>

Fixes #1704.