### PR TITLE
ref: add hint to excimer composer suggestion for PHP ZTS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "spiral/roadrunner-worker": "^3.6"
     },
     "suggest": {
-        "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
+        "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension. (Please use 1.2.3 for FrankenPHP or PHP ZTS)",
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
     },
     "conflict": {


### PR DESCRIPTION
Updates the suggestion text with a hint to use an older version for FrankenPHP or any PHP ZTS based runtime since the newest version does not produce any results anymore