### PR TITLE
chore: Update validate-pr action to latest version

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: getsentry/github-workflows/validate-pr@4243265ac9cc3ee5b89ad2b30c3797ac8483d63a
+      - uses: getsentry/github-workflows/validate-pr@4ff40ada546d4a31b852a4279828b989a6193497
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Updates the pinned SHA for the validate-pr composite action from
getsentry/github-workflows to pick up the bot allowlist fix
(getsentry/github-workflows#155).

Trusted bots (dependabot, renovate, github-actions, etc.) are now
exempt from issue reference validation and draft enforcement.

#skip-changelog

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>