### PR TITLE
meta: Pin symfony/phpunit-bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
         php:
-          - { version: '7.2', phpunit: '^8.5.40' }
-          - { version: '7.3', phpunit: '^9.6.21' }
-          - { version: '7.4', phpunit: '^9.6.21' }
-          - { version: '8.0', phpunit: '^9.6.21' }
-          - { version: '8.1', phpunit: '^9.6.21' }
-          - { version: '8.2', phpunit: '^9.6.21' }
-          - { version: '8.3', phpunit: '^9.6.21' }
-          - { version: '8.4', phpunit: '^9.6.21' }
+          - { version: '7.2', phpunit: '8.5.47' }
+          - { version: '7.3', phpunit: '9.6.28' }
+          - { version: '7.4', phpunit: '9.6.28' }
+          - { version: '8.0', phpunit: '9.6.28' }
+          - { version: '8.1', phpunit: '9.6.28' }
+          - { version: '8.2', phpunit: '9.6.28' }
+          - { version: '8.3', phpunit: '9.6.28' }
+          - { version: '8.4', phpunit: '9.6.28' }
         dependencies:
           - lowest
           - highest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
         php:
-          - { version: '7.2', phpunit: '8.5.47' }
-          - { version: '7.3', phpunit: '9.6.28' }
-          - { version: '7.4', phpunit: '9.6.28' }
-          - { version: '8.0', phpunit: '9.6.28' }
-          - { version: '8.1', phpunit: '9.6.28' }
-          - { version: '8.2', phpunit: '9.6.28' }
-          - { version: '8.3', phpunit: '9.6.28' }
-          - { version: '8.4', phpunit: '9.6.28' }
+          - { version: '7.2', phpunit: '^8.5.40' }
+          - { version: '7.3', phpunit: '^9.6.21' }
+          - { version: '7.4', phpunit: '^9.6.21' }
+          - { version: '8.0', phpunit: '^9.6.21' }
+          - { version: '8.1', phpunit: '^9.6.21' }
+          - { version: '8.2', phpunit: '^9.6.21' }
+          - { version: '8.3', phpunit: '^9.6.21' }
+          - { version: '8.4', phpunit: '^9.6.21' }
         dependencies:
           - lowest
           - highest

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^8.5|^9.6",
-        "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
+        "symfony/phpunit-bridge": "^5.2|6.4.25|7.3.3",
         "vimeo/psalm": "^4.17"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "monolog/monolog": "^1.6|^2.0|^3.0",
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.3",
-        "phpunit/phpunit": "8.5.47|9.6.28",
+        "phpunit/phpunit": "^8.5|^9.6",
         "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
         "vimeo/psalm": "^4.17"
     },
@@ -65,6 +65,7 @@
         "check": [
             "@cs-check",
             "@phpstan",
+            "@psalm",
             "@tests"
         ],
         "tests": "vendor/bin/phpunit --verbose",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "monolog/monolog": "^1.6|^2.0|^3.0",
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.3",
-        "phpunit/phpunit": "^8.5|^9.6",
+        "phpunit/phpunit": "8.5.47|9.6.28",
         "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
         "vimeo/psalm": "^4.17"
     },
@@ -65,7 +65,6 @@
         "check": [
             "@cs-check",
             "@phpstan",
-            "@psalm",
             "@tests"
         ],
         "tests": "vendor/bin/phpunit --verbose",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins dev dependency `symfony/phpunit-bridge` to `6.4.25` and `7.3.3` (retains `^5.2`) in `composer.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b4798efe49dcd5c5ad9d51c97bc7478dec833f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

The latest release made some changes to how the error handler is set-up. Pinning to the previous version for now, to unblock CI.