### PR TITLE
Fix `vsprintf` not handling errors

### DIFF
--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -124,6 +124,14 @@ final class LogsAggregator
         return $hub->captureEvent($event);
     }
 
+    /**
+     * @return Log[]
+     */
+    public function all(): array
+    {
+        return $this->logs;
+    }
+
     private function getTraceId(HubInterface $hub): string
     {
         $span = $hub->getSpan();

--- a/src/Serializer/EnvelopItems/EventItem.php
+++ b/src/Serializer/EnvelopItems/EventItem.php
@@ -9,6 +9,7 @@ use Sentry\ExceptionDataBag;
 use Sentry\Serializer\Traits\BreadcrumbSeralizerTrait;
 use Sentry\Serializer\Traits\StacktraceFrameSeralizerTrait;
 use Sentry\Util\JSON;
+use Sentry\Util\Str;
 
 /**
  * @internal
@@ -124,7 +125,7 @@ class EventItem implements EnvelopeItemInterface
                 $payload['message'] = [
                     'message' => $event->getMessage(),
                     'params' => $event->getMessageParams(),
-                    'formatted' => $event->getMessageFormatted() ?? vsprintf($event->getMessage(), $event->getMessageParams()),
+                    'formatted' => $event->getMessageFormatted() ?? Str::vsprintfOrNull($event->getMessage(), $event->getMessageParams()) ?? $event->getMessage(),
                 ];
             }
         }

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Util;
+
+/**
+ * This class provides some utility methods to work with strings.
+ *
+ * @internal
+ */
+class Str
+{
+    /**
+     * Safe way of running `vsprintf` without throwing exceptions or errors.
+     *
+     * If the string could not be formatted, it returns `null`.
+     *
+     * @see https://www.php.net/manual/en/function.vsprintf.php
+     *
+     * @param array<bool|float|int|string|null> $values
+     */
+    public static function vsprintfOrNull(string $message, array $values): ?string
+    {
+        if (empty($values)) {
+            return $message;
+        }
+
+        foreach ($values as $value) {
+            // If the value is not a scalar or null, we cannot safely format it
+            if (!is_scalar($value) && !is_null($value)) {
+                return null;
+            }
+        }
+
+        try {
+            $result = @vsprintf($message, $values);
+
+            // @phpstan-ignore-next-line on PHP 7 `vsprintf` does not throw an exception but can return `false`
+            return $result === false ? null : $result;
+        } catch (\Error $e) { // This is technically a `ValueError` in PHP 8.0+ but this works in PHP 7 as well
+            return null;
+        }
+    }
+}

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -28,7 +28,7 @@ class Str
 
         foreach ($values as $value) {
             // If the value is not a scalar or null, we cannot safely format it
-            if (!is_scalar($value) && !is_null($value)) {
+            if (!\is_scalar($value) && $value !== null) {
                 return null;
             }
         }

--- a/tests/Logs/LogTest.php
+++ b/tests/Logs/LogTest.php
@@ -5,14 +5,9 @@ declare(strict_types=1);
 namespace Sentry\Tests\Logs;
 
 use PHPUnit\Framework\TestCase;
-use Sentry\Attributes\Attribute;
 use Sentry\Logs\Log;
 use Sentry\Logs\LogLevel;
 
-/**
- * @phpstan-import-type AttributeValue from Attribute
- * @phpstan-import-type AttributeSerialized from Attribute
- */
 final class LogTest extends TestCase
 {
     public function testGettersAndSetters(): void

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -63,5 +63,23 @@ final class LogsAggregatorTest extends TestCase
             ['value'],
             'Message with placeholders but incorrect number of values: %s, %s',
         ];
+
+        yield [
+            'Message with a percentage: 42%',
+            [],
+            'Message with a percentage: 42%',
+        ];
+
+        // This test case is a bit of an odd one, you would not expect this to happen in practice unless the user intended
+        // to format the message but did not add the proper placeholder. On PHP 8+ this will return the message as is, but
+        // on PHP 7 it will return the message without the percentage sign because some processing is done by `vsprintf`.
+        // You would however more likely expect the previous test case where no values are provided when no placeholders are present
+        yield [
+            'Message with a percentage: 42%',
+            ['value'],
+            \PHP_VERSION_ID >= 80000
+                ? 'Message with a percentage: 42%'
+                : 'Message with a percentage: 42',
+        ];
     }
 }

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Logs;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientBuilder;
+use Sentry\Logs\LogLevel;
+use Sentry\Logs\LogsAggregator;
+use Sentry\SentrySdk;
+use Sentry\State\Hub;
+
+final class LogsAggregatorTest extends TestCase
+{
+    /**
+     * @dataProvider messageFormattingDataProvider
+     */
+    public function testMessageFormatting(string $message, array $values, string $expected): void
+    {
+        $client = ClientBuilder::create([
+            'enable_logs' => true,
+        ])->getClient();
+
+        $hub = new Hub($client);
+        SentrySdk::setCurrentHub($hub);
+
+        $aggregator = new LogsAggregator();
+
+        $aggregator->add(LogLevel::info(), $message, $values);
+
+        $logs = $aggregator->all();
+
+        $this->assertCount(1, $logs);
+
+        $log = $logs[0];
+
+        $this->assertEquals($expected, $log->getBody());
+    }
+
+    public static function messageFormattingDataProvider(): \Generator
+    {
+        yield [
+            'Simple message without values',
+            [],
+            'Simple message without values',
+        ];
+
+        yield [
+            'Message with a value: %s',
+            ['value'],
+            'Message with a value: value',
+        ];
+
+        yield [
+            'Message with placeholders but no values: %s',
+            [],
+            'Message with placeholders but no values: %s',
+        ];
+
+        yield [
+            'Message with placeholders but incorrect number of values: %s, %s',
+            ['value'],
+            'Message with placeholders but incorrect number of values: %s, %s',
+        ];
+    }
+}

--- a/tests/Util/StrTest.php
+++ b/tests/Util/StrTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Util\Str;
+
+final class StrTest extends TestCase
+{
+    /**
+     * @dataProvider vsprintfOrNullDataProvider
+     */
+    public function testVsprintfOrNull(string $message, array $values, ?string $expected): void
+    {
+        $this->assertSame($expected, Str::vsprintfOrNull($message, $values));
+    }
+
+    public static function vsprintfOrNullDataProvider(): \Generator
+    {
+        yield [
+            'Simple message without values',
+            [],
+            'Simple message without values',
+        ];
+
+        yield [
+            'Message with a value: %s',
+            ['value'],
+            'Message with a value: value',
+        ];
+
+        yield [
+            'Message with placeholders but no values: %s',
+            [],
+            'Message with placeholders but no values: %s',
+        ];
+
+        yield [
+            'Message with placeholders but incorrect number of values: %s, %s',
+            ['value'],
+            null,
+        ];
+
+        yield [
+            'Message with placeholder: %s',
+            [[1, 2, 3]],
+            null,
+        ];
+
+        yield [
+            'Message with placeholder: %s',
+            [new \stdClass()],
+            null,
+        ];
+    }
+}


### PR DESCRIPTION
When you supply an incorrect number of placeholders or no placeholders at all but your string contains placeholders `vsprintf` throws. We can optimize by not using `vsprintf` at all if there are no values supplied by the user, and in addition we fallback to the raw string and emit a log message if we fail to format the string as expected.

Thanks for pointing this out @HazAT!