### PR TITLE
ref: add high level `flush` to flush all resources

### DIFF
--- a/src/SentrySdk.php
+++ b/src/SentrySdk.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry;
 
+use Sentry\Logs\Logs;
+use Sentry\Metrics\TraceMetrics;
 use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 
@@ -60,5 +62,21 @@ final class SentrySdk
         self::$currentHub = $hub;
 
         return $hub;
+    }
+
+    /**
+     * Flushes all buffered telemetry data.
+     *
+     * This is a convenience facade that forwards the flush operation to all
+     * internally managed components.
+     *
+     * Calling this method is equivalent to invoking `flush()` on each component
+     * individually. It does not change flushing behavior, improve performance,
+     * or reduce the number of network requests.
+     */
+    public static function flush(): void
+    {
+        Logs::getInstance()->flush();
+        TraceMetrics::getInstance()->flush();
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -396,3 +396,18 @@ function addFeatureFlag(string $name, bool $result): void
         $scope->addFeatureFlag($name, $result);
     });
 }
+
+/**
+ * Flushes all buffered telemetry data.
+ *
+ * This is a convenience facade that forwards the flush operation to all
+ * internally managed components.
+ *
+ * Calling this method is equivalent to invoking `flush()` on each component
+ * individually. It does not change flushing behavior, improve performance,
+ * or reduce the number of network requests.
+ */
+function flush(): void
+{
+    SentrySdk::flush();
+}


### PR DESCRIPTION
Adds a `flush` facade method that will call `flush` on individual aggregators or buffers.
If new buffers or aggregators are added, this flush method will be updated, meaning that it will no longer possible to forget to flush individual resources on the callers side if this method is used.

closes PHP-41