### PR TITLE
Handle `metric_bucket` rate limits

### DIFF
--- a/src/Transport/RateLimiter.php
+++ b/src/Transport/RateLimiter.php
@@ -76,6 +76,10 @@ final class RateLimiter
             $category = 'error';
         }
 
+        if ($eventType === EventType::metrics()) {
+            $category = 'metric_bucket';
+        }
+
         return max($this->rateLimits['all'] ?? 0, $this->rateLimits[$category] ?? 0);
     }
 

--- a/tests/Transport/RateLimiterTest.php
+++ b/tests/Transport/RateLimiterTest.php
@@ -54,11 +54,28 @@ final class RateLimiterTest extends TestCase
         ];
 
         yield 'Back-off using X-Sentry-Rate-Limits header with multiple categories' => [
-            new Response(429, ['X-Sentry-Rate-Limits' => ['60:error;transaction:org']], ''),
+            new Response(429, ['X-Sentry-Rate-Limits' => ['60:error;transaction;metric_bucket:org']], ''),
             true,
             [
                 EventType::event(),
                 EventType::transaction(),
+                EventType::metrics(),
+            ],
+        ];
+
+        yield 'Back-off using X-Sentry-Rate-Limits header with metric_bucket category' => [
+            new Response(429, ['X-Sentry-Rate-Limits' => ['60:metric_bucket:organization:quota_exceeded:custom']], ''),
+            true,
+            [
+                EventType::metrics(),
+            ],
+        ];
+
+        yield 'Back-off using X-Sentry-Rate-Limits header with metric_bucket category without reason code' => [
+            new Response(429, ['X-Sentry-Rate-Limits' => ['60:metric_bucket:organization::custom']], ''),
+            true,
+            [
+                EventType::metrics(),
             ],
         ];
 


### PR DESCRIPTION
This adds handling rate limits for metrics.
The namespace will not be customizable from the SDK, hence we do not need to check for the namespace, as `custom` will always be inferred.

closes https://github.com/getsentry/sentry-php/issues/1723