### PR TITLE
Add array shape for init function

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Psr\Log\LoggerInterface;
+use Sentry\HttpClient\HttpClientInterface;
+use Sentry\Integration\IntegrationInterface;
 use Sentry\Metrics\Metrics;
 use Sentry\State\Scope;
 use Sentry\Tracing\PropagationContext;
@@ -14,7 +17,52 @@ use Sentry\Tracing\TransactionContext;
 /**
  * Creates a new Client and Hub which will be set as current.
  *
- * @param array<string, mixed> $options The client options
+ * @param array{
+ *     attach_metric_code_locations?: bool,
+ *     attach_stacktrace?: bool,
+ *     before_breadcrumb?: callable,
+ *     before_send?: callable,
+ *     before_send_check_in?: callable,
+ *     before_send_transaction?: callable,
+ *     capture_silenced_errors?: bool,
+ *     context_lines?: int|null,
+ *     default_integrations?: bool,
+ *     dsn?: string|bool|null|Dsn,
+ *     enable_tracing?: bool|null,
+ *     environment?: string|null,
+ *     error_types?: int|null,
+ *     http_client?: HttpClientInterface|null,
+ *     http_compression?: bool,
+ *     http_connect_timeout?: int|float,
+ *     http_proxy?: string|null,
+ *     http_proxy_authentication?: string|null,
+ *     http_ssl_verify_peer?: bool,
+ *     http_timeout?: int|float,
+ *     ignore_exceptions?: array<class-string>,
+ *     ignore_transactions?: array<string>,
+ *     in_app_exclude?: array<string>,
+ *     in_app_include?: array<string>,
+ *     integrations?: IntegrationInterface[]|callable(IntegrationInterface[]): IntegrationInterface[],
+ *     logger?: LoggerInterface|null,
+ *     max_breadcrumbs?: int,
+ *     max_request_body_size?: "none"|"never"|"small"|"medium"|"always",
+ *     max_value_length?: int,
+ *     prefixes?: array<string>,
+ *     profiler_sample_rate?: int|float|null,
+ *     release?: string|null,
+ *     sample_rate?: float|int,
+ *     send_attempts?: int,
+ *     send_default_pii?: bool,
+ *     server_name?: string,
+ *     server_name?: string,
+ *     spotlight?: bool,
+ *     spotlight_url?: string,
+ *     tags?: array<string>,
+ *     trace_propagation_targets?: array<string>|null,
+ *     traces_sample_rate?: float|int|null,
+ *     traces_sampler?: callable|null,
+ *     transport?: callable,
+ * } $options The client options
  */
 function init(array $options = []): void
 {


### PR DESCRIPTION
To make looking for configuration options easier, and to help static analysis tools to check for incorrect array key types, this PR introduces an array shape for the init function.