### PR TITLE
Add support for variadic parameters and null values

### DIFF
--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -219,7 +219,18 @@ final class FrameBuilder
         foreach ($reflectionFunction->getParameters() as $reflectionParameter) {
             $parameterPosition = $reflectionParameter->getPosition();
 
-            if (!isset($backtraceFrameArgs[$parameterPosition])) {
+            if ($reflectionParameter->isVariadic()) {
+                // For variadic parameters, collect all remaining arguments into an array
+                $variadicArgs = [];
+                for ($i = $parameterPosition; $i < \count($backtraceFrameArgs); ++$i) {
+                    $variadicArgs[] = $backtraceFrameArgs[$i];
+                }
+                $argumentValues[$reflectionParameter->getName()] = $variadicArgs;
+                // Variadic parameter is always the last one, so we can break
+                break;
+            }
+
+            if (!\array_key_exists($parameterPosition, $backtraceFrameArgs)) {
                 continue;
             }
 


### PR DESCRIPTION
| before | after |
|--------|-------|
| ![Firefox 2025-06-07 07 23 11](https://github.com/user-attachments/assets/e40f4765-1bad-418c-a3fc-d551287042c5) | ![Firefox 2025-06-07 07 22 57](https://github.com/user-attachments/assets/d640aaae-8866-48c6-8f12-31282812d0d6) | 

Adding support for variadic parameters and null values in stacktraces.
Method was called with:

```php
Numbers::process(10, null, 40, 50, 60, 70);
```

Closes #1645 