### PR TITLE
Add error message to failed requests

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -107,7 +107,7 @@ class HttpClient implements HttpClientInterface
 
         $error = '';
 
-        if ($statusCode >= 299) {
+        if ($statusCode > 299) {
             $error = (string) $body;
         }
 

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -89,6 +89,7 @@ class HttpClient implements HttpClientInterface
             curl_setopt($curlHandle, \CURLOPT_PROXYUSERPWD, $httpProxyAuthentication);
         }
 
+        /** @var string|false $body */
         $body = curl_exec($curlHandle);
 
         if ($body === false) {
@@ -105,11 +106,7 @@ class HttpClient implements HttpClientInterface
 
         curl_close($curlHandle);
 
-        $error = '';
-
-        if ($statusCode > 299) {
-            $error = (string) $body;
-        }
+        $error = $statusCode >= 400 ? $body : '';
 
         return new Response($statusCode, $responseHeaders, $error);
     }

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -108,7 +108,7 @@ class HttpClient implements HttpClientInterface
         $error = '';
 
         if ($statusCode >= 200 && $statusCode <= 299) {
-            $error = $body;
+            $error = (string) $body;
         }
 
         return new Response($statusCode, $responseHeaders, $error);

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -105,6 +105,12 @@ class HttpClient implements HttpClientInterface
 
         curl_close($curlHandle);
 
-        return new Response($statusCode, $responseHeaders, '');
+        $error = '';
+
+        if ($statusCode >= 200 && $statusCode <= 299) {
+            $error = $body;
+        }
+
+        return new Response($statusCode, $responseHeaders, $error);
     }
 }

--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -107,7 +107,7 @@ class HttpClient implements HttpClientInterface
 
         $error = '';
 
-        if ($statusCode >= 200 && $statusCode <= 299) {
+        if ($statusCode >= 299) {
             $error = (string) $body;
         }
 

--- a/tests/HttpClient/HttpClientTest.php
+++ b/tests/HttpClient/HttpClientTest.php
@@ -71,7 +71,30 @@ class HttpClientTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($response->getStatusCode(), $serverOutput['status']);
         $this->assertEquals($request->getStringBody(), $serverOutput['body']);
+        $this->assertEquals($response->getError(), '');
         $this->assertEquals(\strlen($request->getStringBody()), $serverOutput['headers']['Content-Length']);
+    }
+
+    public function testClientReturnsBodyAsErrorOnNonSuccessStatusCode(): void
+    {
+        $testServer = $this->startTestServer();
+
+        $options = new Options([
+            'dsn' => "http://publicKey@{$testServer}/400",
+        ]);
+
+        $request = new Request();
+        $request->setStringBody('test');
+
+        $client = new HttpClient('sentry.php', 'testing');
+        $response = $client->sendRequest($request, $options);
+
+        $this->stopTestServer();
+
+        $this->assertFalse($response->isSuccess());
+        $this->assertEquals(400, $response->getStatusCode());
+
+        $this->assertEquals($request->getStringBody(), $response->getError());
     }
 
     public function testThrowsExceptionIfDsnOptionIsNotSet(): void

--- a/tests/Monolog/BreadcrumbHandlerTest.php
+++ b/tests/Monolog/BreadcrumbHandlerTest.php
@@ -76,7 +76,7 @@ final class BreadcrumbHandlerTest extends TestCase
         ];
 
         yield 'with context' => [
-                RecordFactory::create('foo bar', Logger::DEBUG, 'channel.foo', ['context' => ['foo' => 'bar']], []),
+            RecordFactory::create('foo bar', Logger::DEBUG, 'channel.foo', ['context' => ['foo' => 'bar']], []),
             $defaultBreadcrumb->withMetadata('context', ['foo' => 'bar']),
         ];
 

--- a/tests/testserver/index.php
+++ b/tests/testserver/index.php
@@ -53,4 +53,4 @@ header('X-Sentry-Test-Server-Status-Code: ' . $status);
 
 http_response_code($status);
 
-return 'Processed.';
+echo $body;


### PR DESCRIPTION
Sometimes we don't log useful info about an error.
In my case, it was hard to debug that `{"detail":"envelope exceeded size limits for type 'event' (https://develop.sentry.dev/sdk/envelopes/#size-limits)"}`

This PR will add an error message for some unsuccessful requests.

I can't find an API for possible response - https://develop.sentry.dev/sdk/envelopes/
So I guess we can just use general info about error.