### PR TITLE
ref: change doc to use `never` instead of `none`

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -1130,7 +1130,7 @@ final class Options
      *                                   captured. It can be set to one of the
      *                                   following values:
      *
-     *                                    - none: request bodies are never sent
+     *                                    - never: request bodies are never sent
      *                                    - small: only small request bodies will
      *                                      be captured where the cutoff for small
      *                                      depends on the SDK (typically 4KB)


### PR DESCRIPTION
Updates the doc block to use `never` instead of `none` to be consistent with the docs