### PR TITLE
ref(logs): use RingBuffer for logs when not using `log_flush_threshold`

### DIFF
--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -13,16 +13,19 @@ use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 use Sentry\Util\Arr;
 use Sentry\Util\Str;
+use Sentry\Util\TelemetryStorage;
 
 /**
  * @internal
  */
 final class LogsAggregator
 {
+    private const LOGS_BUFFER_SIZE = 1000;
+
     /**
-     * @var Log[]
+     * @var TelemetryStorage<Log>|null
      */
-    private $logs = [];
+    private $logs;
 
     /**
      * @param string                       $message    see sprintf for a description of format
@@ -155,25 +158,24 @@ final class LogsAggregator
             $sdkLogger->log($log->getPsrLevel(), "Logs item: {$log->getBody()}", $log->attributes()->toSimpleArray());
         }
 
-        $this->logs[] = $log;
-
         $logFlushThreshold = $options->getLogFlushThreshold();
+        $logs = $this->getStorage($logFlushThreshold);
 
-        if ($logFlushThreshold !== null && \count($this->logs) >= $logFlushThreshold) {
+        $logs->push($log);
+
+        if ($logFlushThreshold !== null && \count($logs) >= $logFlushThreshold) {
             $this->flush($hub);
         }
     }
 
     public function flush(?HubInterface $hub = null): ?EventId
     {
-        if (empty($this->logs)) {
+        if ($this->logs === null || $this->logs->isEmpty()) {
             return null;
         }
 
         $hub = $hub ?? SentrySdk::getCurrentHub();
-        $event = Event::createLogs()->setLogs($this->logs);
-
-        $this->logs = [];
+        $event = Event::createLogs()->setLogs($this->logs->drain());
 
         return $hub->captureEvent($event);
     }
@@ -183,7 +185,7 @@ final class LogsAggregator
      */
     public function all(): array
     {
-        return $this->logs;
+        return $this->logs !== null ? $this->logs->toArray() : [];
     }
 
     /**
@@ -222,5 +224,22 @@ final class LogsAggregator
 
         /** @var array{trace_id: string, parent_span_id: string|null} $traceData */
         return $traceData;
+    }
+
+    /**
+     * @return TelemetryStorage<Log>
+     */
+    private function getStorage(?int $logFlushThreshold = null): TelemetryStorage
+    {
+        if ($this->logs === null) {
+            /** @var TelemetryStorage<Log> $logs */
+            $logs = $logFlushThreshold !== null
+                ? TelemetryStorage::unbounded()
+                : TelemetryStorage::bounded(self::LOGS_BUFFER_SIZE);
+
+            $this->logs = $logs;
+        }
+
+        return $this->logs;
     }
 }

--- a/src/Util/TelemetryStorage.php
+++ b/src/Util/TelemetryStorage.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Util;
+
+/**
+ * Creates a new data container for Telemetry data such as Logs or Metrics.
+ * If a size parameter is passed, it will create a RingBuffer under the hood to restrict the number of
+ * items, if no size is used then it will be backed by a regular array.
+ *
+ * The TelemetryStorage operates under the same constraints as the RingBuffer, meaning that it's possible to
+ * add/remove from the front and the back, but it's not possible to remove from the middle or based on an offset.
+ * To do that, one has to either drain or convert it into an array (which will be basically free if unbounded)
+ *
+ * @template T
+ *
+ * @internal
+ */
+class TelemetryStorage implements \Countable
+{
+    /**
+     * @var T[]|RingBuffer<T>
+     */
+    private $data;
+
+    private function __construct(?int $size = null)
+    {
+        if ($size !== null) {
+            $this->data = new RingBuffer($size);
+        } else {
+            $this->data = [];
+        }
+    }
+
+    public function count(): int
+    {
+        return \count($this->data);
+    }
+
+    /**
+     * @param T $value
+     */
+    public function push($value): void
+    {
+        if ($this->data instanceof RingBuffer) {
+            $this->data->push($value);
+        } else {
+            $this->data[] = $value;
+        }
+    }
+
+    /**
+     * @return T[]
+     */
+    public function drain(): array
+    {
+        if ($this->data instanceof RingBuffer) {
+            return $this->data->drain();
+        }
+        $data = $this->data;
+        $this->data = [];
+
+        return $data;
+    }
+
+    /**
+     * @return T[]
+     */
+    public function toArray(): array
+    {
+        if ($this->data instanceof RingBuffer) {
+            return $this->data->toArray();
+        }
+
+        return $this->data;
+    }
+
+    public function isEmpty(): bool
+    {
+        if ($this->data instanceof RingBuffer) {
+            return $this->data->isEmpty();
+        }
+
+        return empty($this->data);
+    }
+
+    /**
+     * Creates a new TelemetryStorage that is not bounded in size. This version should only be used if there
+     * is another flushing signal available.
+     *
+     * @return self<T>
+     */
+    public static function unbounded(): self
+    {
+        return new self();
+    }
+
+    /**
+     * Creates a TelemetryStorage that has an upper bound of $size. It will drop the oldest items when new items
+     * are added while being at capacity.
+     *
+     * @return self<T>
+     */
+    public static function bounded(int $size): self
+    {
+        return new self($size);
+    }
+}

