### PR TITLE
Remove `max_request_body_size: none` option value

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -100,3 +100,17 @@ The following deprecated methods have been removed:
 ### EventType Changes
 
 The `metrics` event type has been removed from `EventType::cases()` as metrics are no longer supported.
+
+### Request Body Size Option Value Changed
+
+The `max_request_body_size` option value `'none'` has been renamed to `'never'` for consistency:
+
+```php
+// Before (4.x)
+$options->setMaxRequestBodySize('none');
+
+// After (5.0)
+$options->setMaxRequestBodySize('never');
+```
+
+The allowed values for this option are now: `'never'`, `'small'`, `'medium'`, `'always'`.

--- a/src/Integration/RequestIntegration.php
+++ b/src/Integration/RequestIntegration.php
@@ -275,7 +275,7 @@ final class RequestIntegration implements IntegrationInterface
             return false;
         }
 
-        if ($maxRequestBodySize === 'none' || $maxRequestBodySize === 'never') {
+        if ($maxRequestBodySize === 'never') {
             return false;
         }
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -963,7 +963,7 @@ final class Options
         $resolver->setAllowedTypes('max_request_body_size', 'string');
         $resolver->setAllowedTypes('class_serializers', 'array');
 
-        $resolver->setAllowedValues('max_request_body_size', ['none', 'never', 'small', 'medium', 'always']);
+        $resolver->setAllowedValues('max_request_body_size', ['never', 'small', 'medium', 'always']);
         $resolver->setAllowedValues('dsn', \Closure::fromCallable([$this, 'validateDsnOption']));
         $resolver->setAllowedValues('max_breadcrumbs', \Closure::fromCallable([$this, 'validateMaxBreadcrumbsOptions']));
         $resolver->setAllowedValues('class_serializers', \Closure::fromCallable([$this, 'validateClassSerializersOption']));

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -228,25 +228,6 @@ final class RequestIntegrationTest extends TestCase
 
         yield [
             [
-                'max_request_body_size' => 'none',
-            ],
-            (new ServerRequest('POST', 'http://www.example.com/foo'))
-                ->withHeader('Content-Length', '3')
-                ->withBody(Utils::streamFor('foo')),
-            [
-                'url' => 'http://www.example.com/foo',
-                'method' => 'POST',
-                'headers' => [
-                    'Host' => ['www.example.com'],
-                    'Content-Length' => ['3'],
-                ],
-            ],
-            null,
-            null,
-        ];
-
-        yield [
-            [
                 'max_request_body_size' => 'never',
             ],
             (new ServerRequest('POST', 'http://www.example.com/foo'))


### PR DESCRIPTION
We forgot to remove `none` when shipping 4.0, so let's do it now 😄
Initial PR https://github.com/getsentry/sentry-php/pull/1397.