### PR TITLE
Always use `ms` scaled timeouts

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -64,26 +64,14 @@ class HttpClient implements HttpClientInterface
         curl_setopt($curlHandle, \CURLOPT_URL, $dsn->getEnvelopeApiEndpointUrl());
         curl_setopt($curlHandle, \CURLOPT_HTTPHEADER, $requestHeaders);
         curl_setopt($curlHandle, \CURLOPT_USERAGENT, $this->sdkIdentifier . '/' . $this->sdkVersion);
+        curl_setopt($curlHandle, \CURLOPT_TIMEOUT_MS, $options->getHttpTimeout() * 1000);
+        curl_setopt($curlHandle, \CURLOPT_CONNECTTIMEOUT_MS, $options->getHttpConnectTimeout() * 1000);
         curl_setopt($curlHandle, \CURLOPT_ENCODING, '');
         curl_setopt($curlHandle, \CURLOPT_POST, true);
         curl_setopt($curlHandle, \CURLOPT_POSTFIELDS, $requestData);
         curl_setopt($curlHandle, \CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curlHandle, \CURLOPT_HEADERFUNCTION, $responseHeaderCallback);
         curl_setopt($curlHandle, \CURLOPT_HTTP_VERSION, \CURL_HTTP_VERSION_1_1);
-
-        $httpTimeout = $options->getHttpTimeout();
-        if ($httpTimeout < 1.0) {
-            curl_setopt($curlHandle, \CURLOPT_TIMEOUT_MS, $httpTimeout * 1000);
-        } else {
-            curl_setopt($curlHandle, \CURLOPT_TIMEOUT, $httpTimeout);
-        }
-
-        $connectTimeout = $options->getHttpConnectTimeout();
-        if ($connectTimeout < 1.0) {
-            curl_setopt($curlHandle, \CURLOPT_CONNECTTIMEOUT_MS, $connectTimeout * 1000);
-        } else {
-            curl_setopt($curlHandle, \CURLOPT_CONNECTTIMEOUT, $connectTimeout);
-        }
 
         $httpSslVerifyPeer = $options->getHttpSslVerifyPeer();
         if (!$httpSslVerifyPeer) {


### PR DESCRIPTION
#1783 introduces sub-second timeouts. Considering the timeout options are already defined as a float anyway it makes sense to always convert them to the `ms` scale. Especially considering @mfb [pointed out](https://github.com/getsentry/sentry-php/pull/1783#issuecomment-2441777845) `1.5` isn't working correctly either although the `float` data type of the option would suggest that. I think we can half consider this a bug fix.