### PR TITLE
Add new `strictTracePropagation` option

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -266,6 +266,11 @@ parameters:
 			path: src/Options.php
 
 		-
+			message: "#^Method Sentry\\\\Options\\:\\:isStrictTracePropagationEnabled\\(\\) should return bool but returns mixed\\.$#"
+			count: 1
+			path: src/Options.php
+
+		-
 			message: "#^Method Sentry\\\\Options\\:\\:shouldAttachMetricCodeLocations\\(\\) should return bool but returns mixed\\.$#"
 			count: 1
 			path: src/Options.php

--- a/src/Options.php
+++ b/src/Options.php
@@ -669,6 +669,26 @@ final class Options
     }
 
     /**
+     * Returns whether strict trace propagation is enabled or not.
+     */
+    public function isStrictTracePropagationEnabled(): bool
+    {
+        return $this->options['strict_trace_propagation'];
+    }
+
+    /**
+     * Sets if strict trace propagation should be enabled or not.
+     */
+    public function enableStrictTracePropagation(bool $strictTracePropagation): self
+    {
+        $options = array_merge($this->options, ['strict_trace_propagation' => $strictTracePropagation]);
+
+        $this->options = $this->resolver->resolve($options);
+
+        return $this;
+    }
+
+    /**
      * Gets a list of default tags for events.
      *
      * @return array<string, string>
@@ -1186,6 +1206,7 @@ final class Options
                 return null;
             },
             'trace_propagation_targets' => null,
+            'strict_trace_propagation' => false,
             'tags' => [],
             'error_types' => null,
             'max_breadcrumbs' => self::DEFAULT_MAX_BREADCRUMBS,
@@ -1234,6 +1255,7 @@ final class Options
         $resolver->setAllowedTypes('ignore_exceptions', 'string[]');
         $resolver->setAllowedTypes('ignore_transactions', 'string[]');
         $resolver->setAllowedTypes('trace_propagation_targets', ['null', 'string[]']);
+        $resolver->setAllowedTypes('strict_trace_propagation', 'bool');
         $resolver->setAllowedTypes('tags', 'string[]');
         $resolver->setAllowedTypes('error_types', ['null', 'int']);
         $resolver->setAllowedTypes('max_breadcrumbs', 'int');

--- a/src/functions.php
+++ b/src/functions.php
@@ -57,6 +57,7 @@ use Sentry\Tracing\TransactionContext;
  *     server_name?: string,
  *     spotlight?: bool,
  *     spotlight_url?: string,
+ *     strict_trace_propagation: bool,
  *     tags?: array<string>,
  *     trace_propagation_targets?: array<string>|null,
  *     traces_sample_rate?: float|int|null,

--- a/src/functions.php
+++ b/src/functions.php
@@ -57,7 +57,7 @@ use Sentry\Tracing\TransactionContext;
  *     server_name?: string,
  *     spotlight?: bool,
  *     spotlight_url?: string,
- *     strict_trace_propagation: bool,
+ *     strict_trace_propagation?: bool,
  *     tags?: array<string>,
  *     trace_propagation_targets?: array<string>|null,
  *     traces_sample_rate?: float|int|null,

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -279,6 +279,13 @@ final class OptionsTest extends TestCase
         ];
 
         yield [
+            'strict_trace_propagation',
+            true,
+            'isStrictTracePropagationEnabled',
+            'enableStrictTracePropagation',
+        ];
+
+        yield [
             'before_breadcrumb',
             static function (): void {},
             'getBeforeBreadcrumbCallback',


### PR DESCRIPTION
Adding a new config option called `strictTracePropagation`. This will be used for the upcoming [strictTracePropation](https://develop.sentry.dev/sdk/telemetry/traces/#stricttracecontinuation) feature.