--- a/tests/Util/TelemetryStorageTest.php
+++ b/tests/Util/TelemetryStorageTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Util\TelemetryStorage;
+
+final class TelemetryStorageTest extends TestCase
+{
+    public function testUnboundedPushAndToArray(): void
+    {
+        $storage = TelemetryStorage::unbounded();
+        $storage->push('foo');
+        $storage->push('bar');
+
+        $result = $storage->toArray();
+        $this->assertSame(2, $storage->count());
+        $this->assertEquals(['foo', 'bar'], $result);
+    }
+
+    public function testUnboundedDrainClearsStorage(): void
+    {
+        $storage = TelemetryStorage::unbounded();
+        $storage->push('foo');
+        $storage->push('bar');
+
+        $this->assertSame(2, $storage->count());
+        $result = $storage->drain();
+        $this->assertTrue($storage->isEmpty());
+        $this->assertEquals(['foo', 'bar'], $result);
+    }
+
+    public function testUnboundedIsEmpty(): void
+    {
+        $storage = TelemetryStorage::unbounded();
+        $this->assertTrue($storage->isEmpty());
+
+        $storage->push('foo');
+
+        $this->assertFalse($storage->isEmpty());
+    }
+
+    public function testBoundedCapacityOverwritesOldestItems(): void
+    {
+        $storage = TelemetryStorage::bounded(2);
+        $storage->push('foo');
+        $storage->push('bar');
+        $storage->push('baz');
+
+        $this->assertSame(2, $storage->count());
+        $this->assertEquals(['bar', 'baz'], $storage->toArray());
+    }
+
+    public function testBoundedDrainReturnsLogicalOrderAndClearsStorage(): void
+    {
+        $storage = TelemetryStorage::bounded(2);
+        $storage->push('foo');
+        $storage->push('bar');
+        $storage->push('baz');
+
+        $this->assertSame(2, $storage->count());
+        $result = $storage->drain();
+        $this->assertTrue($storage->isEmpty());
+        $this->assertEquals(['bar', 'baz'], $result);
+    }
+
+    public function testBoundedCapacityOneKeepsLatestItem(): void
+    {
+        $storage = TelemetryStorage::bounded(1);
+        $storage->push('foo');
+        $storage->push('bar');
+
+        $this->assertCount(1, $storage);
+        $this->assertEquals(['bar'], $storage->toArray());
+    }
+}


### PR DESCRIPTION
This PR changes the storage for logs to a `RingBuffer` when `log_flush_threshold` is not set. This prevents unbounded memory growth and will rather drop old logs instead of adding potential to trigger OOM. It has a hard cap of 1000, which is reasonably high because envelopes with more than 1000 logs are likely to be above the envelope limit of 1MB which would be dropped by ingestion anyway.

The PR also introduces a `TelemetryStorage` class, which wraps the regular array and `RingBuffer` into a single storage class so that it can be reused by metrics and also to provide a simpler interface in the aggregators.

closes PHP-76