### PR TITLE
adds `JSON_ERROR_NON_BACKED_ENUM` to allowed `JSON::encode()` errors.

### DIFF
--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -34,7 +34,7 @@ final class JSON
 
         $encodedData = json_encode($data, $options, $maxDepth);
 
-        $allowedErrors = [\JSON_ERROR_NONE, \JSON_ERROR_RECURSION, \JSON_ERROR_INF_OR_NAN, \JSON_ERROR_UNSUPPORTED_TYPE];
+        $allowedErrors = [\JSON_ERROR_NONE, \JSON_ERROR_RECURSION, \JSON_ERROR_INF_OR_NAN, \JSON_ERROR_UNSUPPORTED_TYPE, \JSON_ERROR_NON_BACKED_ENUM];
 
         $encounteredAnyError = json_last_error() !== \JSON_ERROR_NONE;
 

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -34,7 +34,10 @@ final class JSON
 
         $encodedData = json_encode($data, $options, $maxDepth);
 
-        $allowedErrors = [\JSON_ERROR_NONE, \JSON_ERROR_RECURSION, \JSON_ERROR_INF_OR_NAN, \JSON_ERROR_UNSUPPORTED_TYPE, \JSON_ERROR_NON_BACKED_ENUM];
+        $allowedErrors = [\JSON_ERROR_NONE, \JSON_ERROR_RECURSION, \JSON_ERROR_INF_OR_NAN, \JSON_ERROR_UNSUPPORTED_TYPE];
+        if (defined('JSON_ERROR_NON_BACKED_ENUM')) {
+            $allowedErrors[] = \JSON_ERROR_NON_BACKED_ENUM;
+        }
 
         $encounteredAnyError = json_last_error() !== \JSON_ERROR_NONE;
 

--- a/src/Util/JSON.php
+++ b/src/Util/JSON.php
@@ -35,7 +35,7 @@ final class JSON
         $encodedData = json_encode($data, $options, $maxDepth);
 
         $allowedErrors = [\JSON_ERROR_NONE, \JSON_ERROR_RECURSION, \JSON_ERROR_INF_OR_NAN, \JSON_ERROR_UNSUPPORTED_TYPE];
-        if (defined('JSON_ERROR_NON_BACKED_ENUM')) {
+        if (\defined('JSON_ERROR_NON_BACKED_ENUM')) {
             $allowedErrors[] = \JSON_ERROR_NON_BACKED_ENUM;
         }
 

--- a/tests/Util/Fixtures/NonBackedEnum.php
+++ b/tests/Util/Fixtures/NonBackedEnum.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace Sentry\Tests\Util\Fixtures;
 

--- a/tests/Util/Fixtures/NonBackedEnum.php
+++ b/tests/Util/Fixtures/NonBackedEnum.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Sentry\Tests\Util\Fixtures;
+
+enum NonBackedEnum
+{
+    case None;
+    case Some;
+}

--- a/tests/Util/JSONTest.php
+++ b/tests/Util/JSONTest.php
@@ -7,6 +7,7 @@ namespace Sentry\Tests\Util;
 use PHPUnit\Framework\TestCase;
 use Sentry\Exception\JsonException;
 use Sentry\Tests\Util\Fixtures\JsonSerializableClass;
+use Sentry\Tests\Util\Fixtures\NonBackedEnum;
 use Sentry\Tests\Util\Fixtures\SimpleClass;
 use Sentry\Util\JSON;
 
@@ -141,6 +142,17 @@ final class JSONTest extends TestCase
     public function testEncodeRespectsOptionsArgument(): void
     {
         $this->assertSame('{}', JSON::encode([], \JSON_FORCE_OBJECT));
+    }
+
+    /**
+     * The `JSON_ERROR_NON_BACKED_ENUM` constant is only exposed from 8.1.5 and up.
+     *
+     * @requires PHP >= 8.1.5
+     */
+    public function testEncodeGracefullyHandlesUnitEnums(): void
+    {
+        $result = JSON::encode([NonBackedEnum::None, NonBackedEnum::Some]);
+        $this->assertSame('[0,0]', $result);
     }
 
     /**


### PR DESCRIPTION
The `JSON_ERROR_NON_BACKED_ENUM` error code is not yet documented (see https://github.com/php/doc-en/issues/2747), but it is returned when trying to encode encode a non-backed enum to JSON.

Since this error code is semantically equivalent to `JSON_ERROR_UNSUPPORTED_TYPE` which is already in the allow list, it makes sense to also add it.

For context, I was adding a Monolog record as a Breadcrumd metadata item, which looked like this:
```php
[
    'type' => 'default',
    'category' => 'doctrine',
    'level' => 'debug',
    'timestamp' => 1709047886.0,
    'message' => 'Executing statement: {sql} (parameters: {params}, types: {types})',
    'data' => [
        'sql' => 'SELECT id, key FROM ... WHERE id = ? AND key = ?',
        'params' => [42, 'somekey'],
        'types' => [
            \Doctrine\DBAL\ParameterType::INTEGER,
            \Doctrine\DBAL\ParameterType::STRING,
        ],
    ],
],
```

The encoding error is triggered by `Doctrine\DBAL\ParameterType`, which is a unit enum in Doctrine DBAL v4.
Since the `JSON_ERROR_NON_BACKED_ENUM` is not handled by `JSON::encode()`, this caused an exception to be thrown in `PayloadSerializerInterface::serialize()` and as a result the whole event was ignored (nothing was sent to the sentry endpoint).