### PR TITLE
ref: replace str_starts_with with strpos in ClockMock

### DIFF
--- a/src/Util/ClockMock.php
+++ b/src/Util/ClockMock.php
@@ -146,7 +146,7 @@ class ClockMock
         if (strpos($class, '\\Tests\\') > 0) {
             $ns = str_replace('\\Tests\\', '\\', $class);
             $mockedNs[] = substr($ns, 0, strrpos($ns, '\\'));
-        } elseif (str_starts_with($class, 'Tests\\')) {
+        } elseif (strpos($class, 'Tests\\') === 0) {
             $mockedNs[] = substr($class, 6, strrpos($class, '\\') - 6);
         }
         foreach ($mockedNs as $ns) {


### PR DESCRIPTION
Replaces the usage of `str_starts_with` in our vendored `ClockMock` with `strpos` to remain PHP 7.2 compatible.

It currently only works because we are using polyfill through `symfony/options-resolver`, which will be removed in the future and will cause this code to fail.