### PR TITLE
fix: reset fatal error handler when starting a new context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Remove OpenTelemetry dependencies on unsupported PHP versions
         if: ${{ matrix.php.version == '7.2' || matrix.php.version == '7.3' || matrix.php.version == '7.4' || matrix.php.version == '8.0' }}
-        run: composer remove open-telemetry/api open-telemetry/exporter-otlp open-telemetry/sdk --dev --no-interaction --no-update
+        run: composer remove open-telemetry/api open-telemetry/exporter-otlp open-telemetry/sem-conv open-telemetry/sdk --dev --no-interaction --no-update
 
       - name: Set phpunit/phpunit version constraint
         run: composer require phpunit/phpunit:'${{ matrix.php.phpunit }}' --dev --no-interaction --no-update

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "nyholm/psr7": "^1.8",
         "open-telemetry/api": "^1.0",
         "open-telemetry/exporter-otlp": "^1.0",
+        "open-telemetry/sem-conv": "^1.27",
         "open-telemetry/sdk": "^1.0",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^8.5.52|^9.6.34",

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -118,6 +118,11 @@ final class ErrorHandler
     private static $reservedMemory;
 
     /**
+     * @var int The amount of memory to reserve for the fatal error handler
+     */
+    private static $reservedMemorySize = self::DEFAULT_RESERVED_MEMORY_SIZE;
+
+    /**
      * @var bool Whether the fatal error handler should be disabled
      */
     private static $disableFatalErrorHandler = false;
@@ -214,6 +219,7 @@ final class ErrorHandler
         }
 
         self::$handlerInstance->isFatalErrorHandlerRegistered = true;
+        self::$reservedMemorySize = $reservedMemorySize;
         self::$reservedMemory = str_repeat('x', $reservedMemorySize);
 
         register_shutdown_function(\Closure::fromCallable([self::$handlerInstance, 'handleFatalError']));
@@ -307,6 +313,11 @@ final class ErrorHandler
     public static function resetFatalErrorHandlerState(): void
     {
         self::$disableFatalErrorHandler = false;
+        self::$didIncreaseMemoryLimit = false;
+
+        if (self::$handlerInstance !== null && self::$handlerInstance->isFatalErrorHandlerRegistered) {
+            self::$reservedMemory = str_repeat('x', self::$reservedMemorySize);
+        }
     }
 
     /**

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -302,6 +302,14 @@ final class ErrorHandler
     }
 
     /**
+     * @internal
+     */
+    public static function resetFatalErrorHandlerState(): void
+    {
+        self::$disableFatalErrorHandler = false;
+    }
+
+    /**
      * Handles errors by capturing them through the client according to the
      * configured bit field.
      *

--- a/src/State/RuntimeContextManager.php
+++ b/src/State/RuntimeContextManager.php
@@ -6,6 +6,7 @@ namespace Sentry\State;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Sentry\ErrorHandler;
 use Sentry\Tracing\PropagationContext;
 
 /**
@@ -112,6 +113,8 @@ final class RuntimeContextManager
             // Nested start calls for the same execution key should be a no-op.
             return;
         }
+
+        ErrorHandler::resetFatalErrorHandlerState();
 
         $this->createContextForExecutionContextKey($executionContextKey);
     }

--- a/tests/Fixtures/OpenTelemetry/TestDiscoveryStrategy.php
+++ b/tests/Fixtures/OpenTelemetry/TestDiscoveryStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sentry\Tests\Fixtures\OpenTelemetry;
 
+use GuzzleHttp\Psr7\HttpFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -21,7 +22,10 @@ final class TestDiscoveryStrategy
         }
 
         if (is_a(RequestFactoryInterface::class, $type, true) || is_a(StreamFactoryInterface::class, $type, true)) {
-            return [['class' => Psr17Factory::class, 'condition' => Psr17Factory::class]];
+            return [
+                ['class' => HttpFactory::class, 'condition' => HttpFactory::class],
+                ['class' => Psr17Factory::class, 'condition' => Psr17Factory::class],
+            ];
         }
 
         return [];

--- a/tests/Integration/OTLPIntegrationTest.php
+++ b/tests/Integration/OTLPIntegrationTest.php
@@ -280,9 +280,9 @@ final class OTLPIntegrationTest extends TestCase
 
         if (method_exists(HttpClientDiscovery::class, 'setDiscoverers')) {
             HttpClientDiscovery::setDiscoverers([new TestClientDiscoverer()]);
-        } else {
-            ClassDiscovery::prependStrategy(TestDiscoveryStrategy::class);
         }
+
+        ClassDiscovery::prependStrategy(TestDiscoveryStrategy::class);
 
         StubOtelHttpClient::reset();
     }

--- a/tests/phpt/error_handler_reset_fatal_error_handler_state.phpt
+++ b/tests/phpt/error_handler_reset_fatal_error_handler_state.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Test that resetting the fatal error handler state re-arms OOM handling
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use Sentry\ErrorHandler;
+
+$vendor = __DIR__;
+
+while (!file_exists($vendor . '/vendor')) {
+    $vendor = \dirname($vendor);
+}
+
+require $vendor . '/vendor/autoload.php';
+
+error_reporting(\E_ALL & ~\E_DEPRECATED & ~\E_USER_DEPRECATED);
+
+function getErrorHandlerProperty(string $name): \ReflectionProperty
+{
+    $property = new \ReflectionProperty(ErrorHandler::class, $name);
+    $property->setAccessible(true);
+
+    return $property;
+}
+
+function setErrorHandlerStaticProperty(string $name, $value): void
+{
+    getErrorHandlerProperty($name)->setValue(null, $value);
+}
+
+function getErrorHandlerStaticProperty(string $name)
+{
+    return getErrorHandlerProperty($name)->getValue();
+}
+
+ErrorHandler::registerOnceFatalErrorHandler(1234);
+
+setErrorHandlerStaticProperty('disableFatalErrorHandler', true);
+setErrorHandlerStaticProperty('didIncreaseMemoryLimit', true);
+setErrorHandlerStaticProperty('reservedMemory', null);
+
+ErrorHandler::resetFatalErrorHandlerState();
+
+var_dump(getErrorHandlerStaticProperty('disableFatalErrorHandler'));
+var_dump(getErrorHandlerStaticProperty('didIncreaseMemoryLimit'));
+var_dump(\strlen(getErrorHandlerStaticProperty('reservedMemory')));
+
+?>
+--EXPECT--
+bool(false)
+bool(false)
+int(1234)


### PR DESCRIPTION
Enables the fatal error handler once a new context is started.

This prevents the error handler from being permanently disabled in runtimes such as FrankenPHP