### PR TITLE
Improve handling of prefix stripping for anonymous frames

### DIFF
--- a/src/Frame.php
+++ b/src/Frame.php
@@ -13,6 +13,9 @@ final class Frame
 {
     public const INTERNAL_FRAME_FILENAME = '[internal]';
 
+    /**
+     * @deprecated This constant is deprecated and will be removed in 5.x.
+     */
     public const ANONYMOUS_CLASS_PREFIX = "class@anonymous\x00";
 
     /**

--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -76,9 +76,13 @@ final class FrameBuilder
 
             // Optimization: skip doing regex if we don't have prefixes to strip
             if ($this->options->getPrefixes()) {
-                $functionName = preg_replace_callback('/@anonymous\\x00([^:]+)(:.*)?/', function (array $matches) {
+                $prefixStrippedFunctionName = preg_replace_callback('/@anonymous\\x00([^:]+)(:.*)?/', function (array $matches) {
                     return "@anonymous\x00" . $this->stripPrefixFromFilePath($this->options, $matches[1]) . ($matches[2] ?? '');
                 }, $functionName);
+
+                if ($prefixStrippedFunctionName) {
+                    $functionName = $prefixStrippedFunctionName;
+                }
             }
 
             $rawFunctionName = \sprintf('%s::%s', $backtraceFrame['class'], $backtraceFrame['function']);

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -149,6 +149,19 @@ final class FrameBuilderTest extends TestCase
             ],
             new Frame(null, 'path/not/of/app/to/file', 10, null, 'path/not/of/app/to/file'),
         ];
+
+        yield [
+            new Options([
+                'prefixes' => ['/path/to'],
+            ]),
+            [
+                'file' => '/path/to/file',
+                'line' => 10,
+                'function' => 'test_function',
+                'class' => "App\\ClassName@anonymous\0/path/to/file:85$29e",
+            ],
+            new Frame("App\\ClassName@anonymous\0/file::test_function", '/file', 10, "App\\ClassName@anonymous\0/path/to/file:85$29e::test_function", '/path/to/file'),
+        ];
     }
 
     /**


### PR DESCRIPTION
Improve handling of prefix stripping for anonymous frames. As reported in #1817 we did not handle the case where the class name is known opposed to being "class". Added a test and ensure we handle that case now. Also added a (micro) optimization to never even run the code if there is no benefit (no prefixes defined).

Fixes #1817