### PR TITLE
Remove stubs from distributed exports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@
 
 # Exclude non-essential files from dist
 /tests export-ignore
+/stubs export-ignore
 /.appveyor.yml export-ignore
 /.craft.yml export-ignore
 /.editorconfig export-ignore


### PR DESCRIPTION
Composer installs and zip downloads should not include the stubs, just like the tests.