### PR TITLE
feat(tracer): add support for the tracing extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
     },
     "suggest": {
         "ext-excimer": "Enable Sentry profiling with the Excimer PHP extension.",
+        "ext-sentry": "Enable automatic function and method tracing with the Sentry PHP tracer extension.",
         "monolog/monolog": "Allow sending log messages to Sentry by using the included Monolog handler."
     },
     "conflict": {

--- a/src/Integration/FunctionTracingIntegration.php
+++ b/src/Integration/FunctionTracingIntegration.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Integration;
+
+use Sentry\Tracing\FunctionTracingCallbacks;
+
+/**
+ * Registers the Sentry PHP tracer extension callbacks.
+ */
+final class FunctionTracingIntegration implements IntegrationInterface
+{
+    public function setupOnce(): void
+    {
+        if (!\function_exists('Sentry\\setStartCallback') || !\function_exists('Sentry\\setEndCallback')) {
+            return;
+        }
+
+        \call_user_func('Sentry\\setStartCallback', [FunctionTracingCallbacks::class, 'handleStart']);
+        \call_user_func('Sentry\\setEndCallback', [FunctionTracingCallbacks::class, 'handleEnd']);
+    }
+}

--- a/src/Integration/IntegrationRegistry.php
+++ b/src/Integration/IntegrationRegistry.php
@@ -147,6 +147,10 @@ final class IntegrationRegistry
             new ModulesIntegration(),
         ];
 
