### PR TITLE
ref: remove @internal annotation from Result

### DIFF
--- a/src/Transport/Result.php
+++ b/src/Transport/Result.php
@@ -9,8 +9,6 @@ use Sentry\Event;
 /**
  * This class contains the details of the sending operation of an event, e.g.
  * if it was sent successfully or if it was skipped because of some reason.
- *
- * @internal
  */
 class Result
 {


### PR DESCRIPTION
Removes the `@internal` annotation from `Sentry\Transport\Result` as it would lead to linter errors when implementing a custom Transport using `Sentry\Transport\TransportInterface`.

closes https://github.com/getsentry/sentry-php/issues/1894
closes PHP-23