### PR TITLE
Use `AWS_LAMBDA_FUNCTION_VERSION` env var for release if available

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -1100,7 +1100,7 @@ final class Options
             'logger' => null,
             'spotlight' => false,
             'spotlight_url' => 'http://localhost:8969',
-            'release' => $_SERVER['SENTRY_RELEASE'] ?? null,
+            'release' => $_SERVER['SENTRY_RELEASE'] ?? $_SERVER['AWS_LAMBDA_FUNCTION_VERSION'] ?? null,
             'dsn' => $_SERVER['SENTRY_DSN'] ?? null,
             'server_name' => gethostname(),
             'ignore_exceptions' => [],

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -611,6 +611,27 @@ final class OptionsTest extends TestCase
         $this->assertSame('0.0.1', (new Options())->getRelease());
     }
 
+    /**
+     * @backupGlobals enabled
+     */
+    public function testReleaseOptionDefaultValueIsGotFromLambdaEnvironmentVariable(): void
+    {
+        $_SERVER['AWS_LAMBDA_FUNCTION_VERSION'] = '0.0.2';
+
+        $this->assertSame('0.0.2', (new Options())->getRelease());
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testReleaseOptionDefaultValueIsPreferredFromSentryEnvironmentVariable(): void
+    {
+        $_SERVER['AWS_LAMBDA_FUNCTION_VERSION'] = '0.0.3';
+        $_SERVER['SENTRY_RELEASE'] = '0.0.4';
+
+        $this->assertSame('0.0.4', (new Options())->getRelease());
+    }
+
     public function testErrorTypesOptionIsNotDynamiclyReadFromErrorReportingLevelWhenSet(): void
     {
         $errorReportingBeforeTest = error_reporting(\E_ERROR);


### PR DESCRIPTION
Fixes #1706