### PR TITLE
feat(logs): Add Monolog channel to compiled log attributes

### DIFF
--- a/src/Monolog/LogsHandler.php
+++ b/src/Monolog/LogsHandler.php
@@ -30,15 +30,22 @@ class LogsHandler implements HandlerInterface
     private $bubble;
 
     /**
+     * Whether to include the channel name as an attribute in the Sentry logs.
+     */
+    private bool $includeChannel;
+
+    /**
      * Creates a new Monolog handler that converts Monolog logs to Sentry logs.
      *
      * @param LogLevel|\Monolog\Level|int|null $logLevel the minimum logging level at which this handler will be triggered and collects the logs
      * @param bool                             $bubble   whether the messages that are handled can bubble up the stack or not
+     * @param bool                             $includeChannel whether to include the channel name as an attribute in the Sentry logs
      */
-    public function __construct($logLevel = null, bool $bubble = true)
+    public function __construct($logLevel = null, bool $bubble = true, bool $includeChannel = false)
     {
         $this->logLevel = $logLevel ?? LogLevel::debug();
         $this->bubble = $bubble;
+        $this->includeChannel = $includeChannel;
     }
 
     /**
@@ -137,6 +144,11 @@ class LogsHandler implements HandlerInterface
      */
     protected function compileAttributes($record): array
     {
-        return array_merge($record['context'], $record['extra'], ['sentry.origin' => 'auto.log.monolog']);
+        return array_merge(
+            $this->includeChannel ? ['channel' => $record['channel']] : [],
+            $record['context'],
+            $record['extra'],
+            ['sentry.origin' => 'auto.log.monolog']
+        );
     }
 }

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -135,6 +135,29 @@ final class LogsHandlerTest extends TestCase
         $this->assertSame('auto.log.monolog', $log->attributes()->toSimpleArray()['sentry.origin']);
     }
 
+    public function testChannelNotIncludedByDefault(): void
+    {
+        $handler = new LogsHandler();
+        $handler->handle(RecordFactory::create('without channel', Logger::WARNING, 'channel.foo', [], []));
+
+        $logs = Logs::getInstance()->aggregator()->all();
+        $this->assertCount(1, $logs);
+        $log = $logs[0];
+        $this->assertArrayNotHasKey('channel', $log->attributes()->toSimpleArray());
+    }
+
+    public function testChannelIncludedWhenEnabled(): void
+    {
+        $handler = new LogsHandler(LogLevel::warn(), true, true);
+        $handler->handle(RecordFactory::create('with channel', Logger::WARNING, 'channel.foo', [], []));
+
+        $logs = Logs::getInstance()->aggregator()->all();
+        $this->assertCount(1, $logs);
+        $log = $logs[0];
+        $this->assertArrayHasKey('channel', $log->attributes()->toSimpleArray());
+        $this->assertSame('channel.foo', $log->attributes()->toSimpleArray()['channel']);
+    }
+
     public function testOriginTagNotAppliedWhenUsingDirectly()
     {
         \Sentry\logger()->info('No origin attribute');


### PR DESCRIPTION
### Description
<!-- What changed and why? -->

Adds `channel` name to the log metadata. 

The channel is a relevant piece of metadata of a log entry. This change includes the channel in the recorded attributes, but remains backwards compatible and will not overwrite existing extra or context fields named 'channel'.

I considered making this an opt-in configuration of the Handler in the constructor, but since this is backwards compatible, I figured that's not necessary.
