### PR TITLE
ref(logs): add sentry.origin attribute to monolog handler

### DIFF
--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -66,8 +66,7 @@ class LogsHandler implements HandlerInterface
             self::getSentryLogLevelFromMonologLevel($record['level']),
             $record['message'],
             [],
-            // If sentry.origin exists in other arrays, it will be overwritten.
-            array_merge(['sentry.origin' => 'auto.logger.monolog'], $record['context'], $record['extra'])
+            array_merge($record['context'], $record['extra'], ['sentry.origin' => 'auto.logger.monolog'])
         );
 
         return $this->bubble === false;

--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -66,7 +66,8 @@ class LogsHandler implements HandlerInterface
             self::getSentryLogLevelFromMonologLevel($record['level']),
             $record['message'],
             [],
-            array_merge($record['context'], $record['extra'])
+            // If sentry.origin exists in other arrays, it will be overwritten.
+            array_merge(['sentry.origin' => 'auto.logger.monolog'], $record['context'], $record['extra'])
         );
 
         return $this->bubble === false;

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -85,7 +85,7 @@ final class LogsHandlerTest extends TestCase
 
     public function testOriginTagNotAppliedWhenUsingDirectly()
     {
-        \Sentry\logger()->info("No origin attribute");
+        \Sentry\logger()->info('No origin attribute');
 
         $logs = Logs::getInstance()->aggregator()->all();
         $this->assertCount(1, $logs);

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -83,6 +83,17 @@ final class LogsHandlerTest extends TestCase
         $this->assertSame('auto.logger.monolog', $log->attributes()->toSimpleArray()['sentry.origin']);
     }
 
+    public function testOriginTagNotAppliedWhenUsingDirectly()
+    {
+        \Sentry\logger()->info("No origin attribute");
+
+        $logs = Logs::getInstance()->aggregator()->all();
+        $this->assertCount(1, $logs);
+        $log = $logs[0];
+        $this->assertSame('No origin attribute', $log->getBody());
+        $this->assertArrayNotHasKey('sentry.origin', $log->attributes()->toSimpleArray());
+    }
+
     public static function handleDataProvider(): iterable
     {
         yield [

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -19,13 +19,6 @@ final class LogsHandlerTest extends TestCase
     protected function setUp(): void
     {
         Logs::getInstance()->flush();
-    }
-
-    /**
-     * @dataProvider handleDataProvider
-     */
-    public function testHandle($record, Log $expectedLog): void
-    {
         $client = ClientBuilder::create([
             'enable_logs' => true,
             'before_send' => static function () {
@@ -35,7 +28,13 @@ final class LogsHandlerTest extends TestCase
 
         $hub = new Hub($client);
         SentrySdk::setCurrentHub($hub);
+    }
 
+    /**
+     * @dataProvider handleDataProvider
+     */
+    public function testHandle($record, Log $expectedLog): void
+    {
         $handler = new LogsHandler();
         $handler->handle($record);
 
@@ -65,21 +64,23 @@ final class LogsHandlerTest extends TestCase
      */
     public function testLogLevels($record, int $countLogs): void
     {
-        $client = ClientBuilder::create([
-            'enable_logs' => true,
-            'before_send' => static function () {
-                return null;
-            },
-        ])->getClient();
-
-        $hub = new Hub($client);
-        SentrySdk::setCurrentHub($hub);
-
         $handler = new LogsHandler(LogLevel::warn());
         $handler->handle($record);
 
         $logs = Logs::getInstance()->aggregator()->all();
         $this->assertCount($countLogs, $logs);
+    }
+
+    public function testOriginTagAppliedWithHandler(): void
+    {
+        $handler = new LogsHandler(LogLevel::warn());
+        $handler->handle(RecordFactory::create('with origin', Logger::WARNING, 'channel.foo', [], []));
+
+        $logs = Logs::getInstance()->aggregator()->all();
+        $this->assertCount(1, $logs);
+        $log = $logs[0];
+        $this->assertArrayHasKey('sentry.origin', $log->attributes()->toSimpleArray());
+        $this->assertSame('auto.logger.monolog', $log->attributes()->toSimpleArray()['sentry.origin']);
     }
 
     public static function handleDataProvider(): iterable


### PR DESCRIPTION
This PR adds `sentry.origin` to the log attributes in the Monolog handler as defined here: https://develop.sentry.dev/sdk/telemetry/logs/#sdk-integration-attributes

When using `\Sentry\logger()->info(..)`, it will not have this attribute since the attribute should only be added for integrations.

This will also add the attributes in symfony because it's using this handler