### PR TITLE
ref: add CodeLocationResolver

### DIFF
--- a/analysis-baseline.toml
+++ b/analysis-baseline.toml
@@ -439,18 +439,6 @@ message = "Unreachable else clause"
 count = 1
 
 [[issues]]
-file = "src/Integration/ModulesIntegration.php"
-code = "no-value"
-message = "Argument #1 passed to function `array_keys` has type `never`, meaning it cannot produce a value."
-count = 1
-
-[[issues]]
-file = "src/Integration/ModulesIntegration.php"
-code = "non-existent-class-like"
-message = 'Class, interface, enum, or trait `PackageVersions\Versions` not found.'
-count = 1
-
-[[issues]]
 file = "src/Integration/RequestIntegration.php"
 code = "invalid-property-assignment-value"
 message = "Invalid type for property `$options`: expected `array{'pii_sanitize_headers': array<array-key, string>}`, but got `array<array-key, mixed>`."

--- a/mago.toml
+++ b/mago.toml
@@ -5,6 +5,7 @@ excludes = [
     "tests/resources/**",
     "tests/Fixtures/**",
     "src/Util/ClockMock.php",
+    "vendor/open-telemetry/gen-otlp-protobuf/GPBMetadata/**",
 ]
 
 [analyzer]

--- a/src/CodeLocationResolver.php
+++ b/src/CodeLocationResolver.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry;
+
+use Sentry\Serializer\RepresentationSerializerInterface;
+
+/**
+ * Resolves code location metadata from backtraces.
+ *
+ * @internal
+ *
+ * @phpstan-import-type StacktraceFrame from FrameBuilder
+ */
+final class CodeLocationResolver
+{
+    /**
+     * @var FrameBuilder An instance of the builder of {@see Frame} objects
+     */
+    private $frameBuilder;
+
+    /**
+     * Constructor.
+     *
+     * @param Options                           $options                  The SDK client options
+     * @param RepresentationSerializerInterface $representationSerializer The representation serializer
+     */
+    public function __construct(Options $options, RepresentationSerializerInterface $representationSerializer)
+    {
+        $this->frameBuilder = new FrameBuilder($options, $representationSerializer);
+    }
+
+    /**
+     * Resolves the first in-app frame from the current backtrace into code
+     * location metadata.
+     *
+     * @return array{'code.filepath': string, 'code.function': string|null, 'code.lineno': int}|null
+     */
+    public function resolve(int $limit = 20): ?array
+    {
+        /** @var list<StacktraceFrame> $backtrace */
+        $backtrace = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS, $limit);
+
+        return $this->resolveFromBacktrace($backtrace);
+    }
+
+    /**
+     * Resolves the first in-app frame from a backtrace into code location metadata.
+     *
+     * @param array<int, array<string, mixed>> $backtrace The backtrace
+     *
+     * @phpstan-param list<StacktraceFrame> $backtrace
+     *
+     * @return array{'code.filepath': string, 'code.function': string|null, 'code.lineno': int}|null
+     */
+    public function resolveFromBacktrace(array $backtrace): ?array
+    {
+        $frame = $this->findFirstInAppFrameForBacktrace($backtrace);
+
+        if ($frame === null) {
+            return null;
+        }
+
+        return $this->getCodeLocationForFrame($frame);
+    }
+
+    /**
+     * Find the first in-app frame for a given backtrace.
+     *
+     * @param array<int, array<string, mixed>> $backtrace The backtrace
+     *
+     * @phpstan-param list<StacktraceFrame> $backtrace
+     */
+    public function findFirstInAppFrameForBacktrace(array $backtrace): ?Frame
+    {
+        $file = Frame::INTERNAL_FRAME_FILENAME;
+        $line = 0;
+
+        foreach ($backtrace as $backtraceFrame) {
+            $frame = $this->frameBuilder->buildFromBacktraceFrame($file, $line, $backtraceFrame);
+
+            if ($frame->isInApp()) {
+                return $frame;
+            }
+
+            $file = $backtraceFrame['file'] ?? Frame::INTERNAL_FRAME_FILENAME;
+            $line = $backtraceFrame['line'] ?? 0;
+        }
+
+        return null;
+    }
+
+    /**
+     * Converts a frame into code location metadata.
+     *
+     * @return array{'code.filepath': string, 'code.function': string|null, 'code.lineno': int}
+     */
+    public function getCodeLocationForFrame(Frame $frame): array
+    {
+        return [
+            'code.filepath' => $frame->getFile(),
+            'code.function' => $frame->getFunctionName(),
+            'code.lineno' => $frame->getLine(),
+        ];
+    }
+}

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -6,7 +6,6 @@ namespace Sentry\Integration;
 
 use Composer\InstalledVersions;
 use Jean85\PrettyVersions;
-use PackageVersions\Versions;
 use Sentry\Event;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
@@ -67,12 +66,19 @@ final class ModulesIntegration implements IntegrationInterface
             return InstalledVersions::getInstalledPackages();
         }
 
