### PR TITLE
Set the current span on the hub in Guzzle middleware

### DIFF
--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -59,6 +59,8 @@ final class GuzzleTracingMiddleware
                     $spanContext->setDescription($request->getMethod() . ' ' . $partialUri);
 
                     $childSpan = $parentSpan->startChild($spanContext);
+
+                    $hub->setSpan($childSpan);
                 }
 
                 if (self::shouldAttachTracingHeaders($client, $request)) {
@@ -68,11 +70,13 @@ final class GuzzleTracingMiddleware
                         ->withHeader('baggage', getBaggage());
                 }
 
-                $handlerPromiseCallback = static function ($responseOrException) use ($hub, $spanAndBreadcrumbData, $childSpan, $partialUri) {
+                $handlerPromiseCallback = static function ($responseOrException) use ($hub, $spanAndBreadcrumbData, $childSpan, $parentSpan, $partialUri) {
                     if ($childSpan !== null) {
                         // We finish the span (which means setting the span end timestamp) first to ensure the measured time
                         // the span spans is as close to only the HTTP request time and do the data collection afterwards
                         $childSpan->finish();
+
+                        $hub->setSpan($parentSpan);
                     }
 
                     $response = null;


### PR DESCRIPTION
When tracking down some performance issues I noticed something odd with the Guzzle tracing middleware. I saw this:

![image](https://github.com/user-attachments/assets/68055a56-c69a-4097-9ad1-eeb45ba7af8d)

That didn't look right to me, that second cache call is a custom Guzzle middleware that retrieves a access token from the cache and should be a child of the `http.client` span or be before that but it's after and seems to cause a "missing instrumentation" block even though everything is accounted for.

Turns out we never set the current span in the Guzzle middleware, this PR fixes that and now it looks like this:

![image](https://github.com/user-attachments/assets/c323d0c9-cdc5-4ec2-993a-2f5575d66895)

Turns out this isn't the fix for the "missing instrumentation", but it is more correct now.