### PR TITLE
`class_serializers` supports closures

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -167,8 +167,7 @@ abstract class AbstractSerializer
         foreach ($this->options->getClassSerializers() as $type => $serializer) {
             if ($object instanceof $type) {
                 $serializers[] = $serializer;
-            }
-            elseif ('callable' == $type && is_callable($serializer)) {
+            } elseif ($type == 'callable' && \is_callable($serializer)) {
                 $serializers[] = $serializer;
             }
         }

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -165,7 +165,10 @@ abstract class AbstractSerializer
         $serializers = [];
 
         foreach ($this->options->getClassSerializers() as $type => $serializer) {
-            if ($object instanceof $type || is_callable($serializer)) {
+            if ($object instanceof $type) {
+                $serializers[] = $serializer;
+            }
+            elseif ('callable' == $type && is_callable($serializer)) {
                 $serializers[] = $serializer;
             }
         }

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -165,7 +165,7 @@ abstract class AbstractSerializer
         $serializers = [];
 
         foreach ($this->options->getClassSerializers() as $type => $serializer) {
-            if ($object instanceof $type) {
+            if ($object instanceof $type || is_callable($serializer)) {
                 $serializers[] = $serializer;
             }
         }


### PR DESCRIPTION
`class_serializers` supports closures

eg.

```php
    'class_serializers' => [
        'callable' => static function (object $object) {
            if(\Hyperf\Stringable\Str::startsWith($object::class,'HyperfExample')){
                return json_decode(json_encode($object),true);
            }
            return $object;
        }
    ],

```