+        if (\function_exists('Sentry\\setStartCallback') && \function_exists('Sentry\\setEndCallback')) {
+            $integrations[] = new FunctionTracingIntegration();
+        }
+
         if ($options->getDsn() !== null || $options->isSpotlightEnabled()) {
             array_unshift($integrations, new ExceptionListenerIntegration(), new ErrorListenerIntegration(), new FatalErrorListenerIntegration());
         }

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -64,6 +64,7 @@ final class FunctionTracingCallbacks
      */
     private static function createSpanContext(array $data): SpanContext
     {
+        /** @var array<string, mixed> $metadata */
         $metadata = $data['metadata'];
         $description = self::extractAndUnset($metadata, 'description');
         if ($description === null) {

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -89,7 +89,7 @@ final class FunctionTracingCallbacks
      * Attempts to extract the value using the specified key and unsets it from
      * the source array.
      * It will only perform extraction if the value is a string or can be converted
-     * to a string (using __toString).
+     * to a string using __toString.
      *
      * @param array<string, mixed> $data
      *
@@ -98,16 +98,12 @@ final class FunctionTracingCallbacks
     private static function extractAndUnset(array &$data, string $key): ?string
     {
         if (isset($data[$key])) {
-            /** @var object|string $value */
+            /** @var mixed|null $value */
             $value = $data[$key];
             if (\is_string($value)) {
                 unset($data[$key]);
 
                 return $value;
-            } elseif (method_exists($value, '__toString')) {
-                unset($data[$key]);
-
-                return (string) $value;
             }
         }
 

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -64,14 +64,15 @@ final class FunctionTracingCallbacks
      */
     private static function createSpanContext(array $data): SpanContext
     {
-        $description = self::extractAndUnset($data, 'description');
+        $metadata = $data['metadata'];
+        $description = self::extractAndUnset($metadata, 'description');
         if ($description === null) {
             /** @var string $name */
             $name = $data['name'];
             $description = $name;
         }
-        $op = self::extractAndUnset($data, 'op') ?? 'function';
-        $origin = self::extractAndUnset($data, 'origin') ?? 'auto.php.tracer';
+        $op = self::extractAndUnset($metadata, 'op') ?? 'function';
+        $origin = self::extractAndUnset($metadata, 'origin') ?? 'auto.php.tracer';
         /** @var float $startTime */
         $startTime = $data['start_time'];
 
@@ -79,7 +80,7 @@ final class FunctionTracingCallbacks
             ->setDescription($description)
             ->setOp($op)
             ->setOrigin($origin)
-            ->setData($data)
+            ->setData($metadata)
             ->setStartTimestamp($startTime);
     }
 

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tracing;
+
+use Sentry\Integration\FunctionTracingIntegration;
+use Sentry\SentrySdk;
+
+/**
+ * @internal
+ */
+final class FunctionTracingCallbacks
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @return array{Span, Span}|null
+     */
+    public static function handleStart(array $data): ?array
+    {
+        $hub = SentrySdk::getCurrentHub();
+
+        if (!$hub->getIntegration(FunctionTracingIntegration::class) instanceof FunctionTracingIntegration) {
+            return null;
+        }
+
+        $parentSpan = $hub->getSpan();
+        if ($parentSpan === null || $parentSpan->getSampled() !== true) {
+            return null;
+        }
+
+        if (!isset($data['name']) || !\is_string($data['name'])) {
+            return null;
+        }
+
+        $context = self::createSpanContext($data['name'], $data);
+        $childSpan = $parentSpan->startChild($context);
+
+        $hub->setSpan($childSpan);
+
+        return [$childSpan, $parentSpan];
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     * @param mixed                $callbackState
+     */
+    public static function handleEnd(array $data, $callbackState = null): void
+    {
+        if (!\is_array($callbackState)
+            || !\array_key_exists(0, $callbackState)
+            || !\array_key_exists(1, $callbackState)
+            || !$callbackState[0] instanceof Span
+            || !$callbackState[1] instanceof Span
+        ) {
+            return;
+        }
+
+        if (!isset($data['end_time']) || (!\is_int($data['end_time']) && !\is_float($data['end_time']))) {
+            return;
+        }
+
+        $callbackState[0]->finish((float) $data['end_time']);
+        SentrySdk::getCurrentHub()->setSpan($callbackState[1]);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function createSpanContext(string $name, array $data): SpanContext
+    {
+        $metadata = [];
+        if (isset($data['metadata']) && \is_array($data['metadata'])) {
+            foreach (array_keys($data['metadata']) as $key) {
+                if (\is_string($key)) {
+                    $metadata[$key] = $data['metadata'][$key];
+                }
+            }
+        }
+
+        $description = $name;
+        $op = 'function';
+        $origin = 'auto.function.sentry_php_tracer';
+
+        if (isset($metadata['sentry.description']) && \is_string($metadata['sentry.description'])) {
+            $description = $metadata['sentry.description'];
+            unset($metadata['sentry.description']);
+        }
+
+        if (isset($metadata['sentry.op']) && \is_string($metadata['sentry.op'])) {
+            $op = $metadata['sentry.op'];
+            unset($metadata['sentry.op']);
+        }
+
+        if (isset($metadata['sentry.origin']) && \is_string($metadata['sentry.origin'])) {
+            $origin = $metadata['sentry.origin'];
+            unset($metadata['sentry.origin']);
+        }
+
+        $context = SpanContext::make()
+            ->setDescription($description)
+            ->setOp($op)
+            ->setOrigin($origin)
+            ->setData($metadata);
+
+        if (isset($data['start_time']) && (\is_int($data['start_time']) || \is_float($data['start_time']))) {
+            $context->setStartTimestamp((float) $data['start_time']);
+        }
+
+        return $context;
+    }
+}

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -79,17 +79,21 @@ final class FunctionTracingCallbacks
      *
      * @return null on failed extraction
      */
-    private static function extractAndUnset(&$data, string $key): ?string {
+    private static function extractAndUnset(&$data, string $key): ?string
+    {
         if (isset($data[$key])) {
             $value = $data[$key];
             if (\is_string($value)) {
                 unset($data[$key]);
+
                 return $value;
-            } else if (method_exists($value, '__toString')) {
+            } elseif (method_exists($value, '__toString')) {
                 unset($data[$key]);
+
                 return (string) $value;
             }
         }
+
         return null;
     }
 }

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -50,7 +50,12 @@ final class FunctionTracingCallbacks
             return;
         }
 
-        $callbackState->getCurrentSpan()->finish($data['end_time']);
+        /**
+         * @var float $endTime
+         */
+        $endTime = $data['end_time'];
+
+        $callbackState->getCurrentSpan()->finish($endTime);
         SentrySdk::getCurrentHub()->setSpan($callbackState->getParentSpan());
     }
 
@@ -59,16 +64,23 @@ final class FunctionTracingCallbacks
      */
     private static function createSpanContext(array $data): SpanContext
     {
-        $description = self::extractAndUnset($data, 'description') ?? $data['name'] ?? null;
+        $description = self::extractAndUnset($data, 'description');
+        if ($description === null) {
+            /** @var string $name */
+            $name = $data['name'];
+            $description = $name;
+        }
         $op = self::extractAndUnset($data, 'op') ?? 'function';
         $origin = self::extractAndUnset($data, 'origin') ?? 'auto.php.tracer';
+        /** @var float $startTime */
+        $startTime = $data['start_time'];
 
         return SpanContext::make()
             ->setDescription($description)
             ->setOp($op)
             ->setOrigin($origin)
             ->setData($data)
-            ->setStartTimestamp($data['start_time']);
+            ->setStartTimestamp($startTime);
     }
 
     /**
@@ -77,11 +89,14 @@ final class FunctionTracingCallbacks
      * It will only perform extraction if the value is a string or can be converted
      * to a string (using __toString).
      *
-     * @return null on failed extraction
+     * @param array<string, mixed> $data
+     *
+     * @return string|null Returns null on failed extraction
      */
-    private static function extractAndUnset(&$data, string $key): ?string
+    private static function extractAndUnset(array &$data, string $key): ?string
     {
         if (isset($data[$key])) {
+            /** @var object|string $value */
             $value = $data[$key];
             if (\is_string($value)) {
                 unset($data[$key]);

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -18,10 +18,8 @@ final class FunctionTracingCallbacks
 
     /**
      * @param array<string, mixed> $data
-     *
-     * @return array{Span, Span}|null
      */
-    public static function handleStart(array $data): ?array
+    public static function handleStart(array $data): ?FunctionTracingState
     {
         $hub = SentrySdk::getCurrentHub();
 
@@ -34,16 +32,12 @@ final class FunctionTracingCallbacks
             return null;
         }
 
-        if (!isset($data['name']) || !\is_string($data['name'])) {
-            return null;
-        }
-
-        $context = self::createSpanContext($data['name'], $data);
+        $context = self::createSpanContext($data);
         $childSpan = $parentSpan->startChild($context);
 
         $hub->setSpan($childSpan);
 
-        return [$childSpan, $parentSpan];
+        return new FunctionTracingState($parentSpan, $childSpan);
     }
 
     /**
@@ -52,66 +46,50 @@ final class FunctionTracingCallbacks
      */
     public static function handleEnd(array $data, $callbackState = null): void
     {
-        if (!\is_array($callbackState)
-            || !\array_key_exists(0, $callbackState)
-            || !\array_key_exists(1, $callbackState)
-            || !$callbackState[0] instanceof Span
-            || !$callbackState[1] instanceof Span
-        ) {
+        if (!$callbackState instanceof FunctionTracingState) {
             return;
         }
 
-        if (!isset($data['end_time']) || (!\is_int($data['end_time']) && !\is_float($data['end_time']))) {
-            return;
-        }
-
-        $callbackState[0]->finish((float) $data['end_time']);
-        SentrySdk::getCurrentHub()->setSpan($callbackState[1]);
+        $callbackState->getCurrentSpan()->finish($data['end_time']);
+        SentrySdk::getCurrentHub()->setSpan($callbackState->getParentSpan());
     }
 
     /**
      * @param array<string, mixed> $data
      */
-    private static function createSpanContext(string $name, array $data): SpanContext
+    private static function createSpanContext(array $data): SpanContext
     {
-        $metadata = [];
-        if (isset($data['metadata']) && \is_array($data['metadata'])) {
-            foreach (array_keys($data['metadata']) as $key) {
-                if (\is_string($key)) {
-                    $metadata[$key] = $data['metadata'][$key];
-                }
-            }
-        }
+        $description = self::extractAndUnset($data, 'description') ?? $data['name'] ?? null;
+        $op = self::extractAndUnset($data, 'op') ?? 'function';
+        $origin = self::extractAndUnset($data, 'origin') ?? 'auto.php.tracer';
 
-        $description = $name;
-        $op = 'function';
-        $origin = 'auto.function.sentry_php_tracer';
-
-        if (isset($metadata['sentry.description']) && \is_string($metadata['sentry.description'])) {
-            $description = $metadata['sentry.description'];
-            unset($metadata['sentry.description']);
-        }
-
-        if (isset($metadata['sentry.op']) && \is_string($metadata['sentry.op'])) {
-            $op = $metadata['sentry.op'];
-            unset($metadata['sentry.op']);
-        }
-
-        if (isset($metadata['sentry.origin']) && \is_string($metadata['sentry.origin'])) {
-            $origin = $metadata['sentry.origin'];
-            unset($metadata['sentry.origin']);
-        }
-
-        $context = SpanContext::make()
+        return SpanContext::make()
             ->setDescription($description)
             ->setOp($op)
             ->setOrigin($origin)
-            ->setData($metadata);
+            ->setData($data)
+            ->setStartTimestamp($data['start_time']);
+    }
 
-        if (isset($data['start_time']) && (\is_int($data['start_time']) || \is_float($data['start_time']))) {
-            $context->setStartTimestamp((float) $data['start_time']);
+    /**
+     * Attempts to extract the value using the specified key and unsets it from
+     * the source array.
+     * It will only perform extraction if the value is a string or can be converted
+     * to a string (using __toString).
+     *
+     * @return null on failed extraction
+     */
+    private static function extractAndUnset(&$data, string $key): ?string {
+        if (isset($data[$key])) {
+            $value = $data[$key];
+            if (\is_string($value)) {
+                unset($data[$key]);
+                return $value;
+            } else if (method_exists($value, '__toString')) {
+                unset($data[$key]);
+                return (string) $value;
+            }
         }
-
-        return $context;
+        return null;
     }
 }

--- a/src/Tracing/FunctionTracingCallbacks.php
+++ b/src/Tracing/FunctionTracingCallbacks.php
@@ -54,8 +54,21 @@ final class FunctionTracingCallbacks
          * @var float $endTime
          */
         $endTime = $data['end_time'];
+        $currentSpan = $callbackState->getCurrentSpan();
+        /** @var array<string, mixed> $metadata */
+        $metadata = $data['metadata'];
 
-        $callbackState->getCurrentSpan()->finish($endTime);
+        if (isset($metadata['http.response.status_code'])
+            && \is_int($metadata['http.response.status_code'])
+        ) {
+            $currentSpan
+                ->setHttpStatus($metadata['http.response.status_code'])
+                ->setData([
+                    'http.response.status_code' => $metadata['http.response.status_code'],
+                ]);
+        }
+
+        $currentSpan->finish($endTime);
         SentrySdk::getCurrentHub()->setSpan($callbackState->getParentSpan());
     }
 

--- a/src/Tracing/FunctionTracingState.php
+++ b/src/Tracing/FunctionTracingState.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Sentry\Tracing;
 
 /**
@@ -24,17 +26,11 @@ final class FunctionTracingState
         $this->currentSpan = $currentSpan;
     }
 
-    /**
-     * @return Span
-     */
     public function getParentSpan(): Span
     {
         return $this->parentSpan;
     }
 
-    /**
-     * @return Span
-     */
     public function getCurrentSpan(): Span
     {
         return $this->currentSpan;

--- a/src/Tracing/FunctionTracingState.php
+++ b/src/Tracing/FunctionTracingState.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Sentry\Tracing;
+
+/**
+ * Used to pass state between the callbacks registered in \Sentry\setStartCallback
+ * and \Sentry\setEndCallback.
+ */
+final class FunctionTracingState
+{
+    /**
+     * @var Span
+     */
+    private $parentSpan;
+
+    /**
+     * @var Span
+     */
+    private $currentSpan;
+
+    public function __construct(Span $parentSpan, Span $currentSpan)
+    {
+        $this->parentSpan = $parentSpan;
+        $this->currentSpan = $currentSpan;
+    }
+
+    /**
+     * @return Span
+     */
+    public function getParentSpan(): Span
+    {
+        return $this->parentSpan;
+    }
+
+    /**
+     * @return Span
+     */
+    public function getCurrentSpan(): Span
+    {
+        return $this->currentSpan;
+    }
+}

--- a/stubs/SentryTracer.stub
+++ b/stubs/SentryTracer.stub
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry {
+    /**
+     * @param array<string, mixed> $extra_metadata
+     */
+    function instrument(?string $class_name, string $function_name, array $extra_metadata = []): bool
+    {
+    }
+
+    /**
+     * @phpstan-param callable(array{name: string, start_time: float, end_time: float, duration: float, metadata: array<string, mixed>}, mixed): mixed $callback
+     */
+    function setEndCallback(callable $callback): bool
+    {
+    }
+
+    /**
+     * @phpstan-param callable(array{name: string, start_time: float, metadata: array<string, mixed>}): mixed $callback
+     */
+    function setStartCallback(callable $callback): bool
+    {
+    }
+
+    final class Trace
+    {
+        /**
+         * @param array<string, mixed> $metadata
+         */
+        public function __construct(array $metadata = [])
+        {
+        }
+    }
+}

--- a/stubs/autoload.php
+++ b/stubs/autoload.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
-if (extension_loaded('excimer')) {
-    return;
+if (!extension_loaded('excimer')) {
+    require_once __DIR__ . '/ExcimerLog.stub';
+    require_once __DIR__ . '/ExcimerLogEntry.stub';
+    require_once __DIR__ . '/ExcimerProfiler.stub';
+    require_once __DIR__ . '/ExcimerTimer.stub';
+    require_once __DIR__ . '/globals.stub';
 }
 
-require_once __DIR__ . '/ExcimerLog.stub';
-require_once __DIR__ . '/ExcimerLogEntry.stub';
-require_once __DIR__ . '/ExcimerProfiler.stub';
-require_once __DIR__ . '/ExcimerTimer.stub';
-require_once __DIR__ . '/globals.stub';
+if (!function_exists('Sentry\\instrument')) {
+    require_once __DIR__ . '/SentryTracer.stub';
+}

--- a/tests/Integration/IntegrationRegistryTest.php
+++ b/tests/Integration/IntegrationRegistryTest.php
@@ -11,6 +11,7 @@ use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
 use Sentry\Integration\FatalErrorListenerIntegration;
 use Sentry\Integration\FrameContextifierIntegration;
+use Sentry\Integration\FunctionTracingIntegration;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\IntegrationRegistry;
 use Sentry\Integration\ModulesIntegration;
@@ -77,16 +78,7 @@ final class IntegrationRegistryTest extends TestCase
                 'dsn' => 'http://public@example.com/sentry/1',
                 'default_integrations' => true,
             ]),
-            [
-                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
-                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
-                RequestIntegration::class => new RequestIntegration(),
-                TransactionIntegration::class => new TransactionIntegration(),
-                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
-                EnvironmentIntegration::class => new EnvironmentIntegration(),
-                ModulesIntegration::class => new ModulesIntegration(),
-            ],
+            self::getExpectedDefaultIntegrations($options, true),
         ];
 
         yield 'No default integrations and some user integrations' => [
@@ -112,15 +104,7 @@ final class IntegrationRegistryTest extends TestCase
                     $integration2,
                 ],
             ]),
-            [
-                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
-                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
-                RequestIntegration::class => new RequestIntegration(),
-                TransactionIntegration::class => new TransactionIntegration(),
-                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
-                EnvironmentIntegration::class => new EnvironmentIntegration(),
-                ModulesIntegration::class => new ModulesIntegration(),
+            self::getExpectedDefaultIntegrations($options, true) + [
                 $integration1ClassName => $integration1,
                 $integration2ClassName => $integration2,
             ],
@@ -135,14 +119,7 @@ final class IntegrationRegistryTest extends TestCase
                     $integration1,
                 ],
             ]),
