### PR TITLE
feat: scrub PII exposed by Cloudflare proxy services by default

### DIFF
--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -59,6 +59,7 @@ final class RequestIntegration implements IntegrationInterface
         'Set-Cookie',
         'X-Forwarded-For',
         'X-Real-IP',
+        'CF-Connecting-IP',
     ];
 
     /**


### PR DESCRIPTION
### Description

CloudFlare's proxy services are known to inject `CF-Connecting-IP` header in the request, which contains the real IP address of the requester. This header seems to have similar functionality as `X-Forwarded-For` and/or `X-Real-IP`. 

As with `X-Real-IP` and `X-Forwarded-For`, the IP-address contained in the `CF-Connecting-IP` header is considered PII and should be scrubbed by default.

See also: https://developers.cloudflare.com/fundamentals/reference/http-headers/