### PR TITLE
Test span sampled status before creating child spans

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -250,10 +250,10 @@ function trace(callable $trace, SpanContext $context)
     return SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($context, $trace) {
         $parentSpan = $scope->getSpan();
 
-        // If there's a span set on the scope there is a transaction
-        // active currently. If that is the case we create a child span
-        // and set it on the scope. Otherwise we only execute the callable
-        if ($parentSpan !== null) {
+        // If there is a span set on the scope and it's sampled there is an active transaction.
+        // If that is the case we create the child span and set it on the scope.
+        // Otherwise we only execute the callable without creating a span.
+        if ($parentSpan !== null && $parentSpan->getSampled()) {
             $span = $parentSpan->startChild($context);
 
             $scope->setSpan($span);

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -365,6 +365,7 @@ final class FunctionsTest extends TestCase
         $hub = new Hub();
 
         $transaction = new Transaction(new TransactionContext());
+        $transaction->setSampled(true);
 
         $hub->setSpan($transaction);
 

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -364,7 +364,7 @@ final class FunctionsTest extends TestCase
     {
         $hub = new Hub();
 
-        $transaction = new Transaction(new TransactionContext());
+        $transaction = new Transaction(TransactionContext::make());
         $transaction->setSampled(true);
 
         $hub->setSpan($transaction);
@@ -386,6 +386,30 @@ final class FunctionsTest extends TestCase
         } catch (\RuntimeException $e) {
             $this->assertSame($transaction, $hub->getSpan());
         }
+    }
+
+    public function testTraceDoesntCreateSpanIfTransactionIsNotSampled(): void
+    {
+        $scope = $this->createMock(Scope::class);
+
+        $hub = new Hub(null, $scope);
+
+        $transaction = new Transaction(TransactionContext::make());
+        $transaction->setSampled(false);
+
+        $scope->expects($this->never())
+              ->method('setSpan');
+        $scope->expects($this->exactly(3))
+              ->method('getSpan')
+              ->willReturn($transaction);
+
+        SentrySdk::setCurrentHub($hub);
+
+        trace(function () use ($transaction, $hub) {
+            $this->assertSame($transaction, $hub->getSpan());
+        }, SpanContext::make());
+
+        $this->assertSame($transaction, $hub->getSpan());
     }
 
     public function testTraceparentWithTracingDisabled(): void

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -28,9 +28,15 @@ final class GuzzleTracingMiddlewareTest extends TestCase
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->atLeast(2))
             ->method('getOptions')
-            ->willReturn(new Options());
+            ->willReturn(new Options([
+                'traces_sample_rate' => 0,
+            ]));
 
         $hub = new Hub($client);
+
+        $transaction = $hub->startTransaction(TransactionContext::make());
+
+        $this->assertFalse($transaction->getSampled());
 
         $expectedPromiseResult = new Response();
 
@@ -49,6 +55,53 @@ final class GuzzleTracingMiddlewareTest extends TestCase
         }
 
         $this->assertSame($expectedPromiseResult, $promiseResult);
