### PR TITLE
feat(scope): remove Hub from Transaction

### DIFF
--- a/src/Tracing/DynamicSamplingContext.php
+++ b/src/Tracing/DynamicSamplingContext.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Sentry\Tracing;
 
+use Sentry\ClientInterface;
 use Sentry\Options;
-use Sentry\State\HubInterface;
 use Sentry\State\Scope;
 
 /**
@@ -149,7 +149,7 @@ final class DynamicSamplingContext
      *
      * @see https://develop.sentry.dev/sdk/performance/dynamic-sampling-context/#baggage-header
      */
-    public static function fromTransaction(Transaction $transaction, HubInterface $hub): self
+    public static function fromTransaction(Transaction $transaction, ClientInterface $client): self
     {
         $samplingContext = new self();
         $samplingContext->set('trace_id', (string) $transaction->getTraceId());
@@ -163,8 +163,6 @@ final class DynamicSamplingContext
         if ($transaction->getMetadata()->getSource() !== TransactionSource::url()) {
             $samplingContext->set('transaction', $transaction->getName());
         }
-
-        $client = $hub->getClient();
 
         self::setOrgOptions($client->getOptions(), $samplingContext);
 

--- a/src/Tracing/Transaction.php
+++ b/src/Tracing/Transaction.php
@@ -9,18 +9,12 @@ use Sentry\EventId;
 use Sentry\Options;
 use Sentry\Profiling\Profiler;
 use Sentry\SentrySdk;
-use Sentry\State\HubInterface;
 
 /**
  * This class stores all the information about a Transaction.
  */
 final class Transaction extends Span
 {
-    /**
-     * @var HubInterface The hub instance
-     */
-    private $hub;
-
     /**
      * @var string Name of the transaction
      */
@@ -45,15 +39,13 @@ final class Transaction extends Span
      * Span constructor.
      *
      * @param TransactionContext $context The context to create the transaction with
-     * @param HubInterface|null  $hub     Instance of a hub to flush the transaction
      *
      * @internal
      */
-    public function __construct(TransactionContext $context, ?HubInterface $hub = null)
+    public function __construct(TransactionContext $context)
     {
         parent::__construct($context);
 
-        $this->hub = $hub ?? SentrySdk::getCurrentHub();
         $this->name = $context->getName();
         $this->metadata = $context->getMetadata();
         $this->transaction = $this;
@@ -98,7 +90,7 @@ final class Transaction extends Span
             return $this->metadata->getDynamicSamplingContext();
         }
 
-        $samplingContext = DynamicSamplingContext::fromTransaction($this->transaction, $this->hub);
+        $samplingContext = DynamicSamplingContext::fromTransaction($this->transaction, SentrySdk::getClient());
         $this->getMetadata()->setDynamicSamplingContext($samplingContext);
 
         return $samplingContext;
@@ -123,7 +115,7 @@ final class Transaction extends Span
     public function initProfiler(?Options $options = null): Profiler
     {
         if ($this->profiler === null) {
-            $this->profiler = new Profiler($options ?? $this->hub->getClient()->getOptions());
+            $this->profiler = new Profiler($options ?? SentrySdk::getClient()->getOptions());
         }
 
         return $this->profiler;
@@ -188,6 +180,6 @@ final class Transaction extends Span
             }
         }
 
-        return $this->hub->captureEvent($event);
+        return \Sentry\captureEvent($event);
     }
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -631,6 +631,7 @@ final class FunctionsTest extends TestCase
 
         $hub = new Hub($client);
 
+        SentrySdk::getGlobalScope()->setClient($client);
         SentrySdk::setCurrentHub($hub);
 
         $transactionContext = new TransactionContext();

--- a/tests/Tracing/DynamicSamplingContextTest.php
+++ b/tests/Tracing/DynamicSamplingContextTest.php
@@ -8,7 +8,6 @@ use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\NoOpClient;
 use Sentry\Options;
-use Sentry\State\Hub;
 use Sentry\State\Scope;
 use Sentry\Tracing\DynamicSamplingContext;
 use Sentry\Tracing\PropagationContext;
@@ -91,16 +90,14 @@ final class DynamicSamplingContextTest extends TestCase
                 'environment' => 'test',
             ]));
 
-        $hub = new Hub($client);
-
         $transactionContext = new TransactionContext();
         $transactionContext->setName('foo');
 
