### PR TITLE
Add getStoreApiEndpointUrl to UPGRADE-4.0

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -58,6 +58,7 @@
 - Removed `NullTransport`.
 - Removed `Dsn::getSecretKey()`.
 - Removed `Dsn::setSecretKey()`.
+- Removed `Dsn::getStoreApiEndpointUrl()`.
 - Removed `EventType::default()`.
 - Removed adding the value of the `logger` option as a tag on the event. If you rely on this behaviour, add the tag manually.
 


### PR DESCRIPTION
Dsn::getStoreApiEndpointUrl() got removed from v4