### PR TITLE
feat(scope): update aggregator flush to use a client

### DIFF
--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -6,6 +6,7 @@ namespace Sentry\Logs;
 
 use Sentry\Attributes\Attribute;
 use Sentry\Client;
+use Sentry\ClientInterface;
 use Sentry\Event;
 use Sentry\EventId;
 use Sentry\SentrySdk;
@@ -159,20 +160,22 @@ final class LogsAggregator
         $logs->push($log);
 
         if ($logFlushThreshold !== null && \count($logs) >= $logFlushThreshold) {
-            $this->flush($hub);
+            $this->flush($client);
         }
     }
 
-    public function flush(?HubInterface $hub = null): ?EventId
+    public function flush(?ClientInterface $client = null): ?EventId
     {
-        if ($this->logs === null || $this->logs->isEmpty()) {
+        $logs = $this->logs;
+
+        if ($logs === null || $logs->isEmpty()) {
             return null;
         }
 
-        $hub = $hub ?? SentrySdk::getCurrentHub();
-        $event = Event::createLogs()->setLogs($this->logs->drain());
+        $client = $client ?? SentrySdk::getCurrentHub()->getClient();
+        $event = Event::createLogs()->setLogs($logs->drain());
 
-        return $hub->captureEvent($event);
+        return $client->captureEvent($event);
     }
 
     /**

--- a/src/Metrics/MetricsAggregator.php
+++ b/src/Metrics/MetricsAggregator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Metrics;
 
 use Sentry\Client;
+use Sentry\ClientInterface;
 use Sentry\Event;
 use Sentry\EventId;
 use Sentry\Metrics\Types\CounterMetric;
@@ -124,20 +125,22 @@ final class MetricsAggregator
         $metrics->push($metric);
 
         if ($metricFlushThreshold !== null && \count($metrics) >= $metricFlushThreshold) {
-            $this->flush($hub);
+            $this->flush($client);
         }
     }
 
-    public function flush(?HubInterface $hub = null): ?EventId
+    public function flush(?ClientInterface $client = null): ?EventId
     {
-        if ($this->metrics === null || $this->metrics->isEmpty()) {
+        $metrics = $this->metrics;
+
+        if ($metrics === null || $metrics->isEmpty()) {
             return null;
         }
 
-        $hub = $hub ?? SentrySdk::getCurrentHub();
-        $event = Event::createMetrics()->setMetrics($this->metrics->drain());
+        $client = $client ?? SentrySdk::getCurrentHub()->getClient();
+        $event = Event::createMetrics()->setMetrics($metrics->drain());
 
-        return $hub->captureEvent($event);
+        return $client->captureEvent($event);
     }
 
     /**

--- a/src/State/RuntimeContextManager.php
+++ b/src/State/RuntimeContextManager.php
@@ -161,12 +161,12 @@ final class RuntimeContextManager
 
     private function flushRuntimeContextResources(RuntimeContext $runtimeContext, ?int $timeout, LoggerInterface $logger): void
     {
-        $hub = $runtimeContext->getHub();
+        $client = $runtimeContext->getHub()->getClient();
 
         // captureEvent can throw before transport send (for example from scope event processors
         // or before_send callbacks), so we isolate failures and continue flushing other resources.
         try {
-            $runtimeContext->getLogsAggregator()->flush($hub);
+            $runtimeContext->getLogsAggregator()->flush($client);
         } catch (\Throwable $exception) {
             $logger->error('Failed to flush logs while ending a runtime context.', [
                 'exception' => $exception,
@@ -176,15 +176,13 @@ final class RuntimeContextManager
 
         // Keep metrics flush independent from logs flush so one bad callback does not block the rest.
         try {
-            $runtimeContext->getMetricsAggregator()->flush($hub);
+            $runtimeContext->getMetricsAggregator()->flush($client);
         } catch (\Throwable $exception) {
             $logger->error('Failed to flush trace metrics while ending a runtime context.', [
                 'exception' => $exception,
                 'runtime_context_id' => $runtimeContext->getId(),
             ]);
         }
-
-        $client = $hub->getClient();
 
         // Custom transports may throw from close(); endContext must stay best-effort and non-fatal.
         try {

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -7,8 +7,11 @@ namespace Sentry\Tests\Logs;
 use PHPUnit\Framework\TestCase;
 use Sentry\Client;
 use Sentry\ClientBuilder;
+use Sentry\ClientInterface;
+use Sentry\Event;
 use Sentry\Logs\LogLevel;
 use Sentry\Logs\LogsAggregator;
+use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\State\Scope;
@@ -269,6 +272,39 @@ final class LogsAggregatorTest extends TestCase
         $this->assertCount(2, StubTransport::$events[0]->getLogs());
         $this->assertSame('First message', StubTransport::$events[0]->getLogs()[0]->getBody());
         $this->assertSame('Second message', StubTransport::$events[0]->getLogs()[1]->getBody());
+    }
+
+    public function testFlushCapturesLogsWithProvidedClient(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getOptions')
+            ->willReturn(new Options([
+                'enable_logs' => true,
+            ]));
+
+        $fallbackClient = $this->createMock(ClientInterface::class);
+        $fallbackClient->method('getOptions')
+            ->willReturn(new Options([
+                'enable_logs' => true,
+            ]));
+        $fallbackClient->expects($this->never())
+            ->method('captureEvent');
+        SentrySdk::setCurrentHub(new Hub($fallbackClient));
+
+        $aggregator = new LogsAggregator();
+        $aggregator->add(LogLevel::info(), 'Test message');
+
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with(
+                $this->callback(function (Event $event): bool {
+                    $this->assertCount(1, $event->getLogs());
+
+                    return true;
+                })
+            );
+
+        $aggregator->flush($client);
     }
 
     public function testDoesNotFlushImmediatelyWhenThresholdIsNull(): void

--- a/tests/Metrics/TraceMetricsTest.php
+++ b/tests/Metrics/TraceMetricsTest.php
@@ -6,12 +6,16 @@ namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sentry\Client;
+use Sentry\ClientInterface;
+use Sentry\Event;
 use Sentry\Metrics\MetricsAggregator;
 use Sentry\Metrics\Types\CounterMetric;
 use Sentry\Metrics\Types\DistributionMetric;
 use Sentry\Metrics\Types\GaugeMetric;
 use Sentry\Metrics\Types\Metric;
 use Sentry\Options;
+use Sentry\SentrySdk;
+use Sentry\State\Hub;
 use Sentry\State\HubAdapter;
 use Sentry\State\Scope;
 
@@ -108,6 +112,39 @@ final class TraceMetricsTest extends TestCase
 
         $this->assertCount(1, StubTransport::$events);
         $this->assertCount(2, StubTransport::$events[0]->getMetrics());
+    }
+
+    public function testFlushCapturesMetricsWithProvidedClient(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('getOptions')
+            ->willReturn(new Options([
+                'enable_metrics' => true,
+            ]));
+
+        $fallbackClient = $this->createMock(ClientInterface::class);
+        $fallbackClient->method('getOptions')
+            ->willReturn(new Options([
+                'enable_metrics' => true,
+            ]));
+        $fallbackClient->expects($this->never())
+            ->method('captureEvent');
+        SentrySdk::setCurrentHub(new Hub($fallbackClient));
+
+        $aggregator = new MetricsAggregator();
+        $aggregator->add(CounterMetric::TYPE, 'test-count', 2, ['foo' => 'bar'], null);
+
+        $client->expects($this->once())
+            ->method('captureEvent')
+            ->with(
+                $this->callback(function (Event $event): bool {
+                    $this->assertCount(1, $event->getMetrics());
+
+                    return true;
+                })
+            );
+
+        $aggregator->flush($client);
     }
 
     public function testMetricsBufferFullWhenMetricFlushThresholdIsNull(): void


### PR DESCRIPTION
This PR removes the `Hub` from the flush signature and replaces it with the `Client`