### PR TITLE
Log correct source of sampling decision

### DIFF
--- a/src/State/Hub.php
+++ b/src/State/Hub.php
@@ -288,7 +288,7 @@ class Hub implements HubInterface
                         $samplingContext->getParentSampled(),
                         $options->getTracesSampleRate() ?? 0
                     );
-                    $sampleSource = $samplingContext->getParentSampled() ? 'parent:sampling_decision' : 'config:traces_sample_rate';
+                    $sampleSource = $samplingContext->getParentSampled() !== null ? 'parent:sampling_decision' : 'config:traces_sample_rate';
                 }
             }
 


### PR DESCRIPTION
We incorrectly log `config:traces_sample_rate` in case `-0` is present on the `sentry-trace` header.