### PR TITLE
Allow passing arbitrary event types to the rate limiter

### DIFF
--- a/src/Transport/HttpTransport.php
+++ b/src/Transport/HttpTransport.php
@@ -91,7 +91,7 @@ class HttpTransport implements TransportInterface
         $this->logger->info(\sprintf('Sending %s to %s.', $eventDescription, $targetDescription), ['event' => $event]);
 
         $eventType = $event->getType();
-        if ($this->rateLimiter->isRateLimited($eventType)) {
+        if ($this->rateLimiter->isRateLimited((string) $eventType)) {
             $this->logger->warning(
                 \sprintf('Rate limit exceeded for sending requests of type "%s".', (string) $eventType),
                 ['event' => $event]

--- a/src/Transport/RateLimiter.php
+++ b/src/Transport/RateLimiter.php
@@ -6,6 +6,7 @@ namespace Sentry\Transport;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Sentry\EventType;
 use Sentry\HttpClient\Response;
 
 final class RateLimiter
@@ -92,15 +93,23 @@ final class RateLimiter
         return false;
     }
 
-    public function isRateLimited(string $eventType): bool
+    /**
+     * @param string|EventType $eventType
+     */
+    public function isRateLimited($eventType): bool
     {
         $disabledUntil = $this->getDisabledUntil($eventType);
 
         return $disabledUntil > time();
     }
 
-    public function getDisabledUntil(string $eventType): int
+    /**
+     * @param string|EventType $eventType
+     */
+    public function getDisabledUntil($eventType): int
     {
+        $eventType = $eventType instanceof EventType ? (string) $eventType : $eventType;
+
         if ($eventType === 'event') {
             $eventType = self::DATA_CATEGORY_ERROR;
         }

--- a/src/Transport/RateLimiter.php
+++ b/src/Transport/RateLimiter.php
@@ -6,7 +6,6 @@ namespace Sentry\Transport;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Sentry\EventType;
 use Sentry\HttpClient\Response;
 
 final class RateLimiter
@@ -93,22 +92,20 @@ final class RateLimiter
         return false;
     }
 
-    public function isRateLimited(EventType $eventType): bool
+    public function isRateLimited(string $eventType): bool
     {
         $disabledUntil = $this->getDisabledUntil($eventType);
 
         return $disabledUntil > time();
     }
 
-    public function getDisabledUntil(EventType $eventType): int
+    public function getDisabledUntil(string $eventType): int
     {
-        $category = (string) $eventType;
-
-        if ($eventType === EventType::event()) {
-            $category = self::DATA_CATEGORY_ERROR;
+        if ($eventType === 'event') {
+            $eventType = self::DATA_CATEGORY_ERROR;
         }
 
-        return max($this->rateLimits['all'] ?? 0, $this->rateLimits[$category] ?? 0);
+        return max($this->rateLimits['all'] ?? 0, $this->rateLimits[$eventType] ?? 0);
     }
 
     private function parseRetryAfterHeader(int $currentTime, string $header): int

--- a/tests/Transport/RateLimiterTest.php
+++ b/tests/Transport/RateLimiterTest.php
@@ -116,13 +116,13 @@ final class RateLimiterTest extends TestCase
     private function assertEventTypesAreRateLimited(array $eventTypesLimited): void
     {
         foreach ($eventTypesLimited as $eventType) {
-            $this->assertTrue($this->rateLimiter->isRateLimited($eventType));
+            $this->assertTrue($this->rateLimiter->isRateLimited((string) $eventType));
         }
 
         $eventTypesNotLimited = array_diff(EventType::cases(), $eventTypesLimited);
 
         foreach ($eventTypesNotLimited as $eventType) {
-            $this->assertFalse($this->rateLimiter->isRateLimited($eventType));
+            $this->assertFalse($this->rateLimiter->isRateLimited((string) $eventType));
         }
     }
 }


### PR DESCRIPTION
This allows us to re-use the rate limiter in: getsentry/sentry-php-agent#16

Since we already store arbitrary rate-limits anyway it makes sense we can also check for them instead of only the ones we have defined in our event type enum.

~~With PHP's type juggling this might not be a breaking change unless `strict_types` is defined. Unsure if we can make this change.~~ Nevermind, we can remove any breaking concern by just doing what I've done in now 👍 