### PR TITLE
Allow retrieving a single piece of data from the span by it’s key

### DIFF
--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -357,18 +357,24 @@ class Span
     }
 
     /**
-     * Gets a map of arbitrary data.
+     * Gets a map of arbitrary data or a specific key from the map of data attached to this span.
      *
-     * @return array<string, mixed>
+     * @param string|null $key     Select a specific key from the data to return the value of
+     * @param mixed       $default When the $key is not found, return this value
+     *
+     * @return ($key is null ? array<string, mixed> : mixed|null)
      */
-    public function getData(): array
+    public function getData(?string $key = null, $default = null)
     {
-        return $this->data;
+        if ($key === null) {
+            return $this->data;
+        }
+
+        return $this->data[$key] ?? $default;
     }
 
     /**
-     * Sets a map of arbitrary data. This method will merge the given data with
-     * the existing one.
+     * Sets a map of arbitrary data. This method will merge the given data with the existing one.
      *
      * @param array<string, mixed> $data The data
      *

--- a/tests/Tracing/SpanTest.php
+++ b/tests/Tracing/SpanTest.php
@@ -272,4 +272,41 @@ final class SpanTest extends TestCase
             ],
         ], $span->getMetricsSummary());
     }
+
+    public function testDataGetter(): void
+    {
+        $span = new Span();
+
+        $initialData = [
+            'foo' => 'bar',
+            'baz' => 1,
+        ];
+
+        $span->setData($initialData);
+
+        $this->assertSame($initialData, $span->getData());
+        $this->assertSame('bar', $span->getData('foo'));
+        $this->assertSame(1, $span->getData('baz'));
+    }
+
+    public function testDataIsMergedWhenSet(): void
+    {
+        $span = new Span();
+
+        $span->setData([
+            'foo' => 'bar',
+            'baz' => 1,
+        ]);
+
+        $span->setData([
+            'baz' => 2,
+        ]);
+
+        $this->assertSame(2, $span->getData('baz'));
+        $this->assertSame('bar', $span->getData('foo'));
+        $this->assertSame([
+            'foo' => 'bar',
+            'baz' => 2,
+        ], $span->getData());
+    }
 }


### PR DESCRIPTION
Add data get helper:

```php
// Old:
$span->setData([
    'failure' => $span->getData()['failure'] + 1,
]);

// New:
$span->setData([
    'failure' => $span->getData('failure', 0) + 1,
]);
```