### PR TITLE
Add date range to MIT licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2012 Functional Software, Inc. dba Sentry
+Copyright (c) 2012-2025 Functional Software, Inc. dba Sentry
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
To align with all other SDK licenses.

#skip-changelog