### PR TITLE
fix: Strip breadcrumb metadata on OOM to prevent silent event loss

### DIFF
--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -56,7 +56,7 @@ final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegrati
                     $scope->clearBreadcrumbs();
 
                     foreach ($strippedBreadcrumbs as $breadcrumb) {
-                        $scope->addBreadcrumb($breadcrumb);
+                        $scope->addBreadcrumb($breadcrumb, \count($strippedBreadcrumbs));
                     }
                 });
             }

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Sentry\Integration;
 
+use Sentry\Breadcrumb;
 use Sentry\ErrorHandler;
 use Sentry\Exception\FatalErrorException;
 use Sentry\SentrySdk;
+use Sentry\State\Scope;
 
 /**
  * This integration hooks into the error handler and captures fatal errors.
@@ -15,6 +17,8 @@ use Sentry\SentrySdk;
  */
 final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegration
 {
+    private const OOM_MESSAGE_MATCHER = '/Allowed memory size of \d+ bytes exhausted/';
+
     /**
      * {@inheritdoc}
      */
@@ -34,6 +38,27 @@ final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegrati
 
             if (!($client->getOptions()->getErrorTypes() & $exception->getSeverity())) {
                 return;
+            }
+
+            if (preg_match(self::OOM_MESSAGE_MATCHER, $exception->getMessage()) === 1) {
+                $currentHub->configureScope(static function (Scope $scope): void {
+                    $strippedBreadcrumbs = array_map(static function (Breadcrumb $breadcrumb): Breadcrumb {
+                        return new Breadcrumb(
+                            $breadcrumb->getLevel(),
+                            $breadcrumb->getType(),
+                            $breadcrumb->getCategory(),
+                            $breadcrumb->getMessage(),
+                            [],
+                            $breadcrumb->getTimestamp()
+                        );
+                    }, $scope->getBreadcrumbs());
+
+                    $scope->clearBreadcrumbs();
+
+                    foreach ($strippedBreadcrumbs as $breadcrumb) {
+                        $scope->addBreadcrumb($breadcrumb);
+                    }
+                });
             }
 
             $integration->captureException($currentHub, $exception);

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -17,6 +17,8 @@ use Sentry\State\Scope;
  */
 final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegration
 {
+    // Intentionally looser than ErrorHandler::OOM_MESSAGE_MATCHER — matches the
+    // prefixed FatalErrorException message and needs no capture groups.
     private const OOM_MESSAGE_MATCHER = '/Allowed memory size of \d+ bytes exhausted/';
 
     /**

--- a/src/Integration/FatalErrorListenerIntegration.php
+++ b/src/Integration/FatalErrorListenerIntegration.php
@@ -17,8 +17,10 @@ use Sentry\State\Scope;
  */
 final class FatalErrorListenerIntegration extends AbstractErrorListenerIntegration
 {
-    // Intentionally looser than ErrorHandler::OOM_MESSAGE_MATCHER — matches the
-    // prefixed FatalErrorException message and needs no capture groups.
+    /**
+     * Intentionally looser than ErrorHandler::OOM_MESSAGE_MATCHER — matches the
+     * prefixed FatalErrorException message and needs no capture groups.
+     */
     private const OOM_MESSAGE_MATCHER = '/Allowed memory size of \d+ bytes exhausted/';
 
     /**

--- a/src/State/Scope.php
+++ b/src/State/Scope.php
@@ -327,6 +327,16 @@ class Scope
     }
 
     /**
+     * Gets the breadcrumbs.
+     *
+     * @return Breadcrumb[]
+     */
+    public function getBreadcrumbs(): array
+    {
+        return $this->breadcrumbs;
+    }
+
+    /**
      * Clears all the breadcrumbs.
      *
      * @return $this

--- a/tests/phpt-oom/php84/out_of_memory_fatal_error_increases_memory_limit.phpt
+++ b/tests/phpt-oom/php84/out_of_memory_fatal_error_increases_memory_limit.phpt
@@ -24,6 +24,8 @@ use Sentry\Transport\Result;
 use Sentry\Transport\ResultStatus;
 use Sentry\Transport\TransportInterface;
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
 $vendor = __DIR__;
 
 while (!file_exists($vendor . '/vendor')) {
@@ -31,8 +33,6 @@ while (!file_exists($vendor . '/vendor')) {
 }
 
 require $vendor . '/vendor/autoload.php';
-
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 $options = new Options([
     'dsn' => 'http://public@example.com/sentry/1',

--- a/tests/phpt-oom/php84/out_of_memory_fatal_error_increases_memory_limit.phpt
+++ b/tests/phpt-oom/php84/out_of_memory_fatal_error_increases_memory_limit.phpt
@@ -2,7 +2,7 @@
 Test that when handling a out of memory error the memory limit is increased with 5 MiB and the event is serialized and ready to be sent
 --SKIPIF--
 <?php
-if (PHP_VERSION_ID >= 80400) {
+if (PHP_VERSION_ID >= 80500) {
     die('skip - only works for PHP 8.4 and below');
 }
 --INI--

--- a/tests/phpt-oom/php84/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
+++ b/tests/phpt-oom/php84/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
@@ -25,6 +25,8 @@ use Sentry\Transport\Result;
 use Sentry\Transport\ResultStatus;
 use Sentry\Transport\TransportInterface;
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
 $vendor = __DIR__;
 
 while (!file_exists($vendor . '/vendor')) {
@@ -32,8 +34,6 @@ while (!file_exists($vendor . '/vendor')) {
 }
 
 require $vendor . '/vendor/autoload.php';
-
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 $options = new Options([
     'dsn' => 'http://public@example.com/sentry/1',

--- a/tests/phpt-oom/php84/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
+++ b/tests/phpt-oom/php84/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
@@ -2,7 +2,7 @@
 Test that when handling an OOM error with large breadcrumbs, breadcrumb metadata is stripped to prevent secondary OOM during serialization
 --SKIPIF--
 <?php
-if (PHP_VERSION_ID >= 80400) {
+if (PHP_VERSION_ID >= 80500) {
     die('skip - only works for PHP 8.4 and below');
 }
 --INI--

--- a/tests/phpt-oom/php84/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
+++ b/tests/phpt-oom/php84/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
@@ -1,0 +1,104 @@
+--TEST--
+Test that when handling an OOM error with large breadcrumbs, breadcrumb metadata is stripped to prevent secondary OOM during serialization
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 80400) {
+    die('skip - only works for PHP 8.4 and below');
+}
+--INI--
+memory_limit=67108864
+--FILE--
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use Sentry\Breadcrumb;
+use Sentry\ClientBuilder;
+use Sentry\Event;
+use Sentry\Options;
+use Sentry\SentrySdk;
+use Sentry\Serializer\PayloadSerializer;
+use Sentry\Serializer\PayloadSerializerInterface;
+use Sentry\Transport\Result;
+use Sentry\Transport\ResultStatus;
+use Sentry\Transport\TransportInterface;
+
+$vendor = __DIR__;
+
+while (!file_exists($vendor . '/vendor')) {
+    $vendor = \dirname($vendor);
+}
+
+require $vendor . '/vendor/autoload.php';
+
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
+$options = new Options([
+    'dsn' => 'http://public@example.com/sentry/1',
+]);
+
+$transport = new class(new PayloadSerializer($options)) implements TransportInterface {
+    private $payloadSerializer;
+
+    public function __construct(PayloadSerializerInterface $payloadSerializer)
+    {
+        $this->payloadSerializer = $payloadSerializer;
+    }
+
+    public function send(Event $event): Result
+    {
+        $breadcrumbs = $event->getBreadcrumbs();
+        echo 'Breadcrumb count: ' . \count($breadcrumbs) . \PHP_EOL;
+
+        if (\count($breadcrumbs) > 0) {
+            $firstBreadcrumb = $breadcrumbs[0];
+            echo 'First breadcrumb category: ' . $firstBreadcrumb->getCategory() . \PHP_EOL;
+            echo 'First breadcrumb has metadata: ' . (empty($firstBreadcrumb->getMetadata()) ? 'no' : 'yes') . \PHP_EOL;
+        }
+
+        $serialized = $this->payloadSerializer->serialize($event);
+
+        echo 'Transport called' . \PHP_EOL;
+
+        return new Result(ResultStatus::success());
+    }
+
+    public function close(?int $timeout = null): Result
+    {
+        return new Result(ResultStatus::success());
+    }
+};
+
+$options->setTransport($transport);
+
+$client = (new ClientBuilder($options))->getClient();
+
+SentrySdk::init()->bindClient($client);
+
+// Add 100 breadcrumbs with ~100KB metadata each to simulate the real-world scenario
+$hub = SentrySdk::getCurrentHub();
+$hub->configureScope(function (\Sentry\State\Scope $scope): void {
+    for ($i = 0; $i < 100; ++$i) {
+        $scope->addBreadcrumb(new Breadcrumb(
+            Breadcrumb::LEVEL_INFO,
+            Breadcrumb::TYPE_DEFAULT,
+            'db.query',
+            'SELECT * FROM large_table WHERE id = ?',
+            ['bindings' => str_repeat('x', 100 * 1024)]
+        ));
+    }
+});
+
+// Trigger OOM - the remaining memory after breadcrumbs is limited
+$array = [];
+for ($i = 0; $i < 100000000; ++$i) {
+    $array[] = 'sentry';
+}
+--EXPECTF--
+Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line %d
+Breadcrumb count: 100
+First breadcrumb category: db.query
+First breadcrumb has metadata: no
+Transport called

--- a/tests/phpt-oom/php85/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
+++ b/tests/phpt-oom/php85/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
@@ -25,6 +25,8 @@ use Sentry\Transport\Result;
 use Sentry\Transport\ResultStatus;
 use Sentry\Transport\TransportInterface;
 
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
+
 $vendor = __DIR__;
 
 while (!file_exists($vendor . '/vendor')) {
@@ -32,8 +34,6 @@ while (!file_exists($vendor . '/vendor')) {
 }
 
 require $vendor . '/vendor/autoload.php';
-
-error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED);
 
 $options = new Options([
     'dsn' => 'http://public@example.com/sentry/1',

--- a/tests/phpt-oom/php85/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
+++ b/tests/phpt-oom/php85/out_of_memory_with_large_breadcrumbs_strips_metadata.phpt
@@ -2,8 +2,8 @@
 Test that when handling an OOM error with large breadcrumbs, breadcrumb metadata is stripped to prevent secondary OOM during serialization
 --SKIPIF--
 <?php
-if (PHP_VERSION_ID >= 80400) {
-    die('skip - only works for PHP 8.4 and below');
+if (PHP_VERSION_ID < 80500) {
+    die('skip - only works for PHP 8.5 and above');
 }
 --INI--
 memory_limit=67108864
@@ -98,6 +98,8 @@ for ($i = 0; $i < 100000000; ++$i) {
 }
 --EXPECTF--
 Fatal error: Allowed memory size of %d bytes exhausted (tried to allocate %d bytes) in %s on line %d
+Stack trace:
+%A
 Breadcrumb count: 100
 First breadcrumb category: db.query
 First breadcrumb has metadata: no


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-laravel/issues/909

When an out-of-memory error occurs with large breadcrumbs (e.g. 100 SQL queries with ~100KB bindings each), the event is silently lost. Serialization needs ~15MB of working memory but only 5MB headroom is available after ErrorHandler raises the limit. The secondary OOM during `json_encode` is caught by `invokeListeners()` and discarded.

This fix detects OOM in `FatalErrorListenerIntegration` and strips breadcrumb metadata before capture — freeing the bulk of the memory while preserving the full breadcrumb trail (type, category, timestamp, message) for debugging.

## Design decisions

**Why strip metadata instead of clearing all breadcrumbs?** The breadcrumb timeline (which queries ran, in what order) is valuable for diagnosing OOM. The metadata (SQL bindings, HTTP bodies) is what carries the bulk (~99% of size) and is rarely needed for OOM diagnosis.

**Why in the integration, not ErrorHandler or PayloadSerializer?** The integration already has access to the exception message for OOM detection. Putting it in ErrorHandler would couple the low-level handler to Hub/Scope. Catching OOM in the serializer is unreliable since PHP's nested try/catch behavior during OOM is fragile.

**Why modify the scope directly instead of using an event processor?** The scope's breadcrumb objects hold references to the large metadata strings. These must be freed from PHP's heap *before* serialization to make room. An event processor runs after `applyToEvent` copies breadcrumbs to the event — by then the scope still holds the originals in memory and the headroom is already consumed.

**Why add `Scope::getBreadcrumbs()`?** We need to read the breadcrumbs to build stripped copies before clearing. The scope had no getter — `addBreadcrumb` and `clearBreadcrumbs` existed but you couldn't iterate the collection.

🤖 Generated with Claude Code