### PR TITLE
Set `http` breadcrumb level based on response code

### DIFF
--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -84,9 +84,17 @@ final class GuzzleTracingMiddleware
                         $response = $responseOrException->getResponse();
                     }
 
+                    $breadcrumbLevel = Breadcrumb::LEVEL_INFO;
+
                     if ($response !== null) {
                         $spanAndBreadcrumbData['http.response.body.size'] = $response->getBody()->getSize();
                         $spanAndBreadcrumbData['http.response.status_code'] = $response->getStatusCode();
+
+                        if ($response->getStatusCode() >= 400 && $response->getStatusCode() < 500) {
+                            $breadcrumbLevel = Breadcrumb::LEVEL_WARNING;
+                        } elseif ($response->getStatusCode() >= 500) {
+                            $breadcrumbLevel = Breadcrumb::LEVEL_ERROR;
+                        }
                     }
 
                     if ($childSpan !== null) {
@@ -99,7 +107,7 @@ final class GuzzleTracingMiddleware
                     }
 
                     $hub->addBreadcrumb(new Breadcrumb(
-                        Breadcrumb::LEVEL_INFO,
+                        $breadcrumbLevel,
                         Breadcrumb::TYPE_HTTP,
                         'http',
                         null,


### PR DESCRIPTION
4XX response codes are set to `warning` and 5XX are set to `error`.

Part of https://github.com/getsentry/team-sdks/issues/100