### PR TITLE
ref(logs): extract attribute compilation logic in Monolog LogsHandler

### DIFF
--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -66,7 +66,7 @@ class LogsHandler implements HandlerInterface
             self::getSentryLogLevelFromMonologLevel($record['level']),
             $record['message'],
             [],
-            array_merge($record['context'], $record['extra'], ['sentry.origin' => 'auto.logger.monolog'])
+            $this->compileAttributes($record)
         );
 
         return $this->bubble === false;
@@ -122,5 +122,10 @@ class LogsHandler implements HandlerInterface
         } catch (\Throwable $e) {
             // Just in case so that the destructor can never fail.
         }
+    }
+
+    protected function compileAttributes(LogRecord $record): array
+    {
+        return array_merge($record['context'], $record['extra'], ['sentry.origin' => 'auto.logger.monolog']);
     }
 }


### PR DESCRIPTION
## Summary

• Extracted the attribute compilation logic from the `handle()` method into a dedicated `compileAttributes()` method
• Improves code readability and maintainability by separating concerns
• Makes the attribute compilation logic reusable for future enhancements

## Changes

- Added protected method `compileAttributes(LogRecord $record): array`
- Refactored `handle()` method to use the new method instead of inline array_merge
- No functional changes - this is purely a code organization improvement

## Test plan

- [x] Existing tests should continue to pass as this is a refactoring with no functional changes
- [x] The Monolog handler should continue to work exactly as before
- [x] The `sentry.origin` attribute should still be properly added to log records