-            [
-                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
-                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
-                RequestIntegration::class => new RequestIntegration(),
-                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
-                EnvironmentIntegration::class => new EnvironmentIntegration(),
-                ModulesIntegration::class => new ModulesIntegration(),
+            self::getExpectedDefaultIntegrations($options, true, [TransactionIntegration::class]) + [
                 TransactionIntegration::class => new TransactionIntegration(),
                 $integration1ClassName => $integration1,
             ],
@@ -156,14 +133,7 @@ final class IntegrationRegistryTest extends TestCase
                     new ModulesIntegration(),
                 ],
             ]),
-            [
-                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
-                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
-                RequestIntegration::class => new RequestIntegration(),
-                TransactionIntegration::class => new TransactionIntegration(),
-                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
-                EnvironmentIntegration::class => new EnvironmentIntegration(),
+            self::getExpectedDefaultIntegrations($options, true, [ModulesIntegration::class]) + [
                 ModulesIntegration::class => new ModulesIntegration(),
             ],
         ];
@@ -199,34 +169,76 @@ final class IntegrationRegistryTest extends TestCase
                     return $defaultIntegrations;
                 },
             ]),
-            [
-                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
-                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
-                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
-                RequestIntegration::class => new RequestIntegration(),
-                TransactionIntegration::class => new TransactionIntegration(),
-                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
-                EnvironmentIntegration::class => new EnvironmentIntegration(),
-                ModulesIntegration::class => new ModulesIntegration(),
-            ],
+            self::getExpectedDefaultIntegrations($options, true),
         ];
 
         yield 'Default integrations with DSN set to null' => [
-            new Options([
+            $options = new Options([
                 'dsn' => null,
                 'default_integrations' => true,
                 'integrations' => static function (array $defaultIntegrations): array {
                     return $defaultIntegrations;
                 },
             ]),
-            [
-                RequestIntegration::class => new RequestIntegration(),
-                TransactionIntegration::class => new TransactionIntegration(),
-                FrameContextifierIntegration::class => new FrameContextifierIntegration(),
-                EnvironmentIntegration::class => new EnvironmentIntegration(),
-                ModulesIntegration::class => new ModulesIntegration(),
-            ],
+            self::getExpectedDefaultIntegrations($options, false),
         ];
+    }
+
+    /**
+     * @param class-string<IntegrationInterface>[] $excludedDefaultIntegrations
+     *
+     * @return array<class-string<IntegrationInterface>, IntegrationInterface>
+     */
+    private static function getExpectedDefaultIntegrations(Options $options, bool $withErrorIntegrations, array $excludedDefaultIntegrations = []): array
+    {
+        $integrations = [
+            RequestIntegration::class => new RequestIntegration(),
+            TransactionIntegration::class => new TransactionIntegration(),
+            FrameContextifierIntegration::class => new FrameContextifierIntegration(),
+            EnvironmentIntegration::class => new EnvironmentIntegration(),
+            ModulesIntegration::class => new ModulesIntegration(),
+        ];
+
+        if (\function_exists('Sentry\\setStartCallback') && \function_exists('Sentry\\setEndCallback')) {
+            $integrations[FunctionTracingIntegration::class] = new FunctionTracingIntegration();
+        }
+
+        foreach ($excludedDefaultIntegrations as $excludedDefaultIntegration) {
+            unset($integrations[$excludedDefaultIntegration]);
+        }
+
+        if ($withErrorIntegrations) {
+            $integrations = [
+                ExceptionListenerIntegration::class => new ExceptionListenerIntegration(),
+                ErrorListenerIntegration::class => ErrorListenerIntegration::make($options),
+                FatalErrorListenerIntegration::class => new FatalErrorListenerIntegration(),
+            ] + $integrations;
+        }
+
+        return $integrations;
+    }
+
+    /**
+     * @runInSeparateProcess
+     *
+     * @preserveGlobalState disabled
+     */
+    public function testDefaultIntegrationsIncludeFunctionTracingIntegrationWhenExtensionCallbacksExist(): void
+    {
+        if (!\function_exists('Sentry\\setStartCallback')) {
+            eval('namespace Sentry { function setStartCallback(callable $callback): bool { return true; } function setEndCallback(callable $callback): bool { return true; } }');
+        }
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())
+            ->method('debug');
+
+        $integrations = IntegrationRegistry::getInstance()->setupIntegrations(new Options([
+            'dsn' => null,
+            'default_integrations' => true,
+        ]), $logger);
+
+        $this->assertArrayHasKey(FunctionTracingIntegration::class, $integrations);
     }
 
     /**

--- a/tests/Tracing/FunctionTracingCallbacksTest.php
+++ b/tests/Tracing/FunctionTracingCallbacksTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Tracing;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\Client;
+use Sentry\Integration\FunctionTracingIntegration;
+use Sentry\Options;
+use Sentry\SentrySdk;
+use Sentry\State\Hub;
+use Sentry\Tests\StubTransport;
+use Sentry\Tracing\FunctionTracingCallbacks;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\Transaction;
+use Sentry\Tracing\TransactionContext;
+
+final class FunctionTracingCallbacksTest extends TestCase
+{
+    public function testHandleStartCreatesSpanAndSetsItActive(): void
+    {
+        $transaction = $this->createActiveTransaction(true, true);
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [],
+        ]);
+
+        $this->assertIsArray($callbackState);
+        $this->assertInstanceOf(Span::class, $callbackState[0]);
+        $this->assertSame($transaction, $callbackState[1]);
+        $this->assertSame($transaction->getSpanId(), $callbackState[0]->getParentSpanId());
+        $this->assertSame($transaction->getTraceId(), $callbackState[0]->getTraceId());
+        $this->assertSame(123.456, $callbackState[0]->getStartTimestamp());
+        $this->assertSame($callbackState[0], SentrySdk::getCurrentHub()->getSpan());
+    }
+
+    public function testHandleEndFinishesSpanWithEndTimeAndRestoresParent(): void
+    {
+        $transaction = $this->createActiveTransaction(true, true);
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [],
+        ]);
+
+        $this->assertIsArray($callbackState);
+
+        FunctionTracingCallbacks::handleEnd([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'end_time' => 234.567,
+            'duration' => 111.111,
+            'metadata' => [],
+        ], $callbackState);
+
+        $this->assertSame(234.567, $callbackState[0]->getEndTimestamp());
+        $this->assertSame($transaction, SentrySdk::getCurrentHub()->getSpan());
+    }
+
+    public function testNestedCallbacksRestoreParentSpansInOrder(): void
+    {
+        $transaction = $this->createActiveTransaction(true, true);
+
+        $outerState = FunctionTracingCallbacks::handleStart([
+            'name' => 'outer',
+            'start_time' => 1.0,
+            'metadata' => [],
+        ]);
+
+        $this->assertIsArray($outerState);
+
+        $innerState = FunctionTracingCallbacks::handleStart([
+            'name' => 'inner',
+            'start_time' => 2.0,
+            'metadata' => [],
+        ]);
+
+        $this->assertIsArray($innerState);
+        $this->assertSame($outerState[0]->getSpanId(), $innerState[0]->getParentSpanId());
+        $this->assertSame($innerState[0], SentrySdk::getCurrentHub()->getSpan());
+
+        FunctionTracingCallbacks::handleEnd([
+            'name' => 'inner',
+            'start_time' => 2.0,
+            'end_time' => 3.0,
+            'duration' => 1.0,
+            'metadata' => [],
+        ], $innerState);
+
+        $this->assertSame($outerState[0], SentrySdk::getCurrentHub()->getSpan());
+
+        FunctionTracingCallbacks::handleEnd([
+            'name' => 'outer',
+            'start_time' => 1.0,
+            'end_time' => 4.0,
+            'duration' => 3.0,
+            'metadata' => [],
+        ], $outerState);
+
+        $this->assertSame($transaction, SentrySdk::getCurrentHub()->getSpan());
+    }
+
+    /**
+     * @dataProvider handleStartNoOpDataProvider
+     */
+    public function testHandleStartReturnsNullWhenSpanCannotBeCreated(bool $withIntegration, bool $withActiveSpan, bool $sampled): void
+    {
+        $this->createHub($withIntegration);
+
+        if ($withActiveSpan) {
+            $transaction = SentrySdk::getCurrentHub()->startTransaction(new TransactionContext());
+            $transaction->setSampled($sampled);
+            SentrySdk::getCurrentHub()->setSpan($transaction);
+        }
+
+        $this->assertNull(FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [],
+        ]));
+    }
+
+    public static function handleStartNoOpDataProvider(): iterable
+    {
+        yield 'disabled integration' => [false, true, true];
+        yield 'no active span' => [true, false, true];
+        yield 'unsampled active span' => [true, true, false];
+    }
+
+    /**
+     * @dataProvider malformedCallbackStateDataProvider
+     *
+     * @param mixed $callbackState
+     */
+    public function testHandleEndIgnoresMalformedCallbackState($callbackState): void
+    {
+        $transaction = $this->createActiveTransaction(true, true);
+
+        FunctionTracingCallbacks::handleEnd([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'end_time' => 234.567,
+            'duration' => 111.111,
+            'metadata' => [],
+        ], $callbackState);
+
+        $this->assertSame($transaction, SentrySdk::getCurrentHub()->getSpan());
+    }
+
+    public static function malformedCallbackStateDataProvider(): iterable
+    {
+        $span = new Span();
+
+        yield 'null' => [null];
+        yield 'missing parent' => [[$span]];
+        yield 'invalid child' => [['foo', $span]];
+        yield 'invalid parent' => [[$span, 'foo']];
+    }
+
+    public function testMetadataIsMappedToSpanContext(): void
+    {
+        $this->createActiveTransaction(true, true);
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [
+                'sentry.description' => 'custom description',
+                'sentry.op' => 'custom.op',
+                'sentry.origin' => 'auto.custom',
+                'custom' => 'value',
+            ],
+        ]);
+
+        $this->assertIsArray($callbackState);
+        $span = $callbackState[0];
+
+        $this->assertSame('custom description', $span->getDescription());
+        $this->assertSame('custom.op', $span->getOp());
+        $this->assertSame('auto.custom', $span->getOrigin());
+        $this->assertSame(['custom' => 'value'], $span->getData());
+    }
+
+    public function testMetadataDefaultsAreUsed(): void
+    {
+        $this->createActiveTransaction(true, true);
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [
+                'custom' => 'value',
+            ],
+        ]);
+
+        $this->assertIsArray($callbackState);
+        $span = $callbackState[0];
+
+        $this->assertSame('foo', $span->getDescription());
+        $this->assertSame('function', $span->getOp());
+        $this->assertSame('auto.function.sentry_php_tracer', $span->getOrigin());
+        $this->assertSame(['custom' => 'value'], $span->getData());
+    }
+
+    private function createActiveTransaction(bool $withIntegration, bool $sampled): Transaction
+    {
+        $hub = $this->createHub($withIntegration);
+        $transaction = $hub->startTransaction(new TransactionContext());
+        $transaction->setSampled($sampled);
+        if ($sampled && $transaction->getSpanRecorder() === null) {
+            $transaction->initSpanRecorder();
+        }
+
+        $hub->setSpan($transaction);
+
+        return $transaction;
+    }
+
+    private function createHub(bool $withIntegration): Hub
+    {
+        $integrations = $withIntegration ? [new FunctionTracingIntegration()] : [];
+        $options = new Options([
+            'default_integrations' => false,
+            'integrations' => $integrations,
+            'traces_sample_rate' => 1.0,
+        ]);
+
+        $hub = new Hub(new Client($options, StubTransport::getInstance()));
+        SentrySdk::setCurrentHub($hub);
+
+        return $hub;
+    }
+}

