### PR TITLE
Do not send template attribute with logs when there are no template values

### DIFF
--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -76,7 +76,6 @@ final class LogsAggregator
             ->setAttribute('sentry.release', $options->getRelease())
             ->setAttribute('sentry.environment', $options->getEnvironment() ?? Event::DEFAULT_ENVIRONMENT)
             ->setAttribute('sentry.server.address', $options->getServerName())
-            ->setAttribute('sentry.message.template', $message)
             ->setAttribute('sentry.trace.parent_span_id', $hub->getSpan() ? $hub->getSpan()->getSpanId() : null);
 
         if ($client instanceof Client) {
@@ -99,8 +98,12 @@ final class LogsAggregator
             }
         });
 
-        foreach ($values as $key => $value) {
-            $log->setAttribute("sentry.message.parameter.{$key}", $value);
+        if (\count($values)) {
+            $log->setAttribute('sentry.message.template', $message);
+
+            foreach ($values as $key => $value) {
+                $log->setAttribute("sentry.message.parameter.{$key}", $value);
+            }
         }
 
         $attributes = Arr::simpleDot($attributes);

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -105,6 +105,12 @@ final class LogsAggregatorTest extends TestCase
         $log = $logs[0];
 
         $this->assertSame($expected, $log->getBody());
+
+        if (\count($values)) {
+            $this->assertNotNull($log->attributes()->get('sentry.message.template'));
+        } else {
+            $this->assertNull($log->attributes()->get('sentry.message.template'));
+        }
     }
 
     public static function messageFormattingDataProvider(): \Generator


### PR DESCRIPTION
In response to getsentry/sentry-docs#14759