### PR TITLE
fix: Only call curl_close() in PHP < 8

### DIFF
--- a/src/HttpClient/HttpClient.php
+++ b/src/HttpClient/HttpClient.php
@@ -106,7 +106,9 @@ class HttpClient implements HttpClientInterface
         if ($body === false) {
             $errorCode = curl_errno($curlHandle);
             $error = curl_error($curlHandle);
-            curl_close($curlHandle);
+            if (\PHP_MAJOR_VERSION < 8) {
+                curl_close($curlHandle);
+            }
 
             $message = 'cURL Error (' . $errorCode . ') ' . $error;
 
@@ -115,7 +117,9 @@ class HttpClient implements HttpClientInterface
 
         $statusCode = curl_getinfo($curlHandle, \CURLINFO_HTTP_CODE);
 
-        curl_close($curlHandle);
+        if (\PHP_MAJOR_VERSION < 8) {
+            curl_close($curlHandle);
+        }
 
         $error = $statusCode >= 400 ? $body : '';
 

--- a/src/Spotlight/SpotlightClient.php
+++ b/src/Spotlight/SpotlightClient.php
@@ -42,7 +42,9 @@ class SpotlightClient
         if ($body === false) {
             $errorCode = curl_errno($curlHandle);
             $error = curl_error($curlHandle);
-            curl_close($curlHandle);
+            if (\PHP_MAJOR_VERSION < 8) {
+                curl_close($curlHandle);
+            }
 
             $message = 'cURL Error (' . $errorCode . ') ' . $error;
 
@@ -51,7 +53,9 @@ class SpotlightClient
 
         $statusCode = curl_getinfo($curlHandle, \CURLINFO_HTTP_CODE);
 
-        curl_close($curlHandle);
+        if (\PHP_MAJOR_VERSION < 8) {
+            curl_close($curlHandle);
+        }
 
         return new Response($statusCode, [], '');
     }


### PR DESCRIPTION
### Description
`curl_close()` has had no effect since PHP 8.0 and is deprecated in PHP 8.5. This patch ensures that `curl_close()` is only called in PHP < 8

#### Issues
resolves: https://github.com/getsentry/sentry-php/issues/1946