### PR TITLE
Fix non string indexed attributes passed as log attributes

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -34,6 +34,7 @@ return (new PhpCsFixer\Config())
             'after_heredoc' => false,
             'elements' => ['arrays'],
         ],
+        'no_whitespace_before_comma_in_array' => false, // Should be dropped when we drop support for PHP 7.x
     ])
     ->setRiskyAllowed(true)
     ->setFinder(

--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -108,15 +108,27 @@ final class LogsAggregator
         foreach ($attributes as $key => $value) {
             $attribute = Attribute::tryFromValue($value);
 
+            if (!\is_string($key)) {
+                if ($sdkLogger !== null) {
+                    $sdkLogger->info(
+                        \sprintf("Dropping log attribute with non-string key '%s' and value of type '%s'.", $key, \gettype($value))
+                    );
+                }
+
+                continue;
+            }
+
             if ($attribute === null) {
                 if ($sdkLogger !== null) {
                     $sdkLogger->info(
                         \sprintf("Dropping log attribute {$key} with value of type '%s' because it is not serializable or an unsupported type.", \gettype($value))
                     );
                 }
-            } else {
-                $log->setAttribute($key, $attribute);
+
+                continue;
             }
+
+            $log->setAttribute($key, $attribute);
         }
 
         $log = ($options->getBeforeSendLogCallback())($log);

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -21,6 +21,68 @@ use Sentry\UserDataBag;
 final class LogsAggregatorTest extends TestCase
 {
     /**
+     * This test is kept simple to ensure the `LogAggregator` is able to handle attributes passed in different formats.
+     *
+     * Extensive testing of attributes is done in the `Attributes/*` test classes.
+     *
+     * @dataProvider attributesDataProvider
+     */
+    public function testAttributes(array $attributes, array $expected): void
+    {
+        $client = ClientBuilder::create([
+            'enable_logs' => true,
+        ])->getClient();
+
+        $hub = new Hub($client);
+        SentrySdk::setCurrentHub($hub);
+
+        $aggregator = new LogsAggregator();
+
+        $aggregator->add(LogLevel::info(), 'Test message', [], $attributes);
+
+        $logs = $aggregator->all();
+
+        $this->assertCount(1, $logs);
+
+        $log = $logs[0];
+
+        $this->assertSame(
+            $expected,
+            array_filter(
+                $log->attributes()->toSimpleArray(),
+                static function (string $key) {
+                    // We are not testing internal Sentry attributes here, only the ones the user supplied
+                    return !str_starts_with($key, 'sentry.');
+                },
+                \ARRAY_FILTER_USE_KEY
+            )
+        );
+    }
+
+    public static function attributesDataProvider(): \Generator
+    {
+        yield [
+            [],
+            [],
+        ];
+
+        yield [
+            ['foo', 'bar'],
+            [],
+        ];
+
+        yield [
+            ['foo' => 'bar'],
+            ['foo' => 'bar'],
+        ];
+
+        yield [
+            ['foo' => ['bar']],
+            [],
+        ];
+    }
+
+    /**
      * @dataProvider messageFormattingDataProvider
      */
     public function testMessageFormatting(string $message, array $values, string $expected): void


### PR DESCRIPTION
In the future we are going to support "array" types, but for now we don't so I opted to discard the values instead of crashing or converting them. Added the missing tests to cover the case, extensive attribute testing is already done elsewhere so I kept the test case relatively small to not duplicate data type testing from the attribute tests.

Fixes #1881