### PR TITLE
ref(logs): implement __destruct to make sure logs are always flushed

### DIFF
--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -6,12 +6,11 @@ namespace Sentry\Monolog;
 
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\HandlerInterface;
 use Monolog\LogRecord;
 use Sentry\Logs\LogLevel;
 use Sentry\Logs\Logs;
 
-class LogsHandler implements HandlerInterface
+class LogsHandler extends \Monolog\Handler\Handler
 {
     use CompatibilityLogLevelTrait;
 
@@ -70,16 +69,6 @@ class LogsHandler implements HandlerInterface
         );
 
         return $this->bubble === false;
-    }
-
-    /**
-     * @param array<array<string, mixed>|LogRecord> $records
-     */
-    public function handleBatch(array $records): void
-    {
-        foreach ($records as $record) {
-            $this->handle($record);
-        }
     }
 
     public function close(): void


### PR DESCRIPTION
~This PR updates the `LogsHandler` to extent `\Monolog\Handler\Handler` so that we inherit the `__destruct` method which will flush when being destructed.~

Implements `__destruct` manually to make sure that logs are always flushed once the handler is destructed.
This will make sure that no logs are lost in case calling `flush()` is forgotten.

We cannot use `\Monolog\Handler\Handler` because it is not available for the lowest version of monolog we support.

resolves https://github.com/getsentry/sentry-php/issues/1915
closes PHP-33