### PR TITLE
docs: remove excimer hint in composer suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "spiral/roadrunner-worker": "^3.6"
     },
     "suggest": {
-        "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension. (Please use 1.2.3 for FrankenPHP or PHP ZTS)",
+        "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
     },
     "conflict": {


### PR DESCRIPTION
Removes the hint since it was fixed upstream with version `1.2.6`