-        if (class_exists(Versions::class)) {
-            // BC layer for Composer 1, using a transient dependency
-            /** @var string[] $packages */
-            $packages = array_keys(Versions::VERSIONS);
+        $versionsClass = 'PackageVersions\\Versions';
 
-            return $packages;
+        if (class_exists($versionsClass)) {
+            // BC layer for Composer 1, using a transient dependency
+            /** @var mixed $versions */
+            $versions = \constant($versionsClass . '::VERSIONS');
+
+            if (\is_array($versions)) {
+                /** @var string[] $packages */
+                $packages = array_keys($versions);
+
+                return $packages;
+            }
         }
 
         // this should not happen

--- a/src/Util/CodeLocationResolver.php
+++ b/src/Util/CodeLocationResolver.php
@@ -2,8 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Sentry;
+namespace Sentry\Util;
 
+use Sentry\Frame;
+use Sentry\FrameBuilder;
+use Sentry\Options;
 use Sentry\Serializer\RepresentationSerializerInterface;
 
 /**

--- a/tests/CodeLocationResolverTest.php
+++ b/tests/CodeLocationResolverTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\CodeLocationResolver;
+use Sentry\Frame;
+use Sentry\Options;
+use Sentry\Serializer\RepresentationSerializer;
+
+final class CodeLocationResolverTest extends TestCase
+{
+    public function testFindFirstInAppFrameForBacktrace(): void
+    {
+        $expectedLine = 123;
+        $resolver = $this->createResolver([
+            'prefixes' => [],
+        ]);
+
+        $frame = $resolver->findFirstInAppFrameForBacktrace($this->createQueryBacktrace($expectedLine));
+
+        $this->assertNotNull($frame);
+        $this->assertSame(__FILE__, $frame->getFile());
+        $this->assertSame($expectedLine, $frame->getLine());
+        $this->assertSame('App\\Repository\\UserRepository::findActiveUsers', $frame->getFunctionName());
+    }
+
+    public function testResolveFromBacktraceReturnsCodeLocationMetadata(): void
+    {
+        $expectedLine = 321;
+        $resolver = $this->createResolver([
+            'prefixes' => [\dirname(__DIR__)],
+        ]);
+
+        $location = $resolver->resolveFromBacktrace($this->createQueryBacktrace($expectedLine));
+
+        $this->assertNotNull($location);
+        $this->assertSame('/tests/CodeLocationResolverTest.php', $location['code.filepath']);
+        $this->assertSame('App\\Repository\\UserRepository::findActiveUsers', $location['code.function']);
+        $this->assertSame($expectedLine, $location['code.lineno']);
+    }
+
+    public function testResolveFromBacktraceReturnsNullWithoutInAppFrame(): void
+    {
+        $resolver = $this->createResolver();
+
+        $location = $resolver->resolveFromBacktrace([
+            [
+                'file' => Frame::INTERNAL_FRAME_FILENAME,
+                'line' => 0,
+                'function' => 'internal',
+            ],
+            [
+                'class' => 'Doctrine\\DBAL\\Connection',
+                'function' => 'executeQuery',
+            ],
+        ]);
+
+        $this->assertNull($location);
+    }
+
+    private function createResolver(array $options = []): CodeLocationResolver
+    {
+        $options = new Options($options);
+
+        return new CodeLocationResolver($options, new RepresentationSerializer($options));
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function createQueryBacktrace(int $line): array
+    {
+        return [
+            [
+                'file' => Frame::INTERNAL_FRAME_FILENAME,
+                'line' => 0,
+                'function' => 'internal',
+            ],
+            [
+                'file' => __FILE__,
+                'line' => $line,
+                'class' => 'Doctrine\\DBAL\\Connection',
+                'function' => 'executeQuery',
+            ],
+            [
+                'class' => 'App\\Repository\\UserRepository',
+                'function' => 'findActiveUsers',
+            ],
+        ];
+    }
+}

--- a/tests/CodeLocationResolverTest.php
+++ b/tests/CodeLocationResolverTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Sentry\CodeLocationResolver;
 use Sentry\Frame;
 use Sentry\Options;
 use Sentry\Serializer\RepresentationSerializer;
+use Sentry\Util\CodeLocationResolver;
 
 final class CodeLocationResolverTest extends TestCase
 {

--- a/tests/CodeLocationResolverTest.php
+++ b/tests/CodeLocationResolverTest.php
@@ -37,7 +37,7 @@ final class CodeLocationResolverTest extends TestCase
         $location = $resolver->resolveFromBacktrace($this->createQueryBacktrace($expectedLine));
 
         $this->assertNotNull($location);
-        $this->assertSame('/tests/CodeLocationResolverTest.php', $location['code.filepath']);
+        $this->assertSame(\DIRECTORY_SEPARATOR . 'tests' . \DIRECTORY_SEPARATOR . 'CodeLocationResolverTest.php', $location['code.filepath']);
         $this->assertSame('App\\Repository\\UserRepository::findActiveUsers', $location['code.function']);
         $this->assertSame($expectedLine, $location['code.lineno']);
     }


### PR DESCRIPTION
Adds `CodeLocationResolver` into the PHP SDK so that it can be used by the depending SDKs. Currently SQL code location is only available in Laravel and moving this class here makes it available for Symfony too without having to duplicate code.

The code is mostly extracted from https://github.com/getsentry/sentry-laravel/blob/54cb822e74ffbc9a6475cfc0ba1ef677b12d0f0f/src/Sentry/Laravel/Tracing/BacktraceHelper.php#L14 and the Laravel part will be replaced by this in the future