### PR TITLE
ref: add `ext-excimer` as composer suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "spiral/roadrunner-worker": "^3.6"
     },
     "suggest": {
+        "ext-excimer": "Enable profiling with the Excimer PHP extension.",
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "spiral/roadrunner-worker": "^3.6"
     },
     "suggest": {
-        "ext-excimer": "Enable profiling with the Excimer PHP extension.",
+        "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
     },
     "conflict": {


### PR DESCRIPTION
Adds `ext-excimer`  as suggestion to our `composer.json` file to make user aware that it's required for profiling without reading through the docs