### PR TITLE
ci: pin mago and generate baseline to prevent random failures

### DIFF
--- a/analysis-baseline.toml
+++ b/analysis-baseline.toml
@@ -20,26 +20,8 @@ count = 1
 
 [[issues]]
 file = "src/Client.php"
-code = "possible-method-access-on-null"
-message = "Attempting to call a method on `null`."
-count = 2
-
-[[issues]]
-file = "src/Client.php"
 code = "possibly-invalid-argument"
 message = '''Possible argument type mismatch for argument #1 of `Sentry\StacktraceBuilder::buildFromBacktrace`: expected `list<array{'args'?: array<array-key, mixed>, 'class'?: class-string, 'file'?: string, 'function'?: string, 'line'?: int, 'type'?: string}>`, but possibly received `array<array-key, mixed>`.'''
-count = 1
-
-[[issues]]
-file = "src/Client.php"
-code = "possibly-null-argument"
-message = 'Argument #1 of method `Sentry\ExceptionDataBag::__construct` is possibly `null`, but parameter type `Throwable` does not accept it.'
-count = 1
-
-[[issues]]
-file = "src/Client.php"
-code = "possibly-null-argument"
-message = 'Argument #1 of method `Sentry\StacktraceBuilder::buildFromException` is possibly `null`, but parameter type `Throwable` does not accept it.'
 count = 1
 
 [[issues]]
@@ -337,8 +319,6 @@ message = "Redundant `<` comparison: left-hand side is never less than right-han
 count = 2
 
 [[issues]]
-# false positive: function curl_share_init_persistent(array $share_options): CurlSharePersistentHandle
-# https://www.php.net/manual/en/function.curl-share-init-persistent.php
 file = "src/HttpClient/HttpClient.php"
 code = "too-many-arguments"
 message = "Too many arguments provided for function `curl_share_init_persistent`."
@@ -1079,7 +1059,7 @@ count = 1
 [[issues]]
 file = "src/Profiling/Profile.php"
 code = "invalid-return-statement"
-message = '''Invalid return type for function `Sentry\Profiling\Profile::getFormattedData`: expected `array{'device': array{'architecture': string}, 'environment': string, 'event_id': string, 'os': array{'build_number': string, 'name': string, 'version': string}, 'platform': string, 'profile': array{'frames': array<int, array{'abs_path': string, 'filename': string, 'function': string, 'lineno': int|null, 'module': null|string}>, 'samples': array<int, array{'elapsed_since_start_ns': int, 'stack_id': int, 'thread_id': string}>, 'stacks': array<int, array<int, int>>}, 'release': string, 'runtime': array{'name': string, 'version': string}, 'timestamp': string, 'transaction': array{'active_thread_id': string, 'id': string, 'name': string, 'trace_id': string}, 'version': string}|null`, but found `array{'device': array{'architecture': null|string}, 'environment': string, 'event_id': string, 'os': array{'build_number': string, 'name': string, 'version': null|string}, 'platform': string('php'), 'profile': array{'frames': array{}|list<array{'abs_path': string, 'filename': string, 'function': string, 'lineno': int, 'module': null|string}>, 'samples': array{}|non-empty-list<array{'elapsed_since_start_ns': int, 'stack_id': non-negative-int, 'thread_id': string}>, 'stacks': list<array<array-key, mixed>>}, 'release': string, 'runtime': array{'name': string, 'sapi': null|string, 'version': null|string}, 'timestamp': string, 'transaction': array{'active_thread_id': string, 'id': string, 'name': null|string, 'trace_id': null|string}, 'version': string}`.'''
+message = '''Invalid return type for function `Sentry\Profiling\Profile::getFormattedData`: expected `array{'device': array{'architecture': string}, 'environment': string, 'event_id': string, 'os': array{'build_number': string, 'name': string, 'version': string}, 'platform': string, 'profile': array{'frames': array<int, array{'abs_path': string, 'filename': string, 'function': string, 'lineno': int|null, 'module': null|string}>, 'samples': array<int, array{'elapsed_since_start_ns': int, 'stack_id': int, 'thread_id': string}>, 'stacks': array<int, array<int, int>>}, 'release': string, 'runtime': array{'name': string, 'version': string}, 'timestamp': string, 'transaction': array{'active_thread_id': string, 'id': string, 'name': string, 'trace_id': string}, 'version': string}|null`, but found `array{'device': array{'architecture': null|string}, 'environment': string, 'event_id': string, 'os': array{'build_number': string, 'name': string, 'version': null|string}, 'platform': string('php'), 'profile': array{'frames': array{}|list<array{'abs_path': string, 'filename': string, 'function': string, 'lineno': int, 'module': null|string}>, 'samples': array{}|non-empty-list<array{'elapsed_since_start_ns': int, 'stack_id': non-negative-int, 'thread_id': string}>, 'stacks': list<array<array-key, mixed>>}, 'release': string, 'runtime': array{'name': string, 'sapi': null|string, 'version': null|string}, 'timestamp': non-empty-string, 'transaction': array{'active_thread_id': string, 'id': string, 'name': null|string, 'trace_id': null|string}, 'version': string}`.'''
 count = 1
 
 [[issues]]

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "carthage-software/mago": "^1.13.3",
+        "carthage-software/mago": "^1.30.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "guzzlehttp/promises": "^2.0.3",
         "monolog/monolog": "^1.6|^2.0|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "carthage-software/mago": "^1.30.0",
+        "carthage-software/mago": "1.30.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "guzzlehttp/promises": "^2.0.3",
         "monolog/monolog": "^1.6|^2.0|^3.0",


### PR DESCRIPTION
Pins `carthage-software/mago` to the newest version and updates the baseline. The reason for this change is that once a new version is released, it might introduce new failures to the CI job. While it's generally good to discover new potential issues, it's annoying if it happens in the middle of completely different changes.