### PR TITLE
ref: deprecate old sentry handler

### DIFF
--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -16,6 +16,9 @@ use Sentry\State\Scope;
  * This Monolog handler logs every message to a Sentry's server using the given
  * hub instance.
  *
+ * @deprecated since version 4.24. To be removed in version 5.0. Use {@see LogsHandler}
+ *             with the `enable_logs` SDK option instead.
+ *
  * @author Stefano Arlandini <sarlandini@alice.it>
  */
 final class Handler extends AbstractProcessingHandler


### PR DESCRIPTION
Adds a deprecation notice to the old Sentry `Handler` that is used to convert log messages into Sentry errors. The `Handler` existed in a time where Sentry had no native log support yet we still allowed to capture logs in some way.

Now that we have the `LogsHandler`, it is becoming increasingly confusing which one to use and what they are really doing, so we want to deprecate it for now and point everyone towards the new logs handler.