### PR TITLE
Serialize date

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -135,6 +135,10 @@ abstract class AbstractSerializer
                     }
                 }
 
+                if ($value instanceof \DateTimeInterface) {
+                    return $this->formatDate($value);
+                }
+
                 if ($this->serializeAllObjects || ($value instanceof \stdClass)) {
                     return $this->serializeObject($value, $_depth);
                 }
@@ -273,6 +277,20 @@ abstract class AbstractSerializer
         }
 
         return $this->serializeString($value);
+    }
+
+    private function formatDate(\DateTimeInterface $date): string
+    {
+        $hasMicroseconds = $date->format('u') !== '000000';
+        $formatted = $hasMicroseconds ? $date->format('Y-m-d H:i:s.u') : $date->format('Y-m-d H:i:s');
+        $className = \get_class($date);
+
+        $timezone = $date->getTimezone();
+        if ($timezone && $timezone->getName() !== 'UTC') {
+            $formatted .= ' ' . $date->format('eP');
+        }
+
+        return "$className($formatted)";
     }
 
     /**

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -144,6 +144,26 @@ final class SerializerTest extends AbstractSerializerTest
         ], $this->invokeSerialization($serializer, $object));
     }
 
+    /**
+     * @dataProvider serializeDateTimeDataProvider
+     */
+    public function testSerializeDateTime(\DateTimeInterface $date, string $expected): void
+    {
+        $serializer = $this->createSerializer();
+
+        $result = $this->invokeSerialization($serializer, $date);
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function serializeDateTimeDataProvider(): \Generator
+    {
+        yield 'DateTime' => [
+            new \DateTime('2001-02-03 13:37:42'),
+            'Object DateTime',
+        ];
+    }
+
     public function testSerializableThatReturnsNull(): void
     {
         $serializer = $this->createSerializer();

--- a/tests/Serializer/SerializerTest.php
+++ b/tests/Serializer/SerializerTest.php
@@ -160,7 +160,22 @@ final class SerializerTest extends AbstractSerializerTest
     {
         yield 'DateTime' => [
             new \DateTime('2001-02-03 13:37:42'),
-            'Object DateTime',
+            'DateTime(2001-02-03 13:37:42)',
+        ];
+
+        yield 'Microseconds' => [
+            new \DateTimeImmutable('2001-02-03 13:37:42.123456'),
+            'DateTimeImmutable(2001-02-03 13:37:42.123456)',
+        ];
+
+        yield 'Timezone' => [
+            new \DateTime('2001-02-03 13:37:42', new \DateTimeZone('Europe/Paris')),
+            'DateTime(2001-02-03 13:37:42 Europe/Paris+01:00)',
+        ];
+
+        yield 'Abbreviated timezone' => [
+            new \DateTime('2021-03-28 13:37:42 CET'),
+            'DateTime(2021-03-28 13:37:42 CET+01:00)',
         ];
     }
 


### PR DESCRIPTION
Fixes #1799.

DateTime becomes readable on Sentry. 

Before they were serialized like this: `Object DateTimeImmutable`.
They now are serialized as `DateTime(2001-02-03 13:37:42)`.