### PR TITLE
Add handling for 413 upstream response

### DIFF
--- a/src/Transport/ResultStatus.php
+++ b/src/Transport/ResultStatus.php
@@ -59,6 +59,15 @@ class ResultStatus implements \Stringable
 
     /**
      * Returns an instance of this enum representing the fact that the event
+     * failed to be sent because the content was too large.
+     */
+    public static function contentTooLarge(): self
+    {
+        return self::getInstance('CONTENT_TOO_LARGE');
+    }
+
+    /**
+     * Returns an instance of this enum representing the fact that the event
      * failed to be sent because of API rate limiting.
      */
     public static function rateLimit(): self
@@ -94,6 +103,8 @@ class ResultStatus implements \Stringable
         switch (true) {
             case $statusCode >= 200 && $statusCode < 300:
                 return self::success();
+            case $statusCode === 413:
+                return self::contentTooLarge();
             case $statusCode === 429:
                 return self::rateLimit();
             case $statusCode >= 400 && $statusCode < 500:

--- a/tests/Transport/HttpTransportTest.php
+++ b/tests/Transport/HttpTransportTest.php
@@ -114,6 +114,18 @@ final class HttpTransportTest extends TestCase
             ],
         ];
 
+        yield [
+            new Response(413, [], ''),
+            ResultStatus::contentTooLarge(),
+            false,
+            [
+                'info' => [
+                    'Sending event [%s] to %s [project:%s].',
+                    'Sent event [%s] to %s [project:%s]. Result: "content_too_large" (status: 413).',
+                ],
+            ],
+        ];
+
         ClockMock::withClockMock(1644105600);
 
         yield [


### PR DESCRIPTION
### Description

Handle 413 response and have a readable error message.

#### Issues

* resolves: #1998
* resolves: [PHP-63](https://linear.app/getsentry/issue/PHP-63/sdk-handling-http-413-php)