### PR TITLE
docs: Fix MonitorConfig checkinMargin & maxRuntime

### DIFF
--- a/src/MonitorConfig.php
+++ b/src/MonitorConfig.php
@@ -12,12 +12,12 @@ final class MonitorConfig
     private $schedule;
 
     /**
-     * @var int|null The check-in margin in seconds
+     * @var int|null The check-in margin in minutes
      */
     private $checkinMargin;
 
     /**
-     * @var int|null The maximum runtime in seconds
+     * @var int|null The maximum runtime in minutes
      */
     private $maxRuntime;
 


### PR DESCRIPTION
Those properties store the durations in minutes
and not seconds.
The DocBlocks should reflect that correctly.

Fixes #1755