--- a/tests/Tracing/FunctionTracingCallbacksTest.php
+++ b/tests/Tracing/FunctionTracingCallbacksTest.php
@@ -206,6 +206,53 @@ final class FunctionTracingCallbacksTest extends TestCase
         $this->assertSame(['custom' => 'value'], $span->getData());
     }
 
+    public function testScalarReservedMetadataIsKeptAsSpanData(): void
+    {
+        $this->createActiveTransaction(true, true);
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [
+                'description' => 123,
+                'op' => 45.67,
+                'origin' => true,
+            ],
+        ]);
+
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
+        $span = $callbackState->getCurrentSpan();
+
+        $this->assertSame('foo', $span->getDescription());
+        $this->assertSame('function', $span->getOp());
+        $this->assertSame('auto.php.tracer', $span->getOrigin());
+        $this->assertSame([
+            'description' => 123,
+            'op' => 45.67,
+            'origin' => true,
+        ], $span->getData());
+    }
+
+    public function testArbitraryObjectMetadataIsKeptAsSpanData(): void
+    {
+        $this->createActiveTransaction(true, true);
+
+        $metadataValue = new \stdClass();
+        $metadataValue->foo = 'bar';
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [
+                'custom' => $metadataValue,
+            ],
+        ]);
+
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
+
+        $this->assertSame(['custom' => $metadataValue], $callbackState->getCurrentSpan()->getData());
+    }
+
     private function createActiveTransaction(bool $withIntegration, bool $sampled): Transaction
     {
         $hub = $this->createHub($withIntegration);

--- a/tests/Tracing/FunctionTracingCallbacksTest.php
+++ b/tests/Tracing/FunctionTracingCallbacksTest.php
@@ -12,6 +12,7 @@ use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\Tests\StubTransport;
 use Sentry\Tracing\FunctionTracingCallbacks;
+use Sentry\Tracing\FunctionTracingState;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
@@ -28,13 +29,12 @@ final class FunctionTracingCallbacksTest extends TestCase
             'metadata' => [],
         ]);
 
