### PR TITLE
Fix stripping prefixes from closure frames

### DIFF
--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -91,6 +91,17 @@ final class FrameBuilder
             $functionName = $backtraceFrame['function'];
         }
 
+        // Starting with PHP 8.4 a closure function call is reported as "{closure:filename:line}" instead of just "{closure}", properly strip the prefixes from that format
+        if (\PHP_VERSION_ID >= 80400 && $functionName !== null && $this->options->getPrefixes()) {
+            $prefixStrippedFunctionName = preg_replace_callback('/^\{closure:(.*?):(\d+)}$/', function (array $matches) {
+                return '{closure:' . $this->stripPrefixFromFilePath($this->options, $matches[1]) . ':' . $matches[2] . '}';
+            }, $functionName);
+
+            if ($prefixStrippedFunctionName) {
+                $functionName = $prefixStrippedFunctionName;
+            }
+        }
+
         return new Frame(
             $functionName,
             $strippedFilePath,

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -162,6 +162,20 @@ final class FrameBuilderTest extends TestCase
             ],
             new Frame("App\\ClassName@anonymous\0/file::test_function", '/file', 10, "App\\ClassName@anonymous\0/path/to/file:85$29e::test_function", '/path/to/file'),
         ];
+
+        if (\PHP_VERSION_ID >= 80400) {
+            yield [
+                new Options([
+                    'prefixes' => ['/path/to'],
+                ]),
+                [
+                    'file' => '/path/to/file',
+                    'line' => 18,
+                    'function' => '{closure:/path/to/file:18}',
+                ],
+                new Frame('{closure:/file:18}', '/file', 18, null, '/path/to/file'),
+            ];
+        }
     }
 
     /**


### PR DESCRIPTION
As pointed out in #1826 another 8.4 case was not handled properly with path prefix stripping.