### PR TITLE
Improve Span API

### DIFF
--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -357,18 +357,24 @@ class Span
     }
 
     /**
-     * Gets a map of arbitrary data.
+     * Gets a map of arbitrary data or a specific key from the map of data attached to this span.
      *
-     * @return array<string, mixed>
+     * @param string|null $key     Select a specific key from the data to return the value of
+     * @param mixed       $default When the $key is not found, return this value
+     *
+     * @return ($key is string ? mixed : array<string, mixed>)
      */
-    public function getData(): array
+    public function getData(?string $key = null, $default = null)
     {
-        return $this->data;
+        if ($key === null) {
+            return $this->data;
+        }
+
+        return $this->data[$key] ?? $default;
     }
 
     /**
-     * Sets a map of arbitrary data. This method will merge the given data with
-     * the existing one.
+     * Sets a map of arbitrary data. This method will merge the given data with the existing one.
      *
      * @param array<string, mixed> $data The data
      *

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -362,7 +362,7 @@ class Span
      * @param string|null $key     Select a specific key from the data to return the value of
      * @param mixed       $default When the $key is not found, return this value
      *
-     * @return ($key is string ? mixed : array<string, mixed>)
+     * @return ($key is null ? array<string, mixed> : mixed|null)
      */
     public function getData(?string $key = null, $default = null)
     {

--- a/src/Tracing/SpanContext.php
+++ b/src/Tracing/SpanContext.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Tracing;
 
+use Sentry\State\Scope;
+
+use function Sentry\trace;
+
 class SpanContext
 {
     /**
@@ -242,5 +246,20 @@ class SpanContext
         $this->endTimestamp = $endTimestamp;
 
         return $this;
+    }
+
+    /**
+     * Execute the given callable while wrapping it in a span added as a child to the current transaction and active span.
+     * If there is no transaction active this is a no-op and the scope passed to the trace callable will be unused.
+     *
+     * @template T
+     *
+     * @param callable(Scope): T $trace The callable that is going to be traced
+     *
+     * @return T
+     */
+    public function trace(callable $trace)
+    {
+        return trace($trace, $this);
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -360,6 +360,17 @@ final class FunctionsTest extends TestCase
         $this->assertSame($returnValue, $result);
     }
 
+    public function testSpanContextTraceReturnsClosureResult(): void
+    {
+        $returnValue = 'foo';
+
+        $result = SpanContext::make()->trace(function () use ($returnValue) {
+            return $returnValue;
+        });
+
+        $this->assertSame($returnValue, $result);
+    }
+
     public function testTraceCorrectlyReplacesAndRestoresCurrentSpan(): void
     {
         $hub = new Hub();

--- a/tests/Tracing/SpanTest.php
+++ b/tests/Tracing/SpanTest.php
@@ -272,4 +272,41 @@ final class SpanTest extends TestCase
             ],
         ], $span->getMetricsSummary());
     }
+
+    public function testDataGetter(): void
+    {
+        $span = new Span();
+
+        $initialData = [
+            'foo' => 'bar',
+            'baz' => 1,
+        ];
+
+        $span->setData($initialData);
+
+        $this->assertSame($initialData, $span->getData());
+        $this->assertSame('bar', $span->getData('foo'));
+        $this->assertSame(1, $span->getData('baz'));
+    }
+
+    public function testDataIsMergedWhenSet(): void
+    {
+        $span = new Span();
+
+        $span->setData([
+            'foo' => 'bar',
+            'baz' => 1,
+        ]);
+
+        $span->setData([
+            'baz' => 2,
+        ]);
+
+        $this->assertSame(2, $span->getData('baz'));
+        $this->assertSame('bar', $span->getData('foo'));
+        $this->assertSame([
+            'foo' => 'bar',
+            'baz' => 2,
+        ], $span->getData());
+    }
 }


### PR DESCRIPTION
Add `trace()` helper directly on `SpanContext`:

```php
// Old:
\Sentry\trace(function (\Sentry\State\Scope $scope) use ($processedUsers) {
    // ...
}, \Sentry\Tracing\SpanContext::make()
       ->setOp('function')
       ->setDescription('processing-users')
);

// New:
\Sentry\Tracing\SpanContext::make()
    ->setOp('function')
    ->setDescription('processing-users')
    ->trace(function (\Sentry\State\Scope $scope) use ($processedUsers) {
        // ...
    });
```

Add data get helper:

```php
// Old:
$span->setData([
    'failure' => $span->getData()['failure'] + 1,
]);

// New:
$span->setData([
    'failure' => $span->getData('failure', 0) + 1,
]);
```