-        $this->assertIsArray($callbackState);
-        $this->assertInstanceOf(Span::class, $callbackState[0]);
-        $this->assertSame($transaction, $callbackState[1]);
-        $this->assertSame($transaction->getSpanId(), $callbackState[0]->getParentSpanId());
-        $this->assertSame($transaction->getTraceId(), $callbackState[0]->getTraceId());
-        $this->assertSame(123.456, $callbackState[0]->getStartTimestamp());
-        $this->assertSame($callbackState[0], SentrySdk::getCurrentHub()->getSpan());
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
+        $this->assertSame($transaction, $callbackState->getParentSpan());
+        $this->assertSame($transaction->getSpanId(), $callbackState->getCurrentSpan()->getParentSpanId());
+        $this->assertSame($transaction->getTraceId(), $callbackState->getCurrentSpan()->getTraceId());
+        $this->assertSame(123.456, $callbackState->getCurrentSpan()->getStartTimestamp());
+        $this->assertSame($callbackState->getCurrentSpan(), SentrySdk::getCurrentHub()->getSpan());
     }
 
     public function testHandleEndFinishesSpanWithEndTimeAndRestoresParent(): void
@@ -47,7 +47,7 @@ final class FunctionTracingCallbacksTest extends TestCase
             'metadata' => [],
         ]);
 
