### PR TITLE
fix(pii): remove guards from aggregators

### DIFF
--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -90,22 +90,20 @@ final class LogsAggregator
             $log->setAttribute('sentry.sdk.version', $client->getSdkVersion());
         }
 
-        if ($options->shouldSendDefaultPii()) {
-            $hub->configureScope(static function (Scope $scope) use ($log) {
-                $user = $scope->getUser();
-                if ($user !== null) {
-                    if ($user->getId() !== null) {
-                        $log->setAttribute('user.id', $user->getId());
-                    }
-                    if ($user->getEmail() !== null) {
-                        $log->setAttribute('user.email', $user->getEmail());
-                    }
-                    if ($user->getUsername() !== null) {
-                        $log->setAttribute('user.name', $user->getUsername());
-                    }
+        $hub->configureScope(static function (Scope $scope) use ($log) {
+            $user = $scope->getUser();
+            if ($user !== null) {
+                if ($user->getId() !== null) {
+                    $log->setAttribute('user.id', $user->getId());
                 }
-            });
-        }
+                if ($user->getEmail() !== null) {
+                    $log->setAttribute('user.email', $user->getEmail());
+                }
+                if ($user->getUsername() !== null) {
+                    $log->setAttribute('user.name', $user->getUsername());
+                }
+            }
+        });
 
         if (\count($values)) {
             $log->setAttribute('sentry.message.template', $message);

--- a/src/Metrics/MetricsAggregator.php
+++ b/src/Metrics/MetricsAggregator.php
@@ -81,22 +81,20 @@ final class MetricsAggregator
                 $defaultAttributes['sentry.sdk.version'] = $client->getSdkVersion();
             }
 
-            if ($options->shouldSendDefaultPii()) {
-                $hub->configureScope(static function (Scope $scope) use (&$defaultAttributes) {
-                    $user = $scope->getUser();
-                    if ($user !== null) {
-                        if ($user->getId() !== null) {
-                            $defaultAttributes['user.id'] = $user->getId();
-                        }
-                        if ($user->getEmail() !== null) {
-                            $defaultAttributes['user.email'] = $user->getEmail();
-                        }
-                        if ($user->getUsername() !== null) {
-                            $defaultAttributes['user.name'] = $user->getUsername();
-                        }
+            $hub->configureScope(static function (Scope $scope) use (&$defaultAttributes) {
+                $user = $scope->getUser();
+                if ($user !== null) {
+                    if ($user->getId() !== null) {
+                        $defaultAttributes['user.id'] = $user->getId();
                     }
-                });
-            }
+                    if ($user->getEmail() !== null) {
+                        $defaultAttributes['user.email'] = $user->getEmail();
+                    }
+                    if ($user->getUsername() !== null) {
+                        $defaultAttributes['user.name'] = $user->getUsername();
+                    }
+                }
+            });
 
             $release = $options->getRelease();
             if ($release !== null) {

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -211,7 +211,7 @@ final class LogsAggregatorTest extends TestCase
         $this->assertSame('my_user', $attributes->get('user.name')->getValue());
     }
 
-    public function testUserAttributesAreNotAddedToLogMessageWhenSendDefaultPiiIsDisabled(): void
+    public function testUserAttributesCanBeSetManuallyWithDefaultPiiOff(): void
     {
         $client = ClientBuilder::create([
             'enable_logs' => true,
@@ -237,9 +237,9 @@ final class LogsAggregatorTest extends TestCase
 
         $attributes = $logs[0]->attributes();
 
-        $this->assertNull($attributes->get('user.id'));
-        $this->assertNull($attributes->get('user.email'));
-        $this->assertNull($attributes->get('user.name'));
+        $this->assertSame('unique_id', $attributes->get('user.id')->getValue());
+        $this->assertSame('foo@example.com', $attributes->get('user.email')->getValue());
+        $this->assertSame('my_user', $attributes->get('user.name')->getValue());
     }
 
     public function testFlushesImmediatelyWhenThresholdIsReached(): void


### PR DESCRIPTION
Removes the PII guards from aggregators. The reason for that is that the flag should be used to prevent _automatic_ pii collection. So if someone sets user information manually, they should still reach Sentry even though `send_default_pii` is disasbled.

The current code in the aggregators removed all user data, even if explicitly set by a user