### PR TITLE
fix(logs): `sentry.origin` value

### DIFF
--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -66,7 +66,7 @@ class LogsHandler implements HandlerInterface
             self::getSentryLogLevelFromMonologLevel($record['level']),
             $record['message'],
             [],
-            array_merge($record['context'], $record['extra'], ['sentry.origin' => 'auto.logger.monolog'])
+            array_merge($record['context'], $record['extra'], ['sentry.origin' => 'auto.log.monolog'])
         );
 
         return $this->bubble === false;

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -129,7 +129,7 @@ final class LogsHandlerTest extends TestCase
         $this->assertCount(1, $logs);
         $log = $logs[0];
         $this->assertArrayHasKey('sentry.origin', $log->attributes()->toSimpleArray());
-        $this->assertSame('auto.logger.monolog', $log->attributes()->toSimpleArray()['sentry.origin']);
+        $this->assertSame('auto.log.monolog', $log->attributes()->toSimpleArray()['sentry.origin']);
     }
 
     public function testOriginTagNotAppliedWhenUsingDirectly()


### PR DESCRIPTION
resolves: #1937
resolves: PHP-39