-        $this->assertIsArray($callbackState);
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
 
         FunctionTracingCallbacks::handleEnd([
             'name' => 'foo',
@@ -57,7 +57,7 @@ final class FunctionTracingCallbacksTest extends TestCase
             'metadata' => [],
         ], $callbackState);
 
-        $this->assertSame(234.567, $callbackState[0]->getEndTimestamp());
+        $this->assertSame(234.567, $callbackState->getCurrentSpan()->getEndTimestamp());
         $this->assertSame($transaction, SentrySdk::getCurrentHub()->getSpan());
     }
 
@@ -71,7 +71,7 @@ final class FunctionTracingCallbacksTest extends TestCase
             'metadata' => [],
         ]);
 
-        $this->assertIsArray($outerState);
+        $this->assertInstanceOf(FunctionTracingState::class, $outerState);
 
         $innerState = FunctionTracingCallbacks::handleStart([
             'name' => 'inner',
@@ -79,9 +79,9 @@ final class FunctionTracingCallbacksTest extends TestCase
             'metadata' => [],
         ]);
 
-        $this->assertIsArray($innerState);
-        $this->assertSame($outerState[0]->getSpanId(), $innerState[0]->getParentSpanId());
-        $this->assertSame($innerState[0], SentrySdk::getCurrentHub()->getSpan());
+        $this->assertInstanceOf(FunctionTracingState::class, $innerState);
+        $this->assertSame($outerState->getCurrentSpan()->getSpanId(), $innerState->getCurrentSpan()->getParentSpanId());
+        $this->assertSame($innerState->getCurrentSpan(), SentrySdk::getCurrentHub()->getSpan());
 
         FunctionTracingCallbacks::handleEnd([
             'name' => 'inner',
@@ -91,7 +91,7 @@ final class FunctionTracingCallbacksTest extends TestCase
             'metadata' => [],
         ], $innerState);
 
