### PR TITLE
Add fast path for ignoring errors

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -101,6 +101,11 @@ final class ErrorHandler
     private $memoryLimitIncreaseOnOutOfMemoryErrorValue = 5 * 1024 * 1024; // 5 MiB
 
     /**
+     * @var Options|null The SDK options
+     */
+    private $options;
+
+    /**
      * @var bool Whether the memory limit has been increased
      */
     private static $didIncreaseMemoryLimit = false;
@@ -153,11 +158,13 @@ final class ErrorHandler
     /**
      * Registers the error handler once and returns its instance.
      */
-    public static function registerOnceErrorHandler(): self
+    public static function registerOnceErrorHandler(?Options $options = null): self
     {
         if (self::$handlerInstance === null) {
             self::$handlerInstance = new self();
         }
+
+        self::$handlerInstance->options = $options;
 
         if (self::$handlerInstance->isErrorHandlerRegistered) {
             return self::$handlerInstance;
@@ -326,23 +333,39 @@ final class ErrorHandler
             }
         }
 
-        if ($isSilencedError) {
-            $errorAsException = new SilencedErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);
-        } else {
-            $errorAsException = new \ErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);
+        if ($this->shouldHandleError($level, $isSilencedError)) {
+            if ($isSilencedError) {
+                $errorAsException = new SilencedErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);
+            } else {
+                $errorAsException = new \ErrorException(self::ERROR_LEVELS_DESCRIPTION[$level] . ': ' . $message, 0, $level, $file, $line);
+            }
+
+            $backtrace = $this->cleanBacktraceFromErrorHandlerFrames($errorAsException->getTrace(), $errorAsException->getFile(), $errorAsException->getLine());
+
+            $this->exceptionReflection->setValue($errorAsException, $backtrace);
+
+            $this->invokeListeners($this->errorListeners, $errorAsException);
         }
-
-        $backtrace = $this->cleanBacktraceFromErrorHandlerFrames($errorAsException->getTrace(), $errorAsException->getFile(), $errorAsException->getLine());
-
-        $this->exceptionReflection->setValue($errorAsException, $backtrace);
-
-        $this->invokeListeners($this->errorListeners, $errorAsException);
 
         if ($this->previousErrorHandler !== null) {
             return false !== ($this->previousErrorHandler)($level, $message, $file, $line, $errcontext);
         }
 
         return false;
+    }
+
+    private function shouldHandleError(int $level, bool $silenced): bool
+    {
+        // If we were not given any options, we should handle all errors
+        if ($this->options === null) {
+            return true;
+        }
+
+        if ($silenced) {
+            return $this->options->shouldCaptureSilencedErrors();
+        }
+
+        return ($this->options->getErrorTypes() & $level) !== 0;
     }
 
     /**

--- a/src/Integration/ErrorListenerIntegration.php
+++ b/src/Integration/ErrorListenerIntegration.php
@@ -6,40 +6,65 @@ namespace Sentry\Integration;
 
 use Sentry\ErrorHandler;
 use Sentry\Exception\SilencedErrorException;
+use Sentry\Options;
 use Sentry\SentrySdk;
 
 /**
  * This integration hooks into the global error handlers and emits events to
  * Sentry.
  */
-final class ErrorListenerIntegration extends AbstractErrorListenerIntegration
+final class ErrorListenerIntegration extends AbstractErrorListenerIntegration implements OptionAwareIntegrationInterface
 {
+    /**
+     * @var Options
+     */
+    private $options;
+
+    public function setOptions(Options $options): void
+    {
+        $this->options = $options;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function setupOnce(): void
     {
-        $errorHandler = ErrorHandler::registerOnceErrorHandler();
-        $errorHandler->addErrorHandlerListener(static function (\ErrorException $exception): void {
-            $currentHub = SentrySdk::getCurrentHub();
-            $integration = $currentHub->getIntegration(self::class);
-            $client = $currentHub->getClient();
+        ErrorHandler::registerOnceErrorHandler($this->options)
+                    ->addErrorHandlerListener(
+                        static function (\ErrorException $exception): void {
+                            $currentHub = SentrySdk::getCurrentHub();
+                            $integration = $currentHub->getIntegration(self::class);
+                            $client = $currentHub->getClient();
 
-            // The client bound to the current hub, if any, could not have this
-            // integration enabled. If this is the case, bail out
-            if ($integration === null || $client === null) {
-                return;
-            }
+                            // The client bound to the current hub, if any, could not have this
+                            // integration enabled. If this is the case, bail out
+                            if ($integration === null || $client === null) {
+                                return;
+                            }
 
-            if ($exception instanceof SilencedErrorException && !$client->getOptions()->shouldCaptureSilencedErrors()) {
-                return;
-            }
+                            if ($exception instanceof SilencedErrorException && !$client->getOptions()->shouldCaptureSilencedErrors()) {
+                                return;
+                            }
 
-            if (!$exception instanceof SilencedErrorException && !($client->getOptions()->getErrorTypes() & $exception->getSeverity())) {
-                return;
-            }
+                            if (!$exception instanceof SilencedErrorException && !($client->getOptions()->getErrorTypes() & $exception->getSeverity())) {
+                                return;
+                            }
 
-            $integration->captureException($currentHub, $exception);
-        });
+                            $integration->captureException($currentHub, $exception);
+                        }
+                    );
+    }
+
+    /**
+     * @internal this is a convenience method to create an instance of this integration for tests
+     */
+    public static function make(Options $options): self
+    {
+        $integration = new self();
+
+        $integration->setOptions($options);
+
+        return $integration;
     }
 }

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -58,7 +58,7 @@ final class IntegrationRegistry
 
             $integrations[$integrationName] = $integration;
 
-            if ($this->setupIntegration($integration)) {
+            if ($this->setupIntegration($integration, $options)) {
                 $installed[] = $integrationName;
             }
         }
@@ -70,12 +70,16 @@ final class IntegrationRegistry
         return $integrations;
     }
 
