### PR TITLE
feat: feature flags

### DIFF
--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -22,6 +22,13 @@ use Sentry\UserDataBag;
 class Scope
 {
     /**
+     * Maximum number of flags allowed. We only track the first flags set.
+     *
+     * @internal
+     */
+    public const MAX_FLAGS = 100;
+
+    /**
      * @var PropagationContext
      */
     private $propagationContext;
@@ -45,6 +52,11 @@ class Scope
      * @var array<string, string> The list of tags associated to this scope
      */
     private $tags = [];
+
+    /**
+     * @var array<int, array<string, bool>> The list of flags associated to this scope
+     */
+    private $flags = [];
 
     /**
      * @var array<string, mixed> A set of extra data associated to this scope
@@ -126,6 +138,35 @@ class Scope
     public function removeTag(string $key): self
     {
         unset($this->tags[$key]);
+
+        return $this;
+    }
+
+    /**
+     * Adds a feature flag to the scope.
+     *
+     * @return $this
+     */
+    public function addFeatureFlag(string $key, bool $result): self
+    {
+        // If the flag was already set, remove it first
+        // This basically mimics an LRU cache so that the most recently added flags are kept
+        foreach ($this->flags as $flagIndex => $flag) {
+            if (isset($flag[$key])) {
+                unset($this->flags[$flagIndex]);
+            }
+        }
+
+        // Keep only the most recent MAX_FLAGS flags
+        if (\count($this->flags) >= self::MAX_FLAGS) {
+            array_shift($this->flags);
+        }
+
+        $this->flags[] = [$key => $result];
+
+        if ($this->span !== null) {
+            $this->span->setFlag($key, $result);
+        }
 
         return $this;
     }
@@ -331,6 +372,7 @@ class Scope
         $this->fingerprint = [];
         $this->breadcrumbs = [];
         $this->tags = [];
+        $this->flags = [];
         $this->extra = [];
         $this->contexts = [];
 
@@ -357,6 +399,17 @@ class Scope
 
         if (!empty($this->tags)) {
             $event->setTags(array_merge($this->tags, $event->getTags()));
+        }
+
+        if (!empty($this->flags)) {
+            $event->setContext('flags', [
+                'values' => array_map(static function (array $flag) {
+                    return [
+                        'flag' => key($flag),
+                        'result' => current($flag),
+                    ];
+                }, $this->flags),
+            ]);
         }
 
         if (!empty($this->extra)) {

--- a/src/Tracing/Span.php
+++ b/src/Tracing/Span.php
@@ -23,6 +23,13 @@ use Sentry\State\Scope;
 class Span
 {
     /**
+     * Maximum number of flags allowed. We only track the first flags set.
+     *
+     * @internal
+     */
+    public const MAX_FLAGS = 10;
+
+    /**
      * @var SpanId Span ID
      */
     protected $spanId;
@@ -61,6 +68,11 @@ class Span
      * @var array<string, string> A List of tags associated to this span
      */
     protected $tags = [];
+
+    /**
+     * @var array<string, bool> A List of flags associated to this span
+     */
+    protected $flags = [];
 
     /**
      * @var array<string, mixed> An arbitrary mapping of additional metadata
@@ -329,6 +341,20 @@ class Span
     }
 
     /**
+     * Sets a feature flag associated to this span.
+     *
+     * @return $this
+     */
+    public function setFlag(string $key, bool $result)
+    {
+        if (\count($this->flags) < self::MAX_FLAGS) {
+            $this->flags[$key] = $result;
+        }
+
+        return $this;
+    }
+
+    /**
      * Gets the ID of the span.
      */
     public function getSpanId(): SpanId
@@ -369,7 +395,13 @@ class Span
     public function getData(?string $key = null, $default = null)
     {
         if ($key === null) {
-            return $this->data;
+            $data = $this->data;
+
+            foreach ($this->flags as $flagKey => $flagValue) {
+                $data["flag.evaluation.{$flagKey}"] = $flagValue;
+            }
+
+            return $data;
         }
 
         return $this->data[$key] ?? $default;

--- a/tests/State/ScopeTest.php
+++ b/tests/State/ScopeTest.php
@@ -12,6 +12,7 @@ use Sentry\Severity;
 use Sentry\State\Scope;
 use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\PropagationContext;
+use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanId;
 use Sentry\Tracing\TraceId;
@@ -75,6 +76,88 @@ final class ScopeTest extends TestCase
 
         $this->assertNotNull($event);
         $this->assertSame(['bar' => 'baz'], $event->getTags());
+    }
+
+    public function testSetFlag(): void
+    {
+        $scope = new Scope();
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertArrayNotHasKey('flags', $event->getContexts());
+
+        $scope->addFeatureFlag('foo', true);
+        $scope->addFeatureFlag('bar', false);
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertArrayHasKey('flags', $event->getContexts());
+        $this->assertEquals([
+            'values' => [
+                [
+                    'flag' => 'foo',
+                    'result' => true,
+                ],
+                [
+                    'flag' => 'bar',
+                    'result' => false,
+                ],
+            ],
+        ], $event->getContexts()['flags']);
+    }
+
+    public function testSetFlagLimit(): void
+    {
+        $scope = new Scope();
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertArrayNotHasKey('flags', $event->getContexts());
+
+        $expectedFlags = [];
+
+        foreach (range(1, Scope::MAX_FLAGS) as $i) {
+            $scope->addFeatureFlag("feature{$i}", true);
+
+            $expectedFlags[] = [
+                'flag' => "feature{$i}",
+                'result' => true,
+            ];
+        }
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertArrayHasKey('flags', $event->getContexts());
+        $this->assertEquals(['values' => $expectedFlags], $event->getContexts()['flags']);
+
+        array_shift($expectedFlags);
+
+        $scope->addFeatureFlag('should-not-be-discarded', true);
+
+        $expectedFlags[] = [
+            'flag' => 'should-not-be-discarded',
+            'result' => true,
+        ];
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertNotNull($event);
+        $this->assertArrayHasKey('flags', $event->getContexts());
+        $this->assertEquals(['values' => $expectedFlags], $event->getContexts()['flags']);
+    }
+
+    public function testSetFlagPropagatesToSpan(): void
+    {
+        $span = new Span();
+
+        $scope = new Scope();
+        $scope->setSpan($span);
+
+        $scope->addFeatureFlag('feature', true);
+
+        $this->assertSame(['flag.evaluation.feature' => true], $span->getData());
     }
 
     public function testSetAndRemoveContext(): void
@@ -364,6 +447,7 @@ final class ScopeTest extends TestCase
         $scope->setFingerprint(['foo']);
         $scope->setExtras(['foo' => 'bar']);
         $scope->setTags(['bar' => 'foo']);
+        $scope->addFeatureFlag('feature', true);
         $scope->setUser(UserDataBag::createFromUserIdentifier('unique_id'));
         $scope->clear();
 
@@ -376,6 +460,7 @@ final class ScopeTest extends TestCase
         $this->assertEmpty($event->getExtra());
         $this->assertEmpty($event->getTags());
         $this->assertEmpty($event->getUser());
+        $this->assertArrayNotHasKey('flags', $event->getContexts());
     }
 
     public function testApplyToEvent(): void
@@ -403,6 +488,7 @@ final class ScopeTest extends TestCase
         $scope->setUser($user);
         $scope->setContext('foocontext', ['foo' => 'bar']);
         $scope->setContext('barcontext', ['bar' => 'foo']);
+        $scope->addFeatureFlag('feature', true);
         $scope->setSpan($span);
 
         $this->assertSame($event, $scope->applyToEvent($event));
@@ -416,6 +502,14 @@ final class ScopeTest extends TestCase
             'foocontext' => [
                 'foo' => 'foo',
                 'bar' => 'bar',
+            ],
+            'flags' => [
+                'values' => [
+                    [
+                        'flag' => 'feature',
+                        'result' => true,
+                    ],
+                ],
             ],
             'trace' => [
                 'span_id' => '566e3688a61d4bc8',

--- a/tests/Tracing/SpanTest.php
+++ b/tests/Tracing/SpanTest.php
@@ -187,4 +187,34 @@ final class SpanTest extends TestCase
         $this->assertSame($context->getOrigin(), $span->getOrigin());
         $this->assertSame($context->getOrigin(), $span->getTraceContext()['origin']);
     }
+
+    public function testFlagIsRecorded(): void
+    {
+        $span = new Span();
+
+        $span->setFlag('feature', true);
+
+        $this->assertSame(['flag.evaluation.feature' => true], $span->getData());
+    }
+
+    public function testFlagLimitRecorded(): void
+    {
+        $span = new Span();
+
+        $expectedFlags = [
+            'flag.evaluation.should-not-be-discarded' => true,
+        ];
+
+        $span->setFlag('should-not-be-discarded', true);
+
+        foreach (range(1, Span::MAX_FLAGS - 1) as $i) {
+            $span->setFlag("feature{$i}", true);
+
+            $expectedFlags["flag.evaluation.feature{$i}"] = true;
+        }
+
+        $span->setFlag('should-be-discarded', true);
+
+        $this->assertSame($expectedFlags, $span->getData());
+    }
 }


### PR DESCRIPTION
This adds support for setting feature flag evaluations on the scope and spans. This is modeled after the Python SDK. Intended purpose is to allow us to integrate with [Laravel Pennant](https://laravel.com/docs/12.x/pennant).

See: 
- https://develop.sentry.dev/sdk/expected-features/#feature-flags
- https://develop.sentry.dev/sdk/data-model/event-payloads/contexts/#feature-flag-context
- https://github.com/getsentry/sentry-python/blob/3e86962e267e86f51e8483c77dc1ad116f316d1c/sentry_sdk/feature_flags.py