-        $this->assertSame($outerState[0], SentrySdk::getCurrentHub()->getSpan());
+        $this->assertSame($outerState->getCurrentSpan(), SentrySdk::getCurrentHub()->getSpan());
 
         FunctionTracingCallbacks::handleEnd([
             'name' => 'outer',
@@ -169,15 +169,15 @@ final class FunctionTracingCallbacksTest extends TestCase
             'name' => 'foo',
             'start_time' => 123.456,
             'metadata' => [
-                'sentry.description' => 'custom description',
-                'sentry.op' => 'custom.op',
-                'sentry.origin' => 'auto.custom',
+                'description' => 'custom description',
+                'op' => 'custom.op',
+                'origin' => 'auto.custom',
                 'custom' => 'value',
             ],
         ]);
 
-        $this->assertIsArray($callbackState);
-        $span = $callbackState[0];
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
+        $span = $callbackState->getCurrentSpan();
 
         $this->assertSame('custom description', $span->getDescription());
         $this->assertSame('custom.op', $span->getOp());
@@ -197,12 +197,12 @@ final class FunctionTracingCallbacksTest extends TestCase
             ],
         ]);
 
-        $this->assertIsArray($callbackState);
-        $span = $callbackState[0];
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
+        $span = $callbackState->getCurrentSpan();
 
         $this->assertSame('foo', $span->getDescription());
         $this->assertSame('function', $span->getOp());
