### PR TITLE
Remove changelog entry for unreleased feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ The Sentry SDK team is happy to announce the immediate availability of Sentry PH
 
 ### Misc
 
-- Replace polyfill methods with PHP 7.2 equivalents. [(#1922)](https://github.com/getsentry/sentry-php/pull/1922)
 - Remove `symfony/phpunit-bridge` as a dev dependency. [(#1930)](https://github.com/getsentry/sentry-php/pull/1930)
 - Update `sentry.origin` to be consistent with other SDKs. [(#1938)](https://github.com/getsentry/sentry-php/pull/1938)
 


### PR DESCRIPTION
In #1941 we accidentally included #1922 which is not to be released until 5.x. This was a textual error. GitHub release notes has been fixed already.