### PR TITLE
Add helper to start a trace from a SpanContext

### DIFF
--- a/src/Tracing/SpanContext.php
+++ b/src/Tracing/SpanContext.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Sentry\Tracing;
 
+use Sentry\State\Scope;
+
+use function Sentry\trace;
+
 class SpanContext
 {
     /**
@@ -242,5 +246,20 @@ class SpanContext
         $this->endTimestamp = $endTimestamp;
 
         return $this;
+    }
+
+    /**
+     * Execute the given callable while wrapping it in a span added as a child to the current transaction and active span.
+     * If there is no transaction active this is a no-op and the scope passed to the trace callable will be unused.
+     *
+     * @template T
+     *
+     * @param callable(Scope): T $trace The callable that is going to be traced
+     *
+     * @return T
+     */
+    public function trace(callable $trace)
+    {
+        return trace($trace, $this);
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -360,6 +360,17 @@ final class FunctionsTest extends TestCase
         $this->assertSame($returnValue, $result);
     }
 
+    public function testSpanContextTraceReturnsClosureResult(): void
+    {
+        $returnValue = 'foo';
+
+        $result = SpanContext::make()->trace(function () use ($returnValue) {
+            return $returnValue;
+        });
+
+        $this->assertSame($returnValue, $result);
+    }
+
     public function testTraceCorrectlyReplacesAndRestoresCurrentSpan(): void
     {
         $hub = new Hub();


### PR DESCRIPTION
Add `trace()` helper directly on `SpanContext`:

```php
// Old:
\Sentry\trace(function (\Sentry\State\Scope $scope) use ($processedUsers) {
    // ...
}, \Sentry\Tracing\SpanContext::make()
       ->setOp('function')
       ->setDescription('processing-users')
);

// New:
\Sentry\Tracing\SpanContext::make()
    ->setOp('function')
    ->setDescription('processing-users')
    ->trace(function (\Sentry\State\Scope $scope) use ($processedUsers) {
        // ...
    });
```