-        $this->assertSame('auto.function.sentry_php_tracer', $span->getOrigin());
+        $this->assertSame('auto.php.tracer', $span->getOrigin());
         $this->assertSame(['custom' => 'value'], $span->getData());
     }
 

--- a/tests/Tracing/FunctionTracingCallbacksTest.php
+++ b/tests/Tracing/FunctionTracingCallbacksTest.php
@@ -14,6 +14,7 @@ use Sentry\Tests\StubTransport;
 use Sentry\Tracing\FunctionTracingCallbacks;
 use Sentry\Tracing\FunctionTracingState;
 use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanStatus;
 use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 
@@ -59,6 +60,33 @@ final class FunctionTracingCallbacksTest extends TestCase
 
         $this->assertSame(234.567, $callbackState->getCurrentSpan()->getEndTimestamp());
         $this->assertSame($transaction, SentrySdk::getCurrentHub()->getSpan());
+    }
+
+    public function testHandleEndSetsHttpStatusFromMetadata(): void
+    {
+        $this->createActiveTransaction(true, true);
+
+        $callbackState = FunctionTracingCallbacks::handleStart([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'metadata' => [],
+        ]);
+
+        $this->assertInstanceOf(FunctionTracingState::class, $callbackState);
+
+        FunctionTracingCallbacks::handleEnd([
+            'name' => 'foo',
+            'start_time' => 123.456,
+            'end_time' => 234.567,
+            'duration' => 111.111,
+            'metadata' => [
+                'http.response.status_code' => 404,
+            ],
+        ], $callbackState);
+
+        $span = $callbackState->getCurrentSpan();
+        $this->assertSame(SpanStatus::notFound(), $span->getStatus());
+        $this->assertSame(404, $span->getData('http.response.status_code'));
     }
 
     public function testNestedCallbacksRestoreParentSpansInOrder(): void

--- a/tests/Tracing/FunctionTracingIntegrationSmokeTest.php
+++ b/tests/Tracing/FunctionTracingIntegrationSmokeTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests\Tracing;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\State\Scope;
+use Sentry\Tests\StubTransport;
+use Sentry\Tracing\TransactionContext;
+
+use function Sentry\configureScope;
+use function Sentry\init;
+use function Sentry\startTransaction;
+
+final class FunctionTracingIntegrationSmokeTest extends TestCase
+{
+    public function testExtensionCreatesNestedSdkSpans(): void
+    {
+        if (!\function_exists('Sentry\\instrument')) {
+            $this->markTestSkipped('The Sentry PHP tracer extension is not loaded.');
+        }
+
+        init([
+            'dsn' => null,
+            'default_integrations' => true,
+            'traces_sample_rate' => 1.0,
+            'transport' => StubTransport::getInstance(),
+        ]);
+
+        $transaction = startTransaction(new TransactionContext('tracer-smoke'));
+        configureScope(static function (Scope $scope) use ($transaction): void {
+            $scope->setSpan($transaction);
+        });
+
+        \Sentry\instrument(self::class, 'tracerSmokeOuter');
+        \Sentry\instrument(self::class, 'tracerSmokeInner');
+
+        self::tracerSmokeOuter();
+        $transaction->finish();
+
+        $this->assertCount(1, StubTransport::$events);
+
+        $spans = StubTransport::$events[0]->getSpans();
+        $this->assertCount(2, $spans);
+
+        $this->assertSame(self::class . '::tracerSmokeOuter', $spans[0]->getDescription());
+        $this->assertSame(self::class . '::tracerSmokeInner', $spans[1]->getDescription());
+        $this->assertSame($transaction->getSpanId(), $spans[0]->getParentSpanId());
+        $this->assertSame($spans[0]->getSpanId(), $spans[1]->getParentSpanId());
+        $this->assertNotNull($spans[0]->getEndTimestamp());
+        $this->assertNotNull($spans[1]->getEndTimestamp());
+        $this->assertGreaterThanOrEqual($spans[0]->getStartTimestamp(), $spans[0]->getEndTimestamp());
+        $this->assertGreaterThanOrEqual($spans[1]->getStartTimestamp(), $spans[1]->getEndTimestamp());
+    }
+
+    public static function tracerSmokeOuter(): void
+    {
+        self::tracerSmokeInner();
+    }
+
+    public static function tracerSmokeInner(): void
+    {
+    }
+}


### PR DESCRIPTION
Adds support for the [Sentry tracing extension](https://github.com/getsentry/sentry-php-tracer) by registering callbacks and creating spans.

The integration as well as the extension is a work in progress