-        $transaction = new Transaction($transactionContext, $hub);
+        $transaction = new Transaction($transactionContext);
         $transaction->getMetadata()->setSamplingRate(1.0);
         $transaction->getMetadata()->setSampleRand(0.5);
 
-        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $hub);
+        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $client);
 
         $this->assertSame((string) $transaction->getTraceId(), $samplingContext->get('trace_id'));
         $this->assertSame((string) $transaction->getMetaData()->getSamplingRate(), $samplingContext->get('sample_rate'));
@@ -114,15 +111,13 @@ final class DynamicSamplingContextTest extends TestCase
 
     public function testFromTransactionSourceUrl(): void
     {
-        $hub = new Hub(new NoOpClient());
-
         $transactionContext = new TransactionContext();
         $transactionContext->setName('/foo/bar/123');
         $transactionContext->setSource(TransactionSource::url());
 
-        $transaction = new Transaction($transactionContext, $hub);
+        $transaction = new Transaction($transactionContext);
 
-        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $hub);
+        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, new NoOpClient());
 
         $this->assertNull($samplingContext->get('transaction'));
     }
@@ -189,9 +184,8 @@ final class DynamicSamplingContextTest extends TestCase
                 'org_id' => 2,
             ]));
 
-        $hub = new Hub($client);
-        $transaction = new Transaction(new TransactionContext(), $hub);
-        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $hub);
+        $transaction = new Transaction(new TransactionContext());
+        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $client);
 
         $this->assertSame('2', $samplingContext->get('org_id'));
     }
@@ -205,9 +199,8 @@ final class DynamicSamplingContextTest extends TestCase
                 'dsn' => 'http://public@o1.example.com/1',
             ]));
 
-        $hub = new Hub($client);
-        $transaction = new Transaction(new TransactionContext(), $hub);
-        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $hub);
+        $transaction = new Transaction(new TransactionContext());
+        $samplingContext = DynamicSamplingContext::fromTransaction($transaction, $client);
 
         $this->assertSame('1', $samplingContext->get('org_id'));
     }

--- a/tests/Tracing/TransactionTest.php
+++ b/tests/Tracing/TransactionTest.php
@@ -10,8 +10,9 @@ use Sentry\Event;
 use Sentry\EventId;
 use Sentry\EventType;
 use Sentry\Options;
+use Sentry\SentrySdk;
 use Sentry\State\Hub;
-use Sentry\State\HubInterface;
+use Sentry\State\Scope;
 use Sentry\Tests\TestUtil\ClockMock;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\Transaction;
@@ -37,19 +38,16 @@ final class TransactionTest extends TestCase
             ->method('getOptions')
             ->willReturn(new Options());
 
-        $hub = $this->createMock(HubInterface::class);
-        $hub->expects($this->once())
-            ->method('getClient')
-            ->willReturn($client);
+        SentrySdk::init($client);
 
-        $transaction = new Transaction($transactionContext, $hub);
+        $transaction = new Transaction($transactionContext);
         $transaction->initSpanRecorder();
 
         $span1 = $transaction->startChild(new SpanContext());
         $span2 = $transaction->startChild(new SpanContext());
         $span3 = $transaction->startChild(new SpanContext()); // This span isn't finished, so it should not be included in the event
 
-        $hub->expects($this->once())
+        $client->expects($this->once())
             ->method('captureEvent')
             ->with($this->callback(function (Event $eventArg) use ($transactionContext, $span1, $span2): bool {
                 $this->assertSame(EventType::transaction(), $eventArg->getType());
@@ -60,7 +58,7 @@ final class TransactionTest extends TestCase
                 $this->assertSame([$span1, $span2], $eventArg->getSpans());
 
                 return true;
-            }))
+            }), null, $this->isInstanceOf(Scope::class))
             ->willReturnCallback(static function (Event $eventArg) use (&$expectedEventId): EventId {
                 $expectedEventId = $eventArg->getId();
 
@@ -77,11 +75,13 @@ final class TransactionTest extends TestCase
 
     public function testFinishDoesNothingIfSampledFlagIsNotTrue(): void
     {
-        $hub = $this->createMock(HubInterface::class);
-        $hub->expects($this->never())
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->never())
             ->method('captureEvent');
 
-        $transaction = new Transaction(new TransactionContext(), $hub);
+        SentrySdk::init($client);
+
+        $transaction = new Transaction(new TransactionContext());
         $transaction->finish();
     }
 


### PR DESCRIPTION
This PR removes the `Hub` from the transaction and instead replaces it with `ClientInterface` in some instances. 