### PR TITLE
Set allowed types for `http_ssl_native_ca`

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -1328,6 +1328,7 @@ final class Options
         $resolver->setAllowedTypes('http_connect_timeout', ['int', 'float']);
         $resolver->setAllowedTypes('http_timeout', ['int', 'float']);
         $resolver->setAllowedTypes('http_ssl_verify_peer', 'bool');
+        $resolver->setAllowedTypes('http_ssl_native_ca', 'bool');
         $resolver->setAllowedTypes('http_compression', 'bool');
         $resolver->setAllowedTypes('capture_silenced_errors', 'bool');
         $resolver->setAllowedTypes('max_request_body_size', 'string');


### PR DESCRIPTION
The `http_ssl_native_ca` option in `src/Options.php` was updated to include type validation.

Previously, `http_ssl_native_ca` had a default value and associated getter/setter methods, but lacked explicit type validation within the `configureOptions` method.