### PR TITLE
meta: Run CI on PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - { version: '8.2', phpunit: '^9.6.21' }
           - { version: '8.3', phpunit: '^9.6.21' }
           - { version: '8.4', phpunit: '^9.6.21' }
+          - { version: '8.5', phpunit: '^9.6.21' }
         dependencies:
           - lowest
           - highest


### PR DESCRIPTION
Adding [PHP 8.5.0 RC 1](https://www.php.net/archive/2025.php#2025-09-25-3) to our CI matrix.