### PR TITLE
Represent callable strings as strings

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -280,7 +280,7 @@ abstract class AbstractSerializer
      */
     protected function serializeCallable($callable): string
     {
-        if (\is_string($callable) && !\function_exists($callable)) {
+        if (\is_string($callable)) {
             return $callable;
         }
 

--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -292,7 +292,7 @@ abstract class AbstractSerializer
             if (\is_array($callable)) {
                 $reflection = new \ReflectionMethod($callable[0], $callable[1]);
                 $class = $reflection->getDeclaringClass();
-            } elseif ($callable instanceof \Closure || (\is_string($callable) && \function_exists($callable))) {
+            } elseif ($callable instanceof \Closure) {
                 $reflection = new \ReflectionFunction($callable);
                 $class = null;
             } elseif (\is_object($callable) && method_exists($callable, '__invoke')) {

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -540,6 +540,11 @@ abstract class AbstractSerializerTest extends TestCase
                 'expected' => 'Lambda void {closure} [int|null param1_70ns]',
             ],
             [
+                // This is (a example of) a PHP provided function that is technically callable but we want to ignore that because it causes more false positives than it helps
+                'callable' => 'header',
+                'expected' => 'header',
+            ],
+            [
                 'callable' => __METHOD__,
                 'expected' => __METHOD__,
             ],


### PR DESCRIPTION
I'm honestly not sure what the logic should be here. A simple callable string like "file" I don't think should be assumed to be a callable.  But seems a lot more reasonable to represent a callable string containing "::" as callable.  Here I also represent callable strings containing an underscore as callables.

Fixes #1734