### PR TITLE
Return `ClientInterface` from `init()`

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -63,11 +63,13 @@ use Sentry\Tracing\TransactionContext;
  *     transport?: callable,
  * } $options The client options
  */
-function init(array $options = []): void
+function init(array $options = []): ClientInterface
 {
     $client = ClientBuilder::create($options)->getClient();
 
     SentrySdk::init()->bindClient($client);
+
+    return $client;
 }
 
 /**

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -50,9 +50,9 @@ final class FunctionsTest extends TestCase
 {
     public function testInit(): void
     {
-        init(['default_integrations' => false]);
+        $client = init(['default_integrations' => false]);
 
-        $this->assertNotNull(SentrySdk::getCurrentHub()->getClient());
+        $this->assertSame($client, SentrySdk::getCurrentHub()->getClient());
     }
 
     /**


### PR DESCRIPTION
```php
\Sentry\init([...]);

$client = SentrySDK::getCurrentHub()->getClient();
if ($client !== null) {
   ...
}
```

```php
$client = \Sentry\init([...]);
```

Seems beneficial to make this change. 