### PR TITLE
Set the active transaction name on the event

### DIFF
--- a/src/Integration/TransactionIntegration.php
+++ b/src/Integration/TransactionIntegration.php
@@ -36,6 +36,13 @@ final class TransactionIntegration implements IntegrationInterface
                 return $event;
             }
 
+            $transaction = SentrySdk::getCurrentHub()->getTransaction();
+            if ($transaction !== null) {
+                $event->setTransaction($transaction->getName());
+
+                return $event;
+            }
+
             if (isset($hint->extra['transaction']) && \is_string($hint->extra['transaction'])) {
                 $event->setTransaction($hint->extra['transaction']);
             } elseif (isset($_SERVER['PATH_INFO'])) {


### PR DESCRIPTION
Brainstorming a fix for https://github.com/getsentry/sentry-php/issues/1715

The scenario here is that an error should contain the active transaction name when the error is sent to Sentry. The only other place besides the integration where we set this property on the event is in [`Transaction::finish()`](https://github.com/getsentry/sentry-php/blob/master/src/Tracing/Transaction.php#L181).