### PR TITLE
Type hint `float` on metrics calls

### DIFF
--- a/src/Metrics/Metrics.php
+++ b/src/Metrics/Metrics.php
@@ -40,12 +40,11 @@ class Metrics
     }
 
     /**
-     * @param int|float             $value
      * @param array<string, string> $tags
      */
     public function increment(
         string $key,
-        $value,
+        float $value,
         ?MetricsUnit $unit = null,
         array $tags = [],
         ?int $timestamp = null,
@@ -63,12 +62,11 @@ class Metrics
     }
 
     /**
-     * @param int|float             $value
      * @param array<string, string> $tags
      */
     public function distribution(
         string $key,
-        $value,
+        float $value,
         ?MetricsUnit $unit = null,
         array $tags = [],
         ?int $timestamp = null,
@@ -86,12 +84,11 @@ class Metrics
     }
 
     /**
-     * @param int|float             $value
      * @param array<string, string> $tags
      */
     public function gauge(
         string $key,
-        $value,
+        float $value,
         ?MetricsUnit $unit = null,
         array $tags = [],
         ?int $timestamp = null,


### PR DESCRIPTION
We can safely type hint `float` in these methods since even in strict typing you can pass an integer to a float parameter. This will allow IDE's to better complain if you pass anything that is not a number to this method. Passing an integer or float will work without complaints of course 😄 