### PR TITLE
ref: remove phpunit bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "phpbench/phpbench": "^1.0",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^8.5|^9.6",
-        "symfony/phpunit-bridge": "^5.2|^6.0|^7.0",
         "vimeo/psalm": "^4.17"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
     excludePaths:
         - tests/resources
         - tests/Fixtures
+        - src/Util/ClockMock.php
     dynamicConstantNames:
         - Monolog\Logger::API
     bootstrapFiles:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,9 +34,9 @@
         </whitelist>
     </filter>
 
-    <listeners>
-        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
+<!--    <listeners>-->
+<!--        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />-->
+<!--    </listeners>-->
 
     <extensions>
         <extension class="Sentry\Tests\SentrySdkExtension" />

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -34,10 +34,6 @@
         </whitelist>
     </filter>
 
-<!--    <listeners>-->
-<!--        <listener class="\Symfony\Bridge\PhpUnit\SymfonyTestsListener" />-->
-<!--    </listeners>-->
-
     <extensions>
         <extension class="Sentry\Tests\SentrySdkExtension" />
     </extensions>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -10,6 +10,7 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <file name="src/Util/ClockMock.php" />
         </ignoreFiles>
     </projectFiles>
 

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Sentry\State;
 
-use Sentry\Attachment\Attachment;
 use Sentry\Breadcrumb;
 use Sentry\CheckInStatus;
 use Sentry\ClientInterface;
@@ -218,10 +217,5 @@ final class HubAdapter implements HubInterface
     public function __sleep()
     {
         throw new \BadMethodCallException('Serializing instances of this class is forbidden.');
-    }
-
-    public function addAttachment(Attachment $attachment): bool
-    {
-        return self::$instance->addAttachment($attachment);
     }
 }

--- a/src/State/HubAdapter.php
+++ b/src/State/HubAdapter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\State;
 
+use Sentry\Attachment\Attachment;
 use Sentry\Breadcrumb;
 use Sentry\CheckInStatus;
 use Sentry\ClientInterface;
@@ -217,5 +218,10 @@ final class HubAdapter implements HubInterface
     public function __sleep()
     {
         throw new \BadMethodCallException('Serializing instances of this class is forbidden.');
+    }
+
+    public function addAttachment(Attachment $attachment): bool
+    {
+        return self::$instance->addAttachment($attachment);
     }
 }

