### PR TITLE
Serialize Enum variants with the variant name

### DIFF
--- a/src/Serializer/AbstractSerializer.php
+++ b/src/Serializer/AbstractSerializer.php
@@ -241,6 +241,12 @@ abstract class AbstractSerializer
             return $value;
         }
 
+        if ($value instanceof \UnitEnum) {
+            $reflection = new \ReflectionObject($value);
+
+            return 'Enum ' . $reflection->getName() . '::' . $value->name;
+        }
+
         if (\is_object($value)) {
             $reflection = new \ReflectionObject($value);
 

--- a/tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Serializer/AbstractSerializerTest.php
@@ -54,6 +54,18 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertSame('Object Sentry\Tests\Serializer\SerializerTestObject', $result);
     }
 
+    /**
+     * @requires PHP >= 8.1
+     */
+    public function testEnumsAreNames(): void
+    {
+        $serializer = $this->createSerializer();
+        $input = SerializerTestEnum::CASE_NAME;
+        $result = $this->invokeSerialization($serializer, $input);
+
+        $this->assertSame('Enum Sentry\Tests\Serializer\SerializerTestEnum::CASE_NAME', $result);
+    }
+
     public static function objectsWithIdPropertyDataProvider(): array
     {
         return [

--- a/tests/Serializer/SerializerTestEnum.php
+++ b/tests/Serializer/SerializerTestEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Serializer;
+
+enum SerializerTestEnum
+{
+    case CASE_NAME;
+}


### PR DESCRIPTION
With enum types it's almost always useful to know exactly which variant is being logged. But the current serializers don't differentiate between enums and objects.

This changes the serializers to add the variant name of the enum that is being serialized.