+
+        $this->assertNull($transaction->getSpanRecorder());
+
+        $hub->configureScope(function (Scope $scope): void {
+            $event = Event::createEvent();
+
+            $scope->applyToEvent($event);
+
+            $this->assertCount(1, $event->getBreadcrumbs());
+        });
+    }
+
+    public function testTraceCreatesBreadcrumbIfSpanIsRecorded(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->atLeast(2))
+               ->method('getOptions')
+               ->willReturn(new Options([
+                   'traces_sample_rate' => 1,
+               ]));
+
+        $hub = new Hub($client);
+
+        $transaction = $hub->startTransaction(TransactionContext::make());
+
+        $this->assertTrue($transaction->getSampled());
+
+        $expectedPromiseResult = new Response();
+
+        $middleware = GuzzleTracingMiddleware::trace($hub);
+        $function = $middleware(static function () use ($expectedPromiseResult): PromiseInterface {
+            return new FulfilledPromise($expectedPromiseResult);
+        });
+
+        /** @var PromiseInterface $promise */
+        $promise = $function(new Request('GET', 'https://www.example.com'), []);
+
+        try {
+            $promiseResult = $promise->wait();
+        } catch (\Throwable $exception) {
+            $promiseResult = $exception;
+        }
+
+        $this->assertSame($expectedPromiseResult, $promiseResult);
+
+        $this->assertNotNull($transaction->getSpanRecorder());
+        $this->assertCount(1, $transaction->getSpanRecorder()->getSpans());
 
         $hub->configureScope(function (Scope $scope): void {
             $event = Event::createEvent();
@@ -133,6 +186,15 @@ final class GuzzleTracingMiddlewareTest extends TestCase
 
     public static function traceHeadersDataProvider(): iterable
     {
+        // Test cases here are duplicated with sampling enabled and disabled because trace headers hould be added regardless of the sample decision
+
+        yield [
+            new Request('GET', 'https://www.example.com'),
+            new Options([
+                'traces_sample_rate' => 0,
+            ]),
+            true,
+        ];
         yield [
             new Request('GET', 'https://www.example.com'),
             new Options([
@@ -141,6 +203,14 @@ final class GuzzleTracingMiddlewareTest extends TestCase
             true,
         ];
 
+        yield [
+            new Request('GET', 'https://www.example.com'),
+            new Options([
+                'traces_sample_rate' => 0,
+                'trace_propagation_targets' => null,
+            ]),
+            true,
+        ];
         yield [
             new Request('GET', 'https://www.example.com'),
             new Options([
@@ -150,6 +220,16 @@ final class GuzzleTracingMiddlewareTest extends TestCase
             true,
         ];
 
+        yield [
+            new Request('GET', 'https://www.example.com'),
+            new Options([
+                'traces_sample_rate' => 0,
+                'trace_propagation_targets' => [
+                    'www.example.com',
+                ],
+            ]),
+            true,
+        ];
         yield [
             new Request('GET', 'https://www.example.com'),
             new Options([
@@ -164,12 +244,30 @@ final class GuzzleTracingMiddlewareTest extends TestCase
         yield [
             new Request('GET', 'https://www.example.com'),
             new Options([
+                'traces_sample_rate' => 0,
+                'trace_propagation_targets' => [],
+            ]),
+            false,
+        ];
+        yield [
+            new Request('GET', 'https://www.example.com'),
+            new Options([
                 'traces_sample_rate' => 1,
                 'trace_propagation_targets' => [],
             ]),
             false,
         ];
 
+        yield [
+            new Request('GET', 'https://www.example.com'),
+            new Options([
+                'traces_sample_rate' => 0,
+                'trace_propagation_targets' => [
+                    'example.com',
+                ],
+            ]),
+            false,
+        ];
         yield [
             new Request('GET', 'https://www.example.com'),
             new Options([

--- a/tests/Tracing/GuzzleTracingMiddlewareTest.php
+++ b/tests/Tracing/GuzzleTracingMiddlewareTest.php
@@ -23,10 +23,10 @@ use Sentry\Tracing\TransactionContext;
 
 final class GuzzleTracingMiddlewareTest extends TestCase
 {
-    public function testTraceDoesNothingIfSpanIsNotSet(): void
+    public function testTraceCreatesBreadcrumbIfSpanIsNotSet(): void
     {
         $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->once())
+        $client->expects($this->atLeast(2))
             ->method('getOptions')
             ->willReturn(new Options());
 
@@ -55,7 +55,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
 
             $scope->applyToEvent($event);
 
-            $this->assertCount(0, $event->getBreadcrumbs());
+            $this->assertCount(1, $event->getBreadcrumbs());
         });
     }
 
@@ -95,7 +95,7 @@ final class GuzzleTracingMiddlewareTest extends TestCase
     /**
      * @dataProvider traceHeadersDataProvider
      */
-    public function testTraceHeadersWithTransacttion(Request $request, Options $options, bool $headersShouldBePresent): void
+    public function testTraceHeadersWithTransaction(Request $request, Options $options, bool $headersShouldBePresent): void
     {
         $client = $this->createMock(ClientInterface::class);
         $client->expects($this->atLeast(2))


### PR DESCRIPTION
As reported in getsentry/sentry-laravel#894 we have some logic issues.

There are only 2 here in the base SDK, both solved by this PR:

- Fixes `trace` helper to check parent span sampled status
- Fixes Guzzle tracker to check parent span sampled status
- Fixes Guzzle tracker not always recording a breadcrumb (a bonus fix)