--- a/src/Util/ClockMock.php
+++ b/src/Util/ClockMock.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Original file: https://github.com/symfony/symfony/blob/9c413a356ccb3c982add8fa2b19813927157aa0e/src/Symfony/Bridge/PhpUnit/ClockMock.php#L18
+ *
+ * Copyright (c) 2004-present Fabien Potencier
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+namespace Sentry\Util;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ * @author Dominic Tubach <dominic.tubach@to.com>
+ */
+class ClockMock
+{
+    private static $now;
+
+    public static function withClockMock($enable = null): ?bool
+    {
+        if ($enable === null) {
+            return self::$now !== null;
+        }
+
+        self::$now = is_numeric($enable) ? (float) $enable : ($enable ? microtime(true) : null);
+
+        return null;
+    }
+
+    public static function time(): int
+    {
+        if (self::$now === null) {
+            return time();
+        }
+
+        return (int) self::$now;
+    }
+
+    public static function sleep($s): int
+    {
+        if (self::$now === null) {
+            return sleep($s);
+        }
+
+        self::$now += (int) $s;
+
+        return 0;
+    }
+
+    public static function usleep($us): void
+    {
+        if (self::$now === null) {
+            usleep($us);
+        } else {
+            self::$now += $us / 1000000;
+        }
+    }
+
+    /**
+     * @return string|float
+     */
+    public static function microtime($asFloat = false)
+    {
+        if (self::$now === null) {
+            return microtime($asFloat);
+        }
+
+        if ($asFloat) {
+            return self::$now;
+        }
+
+        return \sprintf('%0.6f00 %d', self::$now - (int) self::$now, (int) self::$now);
+    }
+
+    public static function date($format, $timestamp = null): string
+    {
+        if ($timestamp === null) {
+            $timestamp = self::time();
+        }
+
+        return date($format, $timestamp);
+    }
+
+    public static function gmdate($format, $timestamp = null): string
+    {
+        if ($timestamp === null) {
+            $timestamp = self::time();
+        }
+
+        return gmdate($format, $timestamp);
+    }
+
+    /**
+     * @return array|int|float
+     */
+    public static function hrtime($asNumber = false)
+    {
+        $ns = (self::$now - (int) self::$now) * 1000000000;
+
+        if ($asNumber) {
+            $number = \sprintf('%d%d', (int) self::$now, $ns);
+
+            return \PHP_INT_SIZE === 8 ? (int) $number : (float) $number;
+        }
+
+        return [(int) self::$now, (int) $ns];
+    }
+
+    /**
+     * @return false|int
+     */
+    public static function strtotime(string $datetime, ?int $timestamp = null)
+    {
+        if ($timestamp === null) {
+            $timestamp = self::time();
+        }
+
+        return strtotime($datetime, $timestamp);
+    }
+
+    public static function register($class): void
+    {
+        $self = static::class;
+
+        $mockedNs = [substr($class, 0, strrpos($class, '\\'))];
+        if (strpos($class, '\\Tests\\') > 0) {
+            $ns = str_replace('\\Tests\\', '\\', $class);
+            $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));
+        } elseif (str_starts_with($class, 'Tests\\')) {
+            $mockedNs[] = substr($class, 6, strrpos($class, '\\') - 6);
+        }
+        foreach ($mockedNs as $ns) {
+            if (\function_exists($ns . '\time')) {
+                continue;
+            }
+            eval(<<<EOPHP
+namespace $ns;
+
+function time()
+{
+    return \\$self::time();
+}
+
+function microtime(\$asFloat = false)
+{
+    return \\$self::microtime(\$asFloat);
+}
+
+function sleep(\$s)
+{
+    return \\$self::sleep(\$s);
+}
+
+function usleep(\$us)
+{
+    \\$self::usleep(\$us);
+}
+
+function date(\$format, \$timestamp = null)
+{
+    return \\$self::date(\$format, \$timestamp);
+}
+
+function gmdate(\$format, \$timestamp = null)
+{
+    return \\$self::gmdate(\$format, \$timestamp);
+}
+
+function hrtime(\$asNumber = false)
+{
+    return \\$self::hrtime(\$asNumber);
+}
+
+function strtotime(\$datetime, \$timestamp = null)
+{
+    return \\$self::strtotime(\$datetime, \$timestamp);
+}
+EOPHP
+            );
+        }
+    }
+}

