### PR TITLE
Do not call Reflection*::setAccessible() in PHP >= 8.1

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -153,7 +153,9 @@ final class ErrorHandler
     private function __construct()
     {
         $this->exceptionReflection = new \ReflectionProperty(\Exception::class, 'trace');
-        $this->exceptionReflection->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $this->exceptionReflection->setAccessible(true);
+        }
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -29,7 +29,7 @@ use Sentry\Tracing\TransactionContext;
  *     capture_silenced_errors?: bool,
  *     context_lines?: int|null,
  *     default_integrations?: bool,
- *     dsn?: string|bool|null|Dsn,
+ *     dsn?: string|bool|Dsn|null,
  *     enable_logs?: bool,
  *     environment?: string|null,
  *     error_types?: int|null,

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -300,12 +300,16 @@ final class FrameBuilderTest extends TestCase
 
         $reflectionClass = new \ReflectionClass($frameBuilder);
         $getFunctionArgumentsMethod = $reflectionClass->getMethod('getFunctionArguments');
-        $getFunctionArgumentsMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentsMethod->setAccessible(true);
+        }
 
         $reflectionFunction = new \ReflectionFunction($testFunction);
 
         $getFunctionArgumentValuesMethod = $reflectionClass->getMethod('getFunctionArgumentValues');
-        $getFunctionArgumentValuesMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentValuesMethod->setAccessible(true);
+        }
 
         $result = $getFunctionArgumentValuesMethod->invoke($frameBuilder, $reflectionFunction, $backtraceFrame['args']);
 
@@ -331,7 +335,9 @@ final class FrameBuilderTest extends TestCase
 
         $reflectionClass = new \ReflectionClass($frameBuilder);
         $getFunctionArgumentValuesMethod = $reflectionClass->getMethod('getFunctionArgumentValues');
-        $getFunctionArgumentValuesMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentValuesMethod->setAccessible(true);
+        }
 
         $reflectionFunction = new \ReflectionFunction($testFunction);
 
@@ -356,7 +362,9 @@ final class FrameBuilderTest extends TestCase
 
         $reflectionClass = new \ReflectionClass($frameBuilder);
         $getFunctionArgumentValuesMethod = $reflectionClass->getMethod('getFunctionArgumentValues');
-        $getFunctionArgumentValuesMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentValuesMethod->setAccessible(true);
+        }
 
         $reflectionFunction = new \ReflectionFunction($testFunction);
 
@@ -383,7 +391,9 @@ final class FrameBuilderTest extends TestCase
 
         $reflectionClass = new \ReflectionClass($frameBuilder);
         $getFunctionArgumentValuesMethod = $reflectionClass->getMethod('getFunctionArgumentValues');
-        $getFunctionArgumentValuesMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentValuesMethod->setAccessible(true);
+        }
 
         $reflectionFunction = new \ReflectionFunction($testFunction);
 
@@ -418,7 +428,9 @@ final class FrameBuilderTest extends TestCase
 
         $reflectionClass = new \ReflectionClass($frameBuilder);
         $getFunctionArgumentValuesMethod = $reflectionClass->getMethod('getFunctionArgumentValues');
-        $getFunctionArgumentValuesMethod->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentValuesMethod->setAccessible(true);
+        }
 
         $reflectionFunction = new \ReflectionFunction($testFunction);
 

--- a/tests/SentrySdkExtension.php
+++ b/tests/SentrySdkExtension.php
@@ -14,18 +14,30 @@ final class SentrySdkExtension implements BeforeTestHookInterface
     public function executeBeforeTest(string $test): void
     {
         $reflectionProperty = new \ReflectionProperty(SentrySdk::class, 'currentHub');
-        $reflectionProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue(null, null);
-        $reflectionProperty->setAccessible(false);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(false);
+        }
 
         $reflectionProperty = new \ReflectionProperty(Scope::class, 'globalEventProcessors');
-        $reflectionProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue(null, []);
-        $reflectionProperty->setAccessible(false);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(false);
+        }
 
         $reflectionProperty = new \ReflectionProperty(IntegrationRegistry::class, 'integrations');
-        $reflectionProperty->setAccessible(true);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
         $reflectionProperty->setValue(IntegrationRegistry::getInstance(), []);
-        $reflectionProperty->setAccessible(false);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(false);
+        }
     }
 }


### PR DESCRIPTION
> As of PHP 8.1.0, calling this method has no effect; all methods are invokable by default.

(https://www.php.net/manual/en/reflectionmethod.setaccessible.php and https://www.php.net/manual/en/reflectionproperty.setaccessible.php).

There're even plans to deprecate the method in PHP 8.5: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations