### PR TITLE
Fix Scope extra data setup by Event extra data

### DIFF
--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -359,7 +359,7 @@ class Scope
             $event->setTags(array_merge($this->tags, $event->getTags()));
         }
 
-        if (!empty($this->extra)) {
+        if (!empty($this->extra) || !empty($event->getExtra())) {
             $event->setExtra(array_merge($this->extra, $event->getExtra()));
         }
 

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -155,6 +155,23 @@ final class ScopeTest extends TestCase
         $this->assertSame(['foo' => 'bar', 'bar' => 'baz'], $event->getExtra());
     }
 
+    public function testSetExtrasOnScopeWithoutExtras(): void
+    {
+        $scope = new Scope();
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertSame([], $event->getExtra());
+
+        $scope->setExtras(['bar' => 'baz']);
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertSame(['bar' => 'baz'], $event->getExtra());
+    }
+
     public function testSetUser(): void
     {
         $scope = new Scope();


### PR DESCRIPTION
Without this fix API doesn't log extra data to Sentry