-    private function setupIntegration(IntegrationInterface $integration): bool
+    private function setupIntegration(IntegrationInterface $integration, Options $options): bool
     {
         $integrationName = \get_class($integration);
 
         if (isset($this->integrations[$integrationName])) {
             return false;
+        }
+
+        if ($integration instanceof OptionAwareIntegrationInterface) {
+            $integration->setOptions($options);
         }
 
         $integration->setupOnce();

--- a/src/Integration/OptionAwareIntegrationInterface.php
+++ b/src/Integration/OptionAwareIntegrationInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Integration;
+
+use Sentry\Options;
+
+interface OptionAwareIntegrationInterface extends IntegrationInterface
+{
+    /**
+     * Sets the options for the integration, is called before `setupOnce()`.
+     */
+    public function setOptions(Options $options): void;
+}

--- a/tests/Integration/IntegrationRegistryTest.php
+++ b/tests/Integration/IntegrationRegistryTest.php
@@ -73,13 +73,13 @@ final class IntegrationRegistryTest extends TestCase
         ];
 
         yield 'Default integrations and no user integrations' => [
-            new Options([
+            $options = new Options([
                 'dsn' => 'http://public@example.com/sentry/1',
                 'default_integrations' => true,
             ]),
             [
                 ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => new ErrorListenerIntegration(),
+                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
                 FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
                 RequestIntegration::class => new RequestIntegration(),
                 TransactionIntegration::class => new TransactionIntegration(),
@@ -104,7 +104,7 @@ final class IntegrationRegistryTest extends TestCase
         ];
 
         yield 'Default integrations and some user integrations' => [
-            new Options([
+            $options = new Options([
                 'dsn' => 'http://public@example.com/sentry/1',
                 'default_integrations' => true,
                 'integrations' => [
@@ -114,7 +114,7 @@ final class IntegrationRegistryTest extends TestCase
             ]),
             [
                 ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => new ErrorListenerIntegration(),
+                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
                 FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
                 RequestIntegration::class => new RequestIntegration(),
                 TransactionIntegration::class => new TransactionIntegration(),
@@ -127,7 +127,7 @@ final class IntegrationRegistryTest extends TestCase
         ];
 
         yield 'Default integrations and some user integrations, one of which is also a default integration' => [
-            new Options([
+            $options = new Options([
                 'dsn' => 'http://public@example.com/sentry/1',
                 'default_integrations' => true,
                 'integrations' => [
@@ -137,7 +137,7 @@ final class IntegrationRegistryTest extends TestCase
             ]),
             [
                 ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => new ErrorListenerIntegration(),
+                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
                 FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
                 RequestIntegration::class => new RequestIntegration(),
                 FrameContextifierIntegration::class => new FrameContextifierIntegration(),
@@ -149,7 +149,7 @@ final class IntegrationRegistryTest extends TestCase
         ];
 
         yield 'Default integrations and one user integration, the ModulesIntegration is also a default integration' => [
-            new Options([
+            $options = new Options([
                 'dsn' => 'http://public@example.com/sentry/1',
                 'default_integrations' => true,
                 'integrations' => [
@@ -158,7 +158,7 @@ final class IntegrationRegistryTest extends TestCase
             ]),
             [
                 ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => new ErrorListenerIntegration(),
+                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
                 FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
                 RequestIntegration::class => new RequestIntegration(),
                 TransactionIntegration::class => new TransactionIntegration(),
@@ -192,7 +192,7 @@ final class IntegrationRegistryTest extends TestCase
         ];
 
         yield 'Default integrations and a callable as user integrations' => [
-            new Options([
+            $options = new Options([
                 'dsn' => 'http://public@example.com/sentry/1',
                 'default_integrations' => true,
                 'integrations' => static function (array $defaultIntegrations): array {
@@ -201,7 +201,7 @@ final class IntegrationRegistryTest extends TestCase
             ]),
             [
                 ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => new ErrorListenerIntegration(),
+                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
                 FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
                 RequestIntegration::class => new RequestIntegration(),
                 TransactionIntegration::class => new TransactionIntegration(),


### PR DESCRIPTION
This change makes the `ErrorHandler` aware of the SDK options in default operations and allows it to take a fast path and ignore errors without doing any work instead of building up a error exception and discarding it in the `ErrorListenerIntegration`. If a lot of errors are being ignored this can end up saving a some time and wasted CPU cycles.

This should be completely backwards compatible and if anyone uses the `ErrorHandler` directly they should not see any improvement nor any negative effect nor need to change their code. But if the `ErrorHandler` is managed by the SDK it will become `Options` aware and allow to take the fast path.

There are intentionally no tests since this change only should affect performance and has no effect on the outcome or operation of the SDK. Either `shouldHandleError` or the two `if` cases in the `ErrorHandler` can be removed without any failing tests and having both also leaves all tests intact proving we still handle and ignore the same errors as before just with slightly improved performance now.

Fixes #1736.