### PR TITLE
Handle namespaces for `metric_bucket` rate limits

### DIFF
--- a/src/Serializer/EnvelopItems/MetricsItem.php
+++ b/src/Serializer/EnvelopItems/MetricsItem.php
@@ -38,7 +38,7 @@ class MetricsItem implements EnvelopeItemInterface
 
         foreach ($metrics as $metric) {
             /**
-             * In case of us adding support for setting a namespace for metrics,
+             * In case of us adding support for emitting metrics from other namespaces,
              * we have to alter the RateLimiter::class to properly handle these
              * namespaces.
              */

--- a/src/Serializer/EnvelopItems/MetricsItem.php
+++ b/src/Serializer/EnvelopItems/MetricsItem.php
@@ -37,6 +37,12 @@ class MetricsItem implements EnvelopeItemInterface
         $metricMetaPayload = [];
 
         foreach ($metrics as $metric) {
+            /**
+             * In case of us adding support for setting a namespace for metrics,
+             * we have to alter the RateLimiter::class to properly handle these
+             * namespaces.
+             */
+
             // key - my.metric
             $line = preg_replace(self::KEY_PATTERN, '_', $metric->getKey());
 

--- a/src/Transport/RateLimiter.php
+++ b/src/Transport/RateLimiter.php
@@ -4,11 +4,23 @@ declare(strict_types=1);
 
 namespace Sentry\Transport;
 
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Sentry\EventType;
 use Sentry\HttpClient\Response;
 
 final class RateLimiter
 {
+    /**
+     * @var string
+     */
+    private const DATA_CATEGORY_ERROR = 'error';
+
+    /**
+     * @var string
+     */
+    private const DATA_CATEGORY_METRIC_BUCKET = 'metric_bucket';
+
     /**
      * The name of the header to look at to know the rate limits for the events
      * categories supported by the server.
@@ -24,7 +36,7 @@ final class RateLimiter
     /**
      * The number of seconds after which an HTTP request can be retried.
      */
-    private const DEFAULT_RETRY_AFTER_DELAY_SECONDS = 60;
+    private const DEFAULT_RETRY_AFTER_SECONDS = 60;
 
     /**
      * @var array<string, int> The map of time instants for each event category after
@@ -32,28 +44,72 @@ final class RateLimiter
      */
     private $rateLimits = [];
 
+    /**
+     * @var LoggerInterface A PSR-3 logger
+     */
+    private $logger;
+
+    public function __construct(?LoggerInterface $logger = null)
+    {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
     public function handleResponse(Response $response): bool
     {
         $now = time();
 
         if ($response->hasHeader(self::RATE_LIMITS_HEADER)) {
             foreach (explode(',', $response->getHeaderLine(self::RATE_LIMITS_HEADER)) as $limit) {
-                $parameters = explode(':', $limit, 3);
-                $parameters = array_splice($parameters, 0, 2);
-                $delay = ctype_digit($parameters[0]) ? (int) $parameters[0] : self::DEFAULT_RETRY_AFTER_DELAY_SECONDS;
+                /**
+                 * $parameters[0] - retry_after
+                 * $parameters[1] - categories
+                 * $parameters[2] - scope (not used)
+                 * $parameters[3] - reason_code (not used)
+                 * $parameters[4] - namespaces (only returned if categories contains "metric_bucket").
+                 */
+                $parameters = explode(':', $limit, 5);
+
+                $retryAfter = $now + (ctype_digit($parameters[0]) ? (int) $parameters[0] : self::DEFAULT_RETRY_AFTER_SECONDS);
 
                 foreach (explode(';', $parameters[1]) as $category) {
-                    $this->rateLimits[$category ?: 'all'] = $now + $delay;
+                    switch ($category) {
+                        case self::DATA_CATEGORY_METRIC_BUCKET:
+                            $namespaces = [];
+                            if (isset($parameters[4])) {
+                                $namespaces = explode(';', $parameters[4]);
+                            }
+
+                            /**
+                             * As we do not support setting any metric namespaces in the SDK,
+                             * checking for the custom namespace suffices.
+                             * In case the namespace was ommited in the response header,
+                             * we'll also back off.
+                             */
+                            if ($namespaces === [] || \in_array('custom', $namespaces)) {
+                                $this->rateLimits[self::DATA_CATEGORY_METRIC_BUCKET] = $retryAfter;
+                            }
+                            break;
+                        default:
+                            $this->rateLimits[$category ?: 'all'] = $retryAfter;
+                    }
+
+                    $this->logger->warning(
+                        sprintf('Rate limited exceeded for category "%s", backing off until "%s".', $category, gmdate(\DATE_ATOM, $retryAfter))
+                    );
                 }
             }
 
-            return true;
+            return $this->rateLimits !== [];
         }
 
         if ($response->hasHeader(self::RETRY_AFTER_HEADER)) {
-            $delay = $this->parseRetryAfterHeader($now, $response->getHeaderLine(self::RETRY_AFTER_HEADER));
+            $retryAfter = $now + $this->parseRetryAfterHeader($now, $response->getHeaderLine(self::RETRY_AFTER_HEADER));
 
-            $this->rateLimits['all'] = $now + $delay;
+            $this->rateLimits['all'] = $retryAfter;
+
+            $this->logger->warning(
+                sprintf('Rate limited exceeded for all categories, backing off until "%s".', gmdate(\DATE_ATOM, $retryAfter))
+            );
 
             return true;
         }
@@ -73,11 +129,11 @@ final class RateLimiter
         $category = (string) $eventType;
 
         if ($eventType === EventType::event()) {
-            $category = 'error';
+            $category = self::DATA_CATEGORY_ERROR;
         }
 
         if ($eventType === EventType::metrics()) {
-            $category = 'metric_bucket';
+            $category = self::DATA_CATEGORY_METRIC_BUCKET;
         }
 
         return max($this->rateLimits['all'] ?? 0, $this->rateLimits[$category] ?? 0);
@@ -95,6 +151,6 @@ final class RateLimiter
             return $headerDate->getTimestamp() - $currentTime;
         }
 
-        return self::DEFAULT_RETRY_AFTER_DELAY_SECONDS;
+        return self::DEFAULT_RETRY_AFTER_SECONDS;
     }
 }

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -125,7 +125,7 @@ final class HttpTransportTest extends TestCase
                     'Sent event [%s] to %s [project:%s]. Result: "rate_limit" (status: 429).',
                 ],
                 'warning' => [
-                    'Rate limited exceeded for requests of type "event", backing off until "2022-02-06T00:01:00+00:00".',
+                    'Rate limited exceeded for all categories, backing off until "2022-02-06T00:01:00+00:00".',
                 ],
             ],
         ];
@@ -230,7 +230,7 @@ final class HttpTransportTest extends TestCase
         $logger->expects($this->exactly(2))
             ->method('warning')
             ->withConsecutive(
-                ['Rate limited exceeded for requests of type "event", backing off until "2022-02-06T00:01:00+00:00".', ['event' => $event]],
+                ['Rate limited exceeded for all categories, backing off until "2022-02-06T00:01:00+00:00".'],
                 ['Rate limit exceeded for sending requests of type "event".', ['event' => $event]]
             );
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-php/pull/1726 seemed to simple to be true, and it wasn't 😬

This adds proper handling of metric namespaces. While the SDK does not support adding a namespace to a metric, Relay could reply with a `X-Sentry-Rate-Limits` header that could contain none `custom` namespaces, in which case we're still good sending our, inferred `custom` namespaces metrics.

Refs https://github.com/getsentry/team-sdks/issues/77