### PR TITLE
Depreacte `SpanStatus::resourceExchausted()`

### DIFF
--- a/src/Tracing/SpanStatus.php
+++ b/src/Tracing/SpanStatus.php
@@ -76,9 +76,20 @@ final class SpanStatus implements \Stringable
      * Gets an instance of this enum representing the fact that the server returned
      * 429 Too Many Requests.
      */
-    public static function resourceExchausted(): self
+    public static function resourceExhausted(): self
     {
         return self::getInstance('resource_exhausted');
+    }
+
+    /**
+     * Gets an instance of this enum representing the fact that the server returned
+     * 429 Too Many Requests.
+     *
+     * @deprecated since version 4.7. To be removed in version 5.0. Use SpanStatus::resourceExhausted() instead.
+     */
+    public static function resourceExchausted(): self
+    {
+        return self::resourceExhausted();
     }
 
     /**
@@ -163,7 +174,7 @@ final class SpanStatus implements \Stringable
             case $statusCode === 413:
                 return self::failedPrecondition();
             case $statusCode === 429:
-                return self::resourceExchausted();
+                return self::resourceExhausted();
             case $statusCode === 501:
                 return self::unimplemented();
             case $statusCode === 503:

--- a/tests/Monolog/BreadcrumbHandlerTest.php
+++ b/tests/Monolog/BreadcrumbHandlerTest.php
@@ -76,7 +76,7 @@ final class BreadcrumbHandlerTest extends TestCase
         ];
 
         yield 'with context' => [
-                RecordFactory::create('foo bar', Logger::DEBUG, 'channel.foo', ['context' => ['foo' => 'bar']], []),
+            RecordFactory::create('foo bar', Logger::DEBUG, 'channel.foo', ['context' => ['foo' => 'bar']], []),
             $defaultBreadcrumb->withMetadata('context', ['foo' => 'bar']),
         ];
 

--- a/tests/Tracing/SpanStatusTest.php
+++ b/tests/Tracing/SpanStatusTest.php
@@ -45,7 +45,7 @@ final class SpanStatusTest extends TestCase
         ];
 
         yield [
-            SpanStatus::resourceExchausted(),
+            SpanStatus::resourceExhausted(),
             'resource_exhausted',
         ];
 


### PR DESCRIPTION
Added `SpanStatus::resourceExhausted()` and deprecated the method which has a typo.