### PR TITLE
Allow profiler to start before SDK and transaction is initialized

### DIFF
--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -14,6 +14,7 @@ use Sentry\EventHint;
 use Sentry\EventId;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\MonitorConfig;
+use Sentry\Profiling\Profiler;
 use Sentry\Severity;
 use Sentry\Tracing\SamplingContext;
 use Sentry\Tracing\Span;
@@ -320,12 +321,16 @@ class Hub implements HubInterface
         $profilesSampleRate = $options->getProfilesSampleRate();
         if ($profilesSampleRate === null) {
             $logger->info(\sprintf('Transaction [%s] is not profiling because `profiles_sample_rate` option is not set.', (string) $transaction->getTraceId()));
+
+            Profiler::maybeDiscardProfilingData();
         } elseif ($this->sample($profilesSampleRate)) {
             $logger->info(\sprintf('Transaction [%s] started profiling because it was sampled.', (string) $transaction->getTraceId()));
 
             $transaction->initProfiler()->start();
         } else {
             $logger->info(\sprintf('Transaction [%s] is not profiling because it was not sampled.', (string) $transaction->getTraceId()));
+
+            Profiler::maybeDiscardProfilingData();
         }
 
         return $transaction;


### PR DESCRIPTION
In plain PHP this is less interesting but in frameworks it can be very.

This allow you to drop a `\Sentry\Profiling\Profiler::startProfiling()` right after the composer autoloader which enable you to start profiling as early as possible capturing the bootstrap of the framework too.

If we later know we are going to discard the transaction we discard the profiling data, if we are sampling the transaction we continue to use the already started (excimer) profiler as normal.

_CI failure because: #1777_