--- a/tests/BreadcrumbTest.php
+++ b/tests/BreadcrumbTest.php
@@ -6,7 +6,7 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\Breadcrumb;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 final class BreadcrumbTest extends TestCase
 {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -24,12 +24,9 @@ use Sentry\State\Scope;
 use Sentry\Transport\Result;
 use Sentry\Transport\ResultStatus;
 use Sentry\Transport\TransportInterface;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class ClientTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     public function testConstructorSetupsIntegrations(): void
     {
         $integrationCalled = false;

--- a/tests/DsnTest.php
+++ b/tests/DsnTest.php
@@ -6,12 +6,9 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\Dsn;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class DsnTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @dataProvider createFromStringDataProvider
      */

--- a/tests/Metrics/MetricsTest.php
+++ b/tests/Metrics/MetricsTest.php
@@ -13,7 +13,7 @@ use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\TransactionContext;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 use function Sentry\metrics;
 

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -11,13 +11,10 @@ use Sentry\HttpClient\HttpClient;
 use Sentry\Options;
 use Sentry\Serializer\PayloadSerializer;
 use Sentry\Transport\HttpTransport;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 final class OptionsTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     /**
      * @var int
      */

--- a/tests/Serializer/PayloadSerializerTest.php
+++ b/tests/Serializer/PayloadSerializerTest.php
@@ -32,8 +32,8 @@ use Sentry\Tracing\SpanStatus;
 use Sentry\Tracing\TraceId;
 use Sentry\Tracing\TransactionMetadata;
 use Sentry\UserDataBag;
+use Sentry\Util\ClockMock;
 use Sentry\Util\SentryUid;
-use Symfony\Bridge\PhpUnit\ClockMock;
 
 /**
  * @group time-sensitive

--- a/tests/Tracing/SpanTest.php
+++ b/tests/Tracing/SpanTest.php
@@ -11,7 +11,7 @@ use Sentry\Tracing\SpanId;
 use Sentry\Tracing\TraceId;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 /**
  * @group time-sensitive

--- a/tests/Tracing/TransactionContextTest.php
+++ b/tests/Tracing/TransactionContextTest.php
@@ -11,12 +11,9 @@ use Sentry\Tracing\TraceId;
 use Sentry\Tracing\TransactionContext;
 use Sentry\Tracing\TransactionMetadata;
 use Sentry\Tracing\TransactionSource;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 final class TransactionContextTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     public function testGettersAndSetters(): void
     {
         $transactionContext = new TransactionContext();

--- a/tests/Tracing/TransactionTest.php
+++ b/tests/Tracing/TransactionTest.php
@@ -16,7 +16,7 @@ use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 /**
  * @group time-sensitive

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -15,7 +15,7 @@ use Sentry\Options;
 use Sentry\Serializer\PayloadSerializerInterface;
 use Sentry\Transport\HttpTransport;
 use Sentry\Transport\ResultStatus;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 final class HttpTransportTest extends TestCase
 {

--- a/tests/Transport/RateLimiterTest.php
+++ b/tests/Transport/RateLimiterTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Sentry\EventType;
 use Sentry\HttpClient\Response;
 use Sentry\Transport\RateLimiter;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 /**
  * @group time-sensitive

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,7 +7,7 @@ use Sentry\Event;
 use Sentry\Metrics\Metrics;
 use Sentry\Tracing\Span;
 use Sentry\Transport\RateLimiter;
-use Symfony\Bridge\PhpUnit\ClockMock;
+use Sentry\Util\ClockMock;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
@@ -27,3 +27,4 @@ ClockMock::register(Breadcrumb::class);
 ClockMock::register(Span::class);
 ClockMock::register(RateLimiter::class);
 ClockMock::register(Metrics::class);
+ClockMock::register(Sentry\Serializer\PayloadSerializer::class);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces Symfony PHPUnit Bridge/ClockMock with a new internal `Sentry\Util\ClockMock`, updates tests accordingly, and adjusts static analysis and PHPUnit config.
> 
> - **Testing**:
>   - Replace `Symfony\Bridge\PhpUnit\ClockMock` with internal `Sentry\Util\ClockMock` across tests and `tests/bootstrap.php` (adds additional `ClockMock::register(...)`, incl. `Sentry\Serializer\PayloadSerializer`).
>   - Remove `Symfony\Bridge\PhpUnit\ExpectDeprecationTrait` usages from tests.
> - **New Utility**:
>   - Add `src/Util/ClockMock.php` (ported clock mocking functions) used by tests.
> - **Config**:
>   - Remove `symfony/phpunit-bridge` from `require-dev` and drop PHPUnit `<listeners>` from `phpunit.xml.dist`.
>   - Exclude `src/Util/ClockMock.php` from analyzers (`phpstan.neon` excludePaths, `psalm.xml.dist` ignoreFiles).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee9440ab4a6d31931665b0c1aabe14302a6d8736. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Removes the `symfony/phpunit-bridge` dependency in favour of a vendored `ClockMock` class from said dependency. The motivation behind this is that a change in the bridge broke our pipeline and we only really use the `ClockMock` from the package.