### PR TITLE
feat: add nested option support

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -1548,7 +1548,11 @@ final class Options
      */
     public function updateOptions(array $override = []): self
     {
-        $resolved = $this->resolver->resolveOnly($override, $this->getLoggerOrNullLogger($override));
+        $resolved = $this->resolver->resolveOnly(
+            $override,
+            $this->options,
+            $this->getLoggerOrNullLogger($override)
+        );
 
         $this->options = array_merge($this->options, $resolved);
 

--- a/src/OptionsResolver.php
+++ b/src/OptionsResolver.php
@@ -5,7 +5,25 @@ declare(strict_types=1);
 namespace Sentry;
 
 use Psr\Log\LoggerInterface;
+use Sentry\Util\Arr;
 
+/**
+ * A container that declares defaults and allows validation and normalization in a central place.
+ * When a value fails validation, it will instead fall back to the default value and emit debug logs.
+ *
+ * Supports a nested config with arbitrary number of layers.
+ *
+ * To set validation on nested values, it's possible to use a . (dot) syntax, similar to how JSON can be traversed.
+ * For example, using 'foo.bar' will refer to
+ * 'foo' => [
+ *     'bar' => 'test'
+ * ]
+ *
+ * Dot syntax is generally available to set validators and normalizers, while defaults are specified using
+ * the real array shape
+ *
+ * @internal
+ */
 class OptionsResolver
 {
     /**
@@ -17,23 +35,24 @@ class OptionsResolver
     private $defaults = [];
 
     /**
-     * List of allowed types for each top level array key.
+     * List of all allowed types for a path. Stored using dot syntax.
      *
      * @var array<string, string[]>
      */
     private $allowedTypes = [];
 
     /**
-     * List of valid values or a validation callback for each top level array key.
+     * List of valid values or a validation callback for each option path.
+     * Stored using dot syntax.
      *
-     * @var array<string, mixed[]|callable>
+     * @var array<string, mixed[]|callable|bool|float|int|string|null>
      */
     private $allowedValues = [];
 
     /**
-     * Stores normalizers for each top level array key. Normalizers are executed for defaults and user provided options.
+     * Stores normalizers for each option path. Stored using dot syntax.
      *
-     * @var array<callable>
+     * @var array<string, callable>
      */
     private $normalizers = [];
 
@@ -42,14 +61,7 @@ class OptionsResolver
      */
     public function setDefaults(array $defaults): void
     {
-        $processed = [];
-
-        foreach (array_keys($defaults) as $option) {
-            $validation = $this->normalizeAndValidate($option, $defaults[$option]);
-            $processed[$option] = $validation[0] ? $validation[1] : null;
-        }
-
-        $this->defaults = $processed;
+        $this->defaults = $this->processDefaults($defaults, '');
     }
 
     /**
@@ -57,8 +69,7 @@ class OptionsResolver
      */
     public function setDefault(string $name, $value): void
     {
-        $validation = $this->normalizeAndValidate($name, $value);
-        $this->defaults[$name] = $validation[0] ? $validation[1] : null;
+        $this->defaults[$name] = $this->processDefaults([$name => $value], '')[$name];
     }
 
     /**
@@ -90,7 +101,7 @@ class OptionsResolver
     }
 
     /**
-     * @param mixed[]|callable $values
+     * @param mixed[]|callable|bool|float|int|string|null $values
      */
     public function setAllowedValues(string $path, $values): void
     {
@@ -115,43 +126,113 @@ class OptionsResolver
      */
     public function resolve(array $options = [], ?LoggerInterface $logger = null): array
     {
-        return array_merge($this->defaults, $this->resolveOnly($options, $logger));
+        return array_merge($this->defaults, $this->resolveOnly($options, [], $logger));
     }
 
     /**
-     * Resolves passed options against the defaults but in contrast to {@see self::resolve}, it will not merge
-     * defaults into the result. This means that the returning array will always be equal or smaller than
-     * the input array.
+     * Resolves only the options passed as $override and all nested keys that belong to it.
      *
+     * @param array<string, mixed> $override
      * @param array<string, mixed> $options
      *
      * @return array<string, mixed>
      */
-    public function resolveOnly(array $options = [], ?LoggerInterface $logger = null): array
+    public function resolveOnly(
+        array $override = [],
+        array $options = [],
+        ?LoggerInterface $logger = null
+    ): array {
+        return $this->applyOptions(array_intersect_key($options, $override), $this->defaults, $override, '', $logger);
+    }
+
+    /**
+     * @param array<string, mixed> $defaults
+     *
+     * @return array<string, mixed>
+     */
+    private function processDefaults(array $defaults, string $parentPath): array
     {
-        $result = [];
+        /** @mago-ignore analysis:mixed-assignment */
+        foreach ($defaults as $option => $value) {
+            $path = $parentPath === '' ? $option : $parentPath . '.' . $option;
+            /** @mago-ignore analysis:mixed-assignment */
+            [$isValid, $processed] = $this->normalizeAndValidate($path, $value);
 
-        foreach (array_keys($options) as $option) {
-            if (!\array_key_exists($option, $this->defaults)) {
-                if ($logger !== null) {
-                    $logger->debug(\sprintf('Option "%s" does not exist and will be ignored', $option));
-                }
-                continue;
+            if (!$isValid) {
+                $defaults[$option] = null;
+            } elseif (!Arr::isAssociative($processed)) {
+                $defaults[$option] = $processed;
+            } else {
+                /** @var array<string, mixed> $processed */
+                $defaults[$option] = $this->processDefaults($processed, $path);
             }
-
-            $validation = $this->normalizeAndValidate($option, $options[$option]);
-            if (!$validation[0]) {
-                if ($logger !== null) {
-                    $logger->debug(\sprintf('Invalid value for option "%s". Using default value.', $option));
-                }
-                $result[$option] = $this->defaults[$option];
-                continue;
-            }
-
-            $result[$option] = $validation[1];
         }
 
-        return $result;
+        return $defaults;
+    }
+
+    /**
+     * @param array<string, mixed> $resolved
+     * @param array<string, mixed> $defaults
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     */
+    private function applyOptions(
+        array $resolved,
+        array $defaults,
+        array $options,
+        string $parentPath,
+        ?LoggerInterface $logger
+    ): array {
+        /** @mago-ignore analysis:mixed-assignment */
+        foreach ($options as $option => $value) {
+            $path = $parentPath === '' ? $option : $parentPath . '.' . $option;
+
+            if (!\array_key_exists($option, $defaults)) {
+                if ($logger !== null) {
+                    $logger->debug(\sprintf('Option "%s" does not exist and will be ignored', $path));
+                }
+
+                continue;
+            }
+
+            /** @mago-ignore analysis:mixed-assignment */
+            $default = $defaults[$option];
+            $isBranch = Arr::isAssociative($default);
+            /** @mago-ignore analysis:mixed-assignment */
+            [$isValid, $value] = $this->normalizeAndValidate($path, $value);
+
+            // If the value is invalid or the value is not in the correct shape, we fall back to the default.
+            // For example, we expected to receive a nested value, but we got a scalar
+            if (!$isValid || ($isBranch && !\is_array($value))) {
+                if ($logger !== null) {
+                    $logger->debug(\sprintf('Invalid value for option "%s". Using default value.', $path));
+                }
+
+                $resolved[$option] = $default;
+
+                continue;
+            }
+
+            if (!$isBranch) {
+                $resolved[$option] = $value;
+
+                continue;
+            }
+
+            $base = $resolved[$option] ?? null;
+            if (!\is_array($base)) {
+                $base = $default;
+            }
+
+            /** @var array<string, mixed> $default */
+            /** @var array<string, mixed> $base */
+            /** @var array<string, mixed> $value */
+            $resolved[$option] = $this->applyOptions($base, $default, $value, $path, $logger);
+        }
+
+        return $resolved;
     }
 
     /**
@@ -276,8 +357,13 @@ class OptionsResolver
         if ($allowedValue === null) {
             return true;
         }
+
         if (\is_callable($allowedValue)) {
             return $allowedValue($value) === true;
+        }
+
+        if (!\is_array($allowedValue)) {
+            return $value === $allowedValue;
         }
 
         return \in_array($value, $allowedValue, true);

--- a/src/OptionsResolver.php
+++ b/src/OptionsResolver.php
@@ -9,7 +9,8 @@ use Sentry\Util\Arr;
 
 /**
  * A container that declares defaults and allows validation and normalization in a central place.
- * When a value fails validation, it will instead fall back to the default value and emit debug logs.
+ * When a value fails validation, it will keep the current value (or fall back to the default value if there is no
+ * current value) and emit debug logs.
  *
  * Supports a nested config with arbitrary number of layers.
  *
@@ -203,14 +204,17 @@ class OptionsResolver
             /** @mago-ignore analysis:mixed-assignment */
             [$isValid, $value] = $this->normalizeAndValidate($path, $value);
 
-            // If the value is invalid or the value is not in the correct shape, we fall back to the default.
+            // If the value is invalid or the value is not in the correct shape, keep the current value if one exists.
+            // Otherwise, fall back to the default.
             // For example, we expected to receive a nested value, but we got a scalar
             if (!$isValid || ($isBranch && !\is_array($value))) {
                 if ($logger !== null) {
-                    $logger->debug(\sprintf('Invalid value for option "%s". Using default value.', $path));
+                    $logger->debug(\sprintf('Invalid value for option "%s". The value has been ignored.', $path));
                 }
 
-                $resolved[$option] = $default;
+                if (!\array_key_exists($option, $resolved)) {
+                    $resolved[$option] = $default;
+                }
 
                 continue;
             }

--- a/src/Util/Arr.php
+++ b/src/Util/Arr.php
@@ -49,7 +49,7 @@ class Arr
      *
      * @see https://www.php.net/manual/en/function.array-is-list.php#126794
      *
-     * @param array<string, mixed> $array
+     * @param array<array-key, mixed> $array
      */
     public static function isList(array $array): bool
     {
@@ -62,5 +62,15 @@ class Arr
         }
 
         return true;
+    }
+
+    /**
+     * Checks whether a given value is an associative array.
+     *
+     * @param mixed $value
+     */
+    public static function isAssociative($value): bool
+    {
+        return \is_array($value) && !self::isList($value);
     }
 }

--- a/tests/OptionResolverTest.php
+++ b/tests/OptionResolverTest.php
@@ -64,11 +64,11 @@ class OptionResolverTest extends TestCase
         $this->assertEquals(['foo' => ['php'], 'a' => 'b'], $result);
     }
 
-    public function testEmptyDefaultArrayIsReplaced()
+    public function testEmptyDefaultArrayIsReplaced(): void
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'empty' => []
+            'empty' => [],
         ]);
 
         $result = $resolver->resolve([
@@ -78,14 +78,14 @@ class OptionResolverTest extends TestCase
         $this->assertSame(['empty' => ['not' => 'empty']], $result);
     }
 
-    public function testRegularArrayIsReplaced()
+    public function testRegularArrayIsReplaced(): void
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'list' => ['abc', 'efg']
+            'list' => ['abc', 'efg'],
         ]);
         $result = $resolver->resolve([
-            'list' => ['foo']
+            'list' => ['foo'],
         ]);
         $this->assertSame(['list' => ['foo']], $result);
     }
@@ -130,8 +130,8 @@ class OptionResolverTest extends TestCase
             'foo' => [
                 'bar' => [
                     'baz' => '   abc   ',
-                ]
-            ]
+                ],
+            ],
         ]);
 
         $this->assertSame([
@@ -152,7 +152,7 @@ class OptionResolverTest extends TestCase
 
         $result = $resolver->resolveOnly([
             'known' => null,
-            'missing' => null
+            'missing' => null,
         ], [], $logger);
 
         $this->assertSame(['known' => null], $result);
@@ -217,6 +217,38 @@ class OptionResolverTest extends TestCase
         $this->assertSame(0, $normalizerCalls);
     }
 
+    public function testResolveOnlyKeepsCurrentValueWhenOverrideIsInvalid(): void
+    {
+        $logger = StubLogger::getInstance();
+        $resolver = new OptionsResolver();
+        $resolver->setAllowedTypes('foo.bar.baz', 'string');
+        $resolver->setDefaults([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'default',
+                ],
+            ],
+        ]);
+        $currentOptions = [
+            'foo' => [
+                'bar' => [
+                    'baz' => 'current',
+                ],
+            ],
+        ];
+
+        $result = $this->resolvePartialUpdate($resolver, $currentOptions, [
+            'foo' => ['bar' => ['baz' => 42]],
+        ], $logger);
+
+        $this->assertSame($currentOptions, $result);
+        $this->assertSame([[
+            'level' => 'debug',
+            'message' => 'Invalid value for option "foo.bar.baz". The value has been ignored.',
+            'context' => [],
+        ]], StubLogger::$logs);
+    }
+
     public function testNestedValidationLogsFullOptionPaths(): void
     {
         $logger = StubLogger::getInstance();
@@ -258,7 +290,7 @@ class OptionResolverTest extends TestCase
             ],
             [
                 'level' => 'debug',
-                'message' => 'Invalid value for option "foo.bar.baz". Using default value.',
+                'message' => 'Invalid value for option "foo.bar.baz". The value has been ignored.',
                 'context' => [],
             ],
         ], StubLogger::$logs);
@@ -284,7 +316,7 @@ class OptionResolverTest extends TestCase
         ], $result);
         $this->assertSame([[
             'level' => 'debug',
-            'message' => 'Invalid value for option "foo". Using default value.',
+            'message' => 'Invalid value for option "foo". The value has been ignored.',
             'context' => [],
         ]], StubLogger::$logs);
     }
@@ -312,7 +344,7 @@ class OptionResolverTest extends TestCase
         ], $result);
         $this->assertSame([[
             'level' => 'debug',
-            'message' => 'Invalid value for option "foo.bar.baz". Using default value.',
+            'message' => 'Invalid value for option "foo.bar.baz". The value has been ignored.',
             'context' => [],
         ]], StubLogger::$logs);
     }
@@ -608,7 +640,7 @@ class OptionResolverTest extends TestCase
             ],
             [
                 'level' => 'debug',
-                'message' => 'Invalid value for option "test". Using default value.',
+                'message' => 'Invalid value for option "test". The value has been ignored.',
                 'context' => [],
             ],
         ], StubLogger::$logs);
@@ -637,7 +669,7 @@ class OptionResolverTest extends TestCase
             ],
             [
                 'level' => 'debug',
-                'message' => 'Invalid value for option "test". Using default value.',
+                'message' => 'Invalid value for option "test". The value has been ignored.',
                 'context' => [],
             ],
         ], StubLogger::$logs);

--- a/tests/OptionResolverTest.php
+++ b/tests/OptionResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Tests;
 
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sentry\OptionsResolver;
 
 class OptionResolverTest extends TestCase
@@ -31,9 +32,28 @@ class OptionResolverTest extends TestCase
     public function testNestedOptionResolve(): void
     {
         $resolver = new OptionsResolver();
-        $resolver->setDefaults(['foo' => ['bar' => 'baz'], 'a' => 'b']);
-        $result = $resolver->resolve(['foo' => ['bar' => 'test']]);
-        $this->assertEquals(['foo' => ['bar' => 'test'], 'a' => 'b'], $result);
+        $resolver->setDefaults([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'abc',
+                    'example' => 'sweet',
+                ],
+            ],
+            'a' => 'b',
+        ]);
+
+        $result = $resolver->resolve([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'hello',
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            'foo' => ['bar' => ['baz' => 'hello', 'example' => 'sweet']],
+            'a' => 'b',
+        ], $result);
     }
 
     public function testArrayValues(): void
@@ -42,6 +62,276 @@ class OptionResolverTest extends TestCase
         $resolver->setDefaults(['foo' => ['bar', 'baz'], 'a' => 'b']);
         $result = $resolver->resolve(['foo' => ['php'], 'a' => 'b']);
         $this->assertEquals(['foo' => ['php'], 'a' => 'b'], $result);
+    }
+
+    public function testEmptyDefaultArrayIsReplaced()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'empty' => []
+        ]);
+
+        $result = $resolver->resolve([
+            'empty' => ['not' => 'empty'],
+        ]);
+
+        $this->assertSame(['empty' => ['not' => 'empty']], $result);
+    }
+
+    public function testRegularArrayIsReplaced()
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'list' => ['abc', 'efg']
+        ]);
+        $result = $resolver->resolve([
+            'list' => ['foo']
+        ]);
+        $this->assertSame(['list' => ['foo']], $result);
+    }
+
+    public function testDefaultsAreNormalizedInSubtree(): void
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setNormalizer('foo.bar.baz', static function (string $value): string {
+            return trim($value);
+        });
+        $resolver->setDefault('foo', ['bar' => ['baz' => '   abc   ', 'example' => '   sweet   ']]);
+
+        $result = $resolver->resolve();
+
+        $this->assertSame([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'abc',
+                    'example' => '   sweet   ',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function testNormalizerIsAppliedInSubtree(): void
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setAllowedTypes('foo.bar.baz', 'string');
+        $resolver->setNormalizer('foo.bar.baz', static function (string $value): string {
+            return trim($value);
+        });
+        $resolver->setDefaults([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'foo',
+                    'example' => 'sweet',
+                ],
+            ],
+        ]);
+
+        $result = $resolver->resolve([
+            'foo' => [
+                'bar' => [
+                    'baz' => '   abc   ',
+                ]
+            ]
+        ]);
+
+        $this->assertSame([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'abc',
+                    'example' => 'sweet',
+                ],
+            ],
+        ], $result);
+    }
+
+    public function testNullIsValidDefault(): void
+    {
+        $logger = StubLogger::getInstance();
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults(['known' => null]);
+
+        $result = $resolver->resolveOnly([
+            'known' => null,
+            'missing' => null
+        ], [], $logger);
+
+        $this->assertSame(['known' => null], $result);
+        $this->assertSame([[
+            'level' => 'debug',
+            'message' => 'Option "missing" does not exist and will be ignored',
+            'context' => [],
+        ]], StubLogger::$logs);
+    }
+
+    public function testResolveOnlyReplacesArrayValues(): void
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'foo' => [
+                'map' => [],
+            ],
+        ]);
+        $currentOptions = [
+            'foo' => [
+                'map' => ['old' => 'value'],
+            ],
+        ];
+
+        $result = $this->resolvePartialUpdate($resolver, $currentOptions, [
+            'foo' => ['map' => ['new' => 'value']],
+        ]);
+
+        $this->assertSame([
+            'foo' => [
+                'map' => ['new' => 'value'],
+            ],
+        ], $result);
+    }
+
+    public function testResolveOnlyDoesNotNormalizeOmittedValues(): void
+    {
+        $normalizerCalls = 0;
+        $resolver = new OptionsResolver();
+        $resolver->setNormalizer('foo.bar.example', static function (string $value) use (&$normalizerCalls): string {
+            ++$normalizerCalls;
+
+            return $value;
+        });
+        $resolver->setDefaults([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'abc',
+                    'example' => 'sweet',
+                ],
+            ],
+        ]);
+        $normalizerCalls = 0;
+
+        $result = $resolver->resolveOnly([
+            'foo' => ['bar' => ['baz' => 'hello']],
+        ]);
+
+        $this->assertSame([
+            'foo' => ['bar' => ['baz' => 'hello', 'example' => 'sweet']],
+        ], $result);
+        $this->assertSame(0, $normalizerCalls);
+    }
+
+    public function testNestedValidationLogsFullOptionPaths(): void
+    {
+        $logger = StubLogger::getInstance();
+        $resolver = new OptionsResolver();
+        $resolver->setAllowedTypes('foo.bar.baz', 'string');
+        $resolver->setDefaults([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'abc',
+                    'example' => 'sweet',
+                ],
+            ],
+        ]);
+
+        $result = $resolver->resolve([
+            'foo' => [
+                'bar' => [
+                    0 => 'ignored',
+                    'unknown' => 'ignored',
+                    'baz' => 42,
+                    'example' => 'tart',
+                ],
+            ],
+        ], $logger);
+
+        $this->assertSame([
+            'foo' => ['bar' => ['baz' => 'abc', 'example' => 'tart']],
+        ], $result);
+        $this->assertSame([
+            [
+                'level' => 'debug',
+                'message' => 'Option "foo.bar.0" does not exist and will be ignored',
+                'context' => [],
+            ],
+            [
+                'level' => 'debug',
+                'message' => 'Option "foo.bar.unknown" does not exist and will be ignored',
+                'context' => [],
+            ],
+            [
+                'level' => 'debug',
+                'message' => 'Invalid value for option "foo.bar.baz". Using default value.',
+                'context' => [],
+            ],
+        ], StubLogger::$logs);
+    }
+
+    public function testNestedSchemaFallsBackWhenPassedValueIsNotAnArray(): void
+    {
+        $logger = StubLogger::getInstance();
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'foo' => [
+                'bar' => [
+                    'baz' => 'abc',
+                    'example' => 'sweet',
+                ],
+            ],
+        ]);
+
+        $result = $resolver->resolve(['foo' => 'invalid'], $logger);
+
+        $this->assertSame([
+            'foo' => ['bar' => ['baz' => 'abc', 'example' => 'sweet']],
+        ], $result);
+        $this->assertSame([[
+            'level' => 'debug',
+            'message' => 'Invalid value for option "foo". Using default value.',
+            'context' => [],
+        ]], StubLogger::$logs);
+    }
+
+    public function testAllowedValuesAcceptsScalarAtNestedPath(): void
+    {
+        $logger = StubLogger::getInstance();
+        $resolver = new OptionsResolver();
+        $resolver->setAllowedValues('foo.bar.baz', 'abc');
+        $resolver->setDefaults([
+            'foo' => ['bar' => ['baz' => 'abc']],
+        ]);
+
+        $result = $resolver->resolve(['foo' => ['bar' => ['baz' => 'abc']]], $logger);
+
+        $this->assertSame([
+            'foo' => ['bar' => ['baz' => 'abc']],
+        ], $result);
+        $this->assertSame([], StubLogger::$logs);
+
+        $result = $resolver->resolve(['foo' => ['bar' => ['baz' => 'def']]], $logger);
+
+        $this->assertSame([
+            'foo' => ['bar' => ['baz' => 'abc']],
+        ], $result);
+        $this->assertSame([[
+            'level' => 'debug',
+            'message' => 'Invalid value for option "foo.bar.baz". Using default value.',
+            'context' => [],
+        ]], StubLogger::$logs);
+    }
+
+    public function testNullAllowedValueDisablesNestedValueValidation(): void
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setAllowedValues('foo.bar', null);
+        $resolver->setDefaults([
+            'foo' => ['bar' => null],
+        ]);
+
+        $result = $resolver->resolve([
+            'foo' => ['bar' => 'custom'],
+        ]);
+
+        $this->assertSame([
+            'foo' => ['bar' => 'custom'],
+        ], $result);
     }
 
     public function testAllowedTypeIntValid(): void
@@ -331,14 +621,14 @@ class OptionResolverTest extends TestCase
         $resolver->setAllowedValues('test', ['foo']);
         $resolver->setDefaults(['test' => 'foo', 'abc' => 'def', 'bar' => 'baz']);
 
-        $resolver->resolveOnly(['example' => 'test'], $logger);
+        $resolver->resolveOnly(['example' => 'test'], [], $logger);
         $this->assertSame([[
             'level' => 'debug',
             'message' => 'Option "example" does not exist and will be ignored',
             'context' => [],
         ]], StubLogger::$logs);
 
-        $resolver->resolveOnly(['test' => 'abc'], $logger);
+        $resolver->resolveOnly(['test' => 'abc'], [], $logger);
         $this->assertSame([
             [
                 'level' => 'debug',
@@ -351,5 +641,22 @@ class OptionResolverTest extends TestCase
                 'context' => [],
             ],
         ], StubLogger::$logs);
+    }
+
+    /**
+     * @param array<string, mixed> $currentOptions
+     * @param array<string, mixed> $override
+     *
+     * @return array<string, mixed>
+     */
+    private function resolvePartialUpdate(
+        OptionsResolver $resolver,
+        array $currentOptions,
+        array $override,
+        ?LoggerInterface $logger = null
+    ): array {
+        $resolved = $resolver->resolveOnly($override, $currentOptions, $logger);
+
+        return array_merge($currentOptions, $resolved);
     }
 }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -922,10 +922,12 @@ final class OptionsTest extends TestCase
 
         $options->updateOptions(['tags' => ['invalid' => 42]]);
 
-        $this->assertSame([], $options->getTags());
+        $this->assertSame([
+            'environment' => 'staging',
+        ], $options->getTags());
     }
 
-    public function testUpdateOptionsLogsInvalidValuesAndFallsBackToDefault(): void
+    public function testUpdateOptionsLogsInvalidValuesAndKeepsCurrentValue(): void
     {
         $logger = StubLogger::getInstance();
 
@@ -937,11 +939,11 @@ final class OptionsTest extends TestCase
 
         $options->updateOptions(['sample_rate' => 'invalid']);
 
-        $this->assertSame(1.0, $options->getSampleRate());
+        $this->assertSame(0.5, $options->getSampleRate());
         $this->assertSame('custom', $options->getEnvironment());
         $this->assertSame([[
             'level' => 'debug',
-            'message' => 'Invalid value for option "sample_rate". Using default value.',
+            'message' => 'Invalid value for option "sample_rate". The value has been ignored.',
             'context' => [],
         ]], StubLogger::$logs);
     }

--- a/tests/OptionsTest.php
+++ b/tests/OptionsTest.php
@@ -900,6 +900,31 @@ final class OptionsTest extends TestCase
         ];
     }
 
+    public function testTagsAreValidatedAndReplacedAsOneAssociativeArray(): void
+    {
+        $options = new Options([
+            'tags' => [
+                'environment' => 'production',
+                'release' => '1.0',
+            ],
+        ]);
+
+        $this->assertSame([
+            'environment' => 'production',
+            'release' => '1.0',
+        ], $options->getTags());
+
+        $options->setTags(['environment' => 'staging']);
+
+        $this->assertSame([
+            'environment' => 'staging',
+        ], $options->getTags());
+
+        $options->updateOptions(['tags' => ['invalid' => 42]]);
+
+        $this->assertSame([], $options->getTags());
+    }
+
     public function testUpdateOptionsLogsInvalidValuesAndFallsBackToDefault(): void
     {
         $logger = StubLogger::getInstance();
@@ -907,11 +932,13 @@ final class OptionsTest extends TestCase
         $options = new Options([
             'logger' => $logger,
             'sample_rate' => 0.5,
+            'environment' => 'custom',
         ]);
 
         $options->updateOptions(['sample_rate' => 'invalid']);
 
         $this->assertSame(1.0, $options->getSampleRate());
+        $this->assertSame('custom', $options->getEnvironment());
         $this->assertSame([[
             'level' => 'debug',
             'message' => 'Invalid value for option "sample_rate". Using default value.',

--- a/tests/Util/ArrTest.php
+++ b/tests/Util/ArrTest.php
@@ -78,23 +78,39 @@ final class ArrTest extends TestCase
 
     /**
      * @dataProvider isListDataProvider
+     *
+     * @param mixed $value
      */
-    public function testIsList(array $value, bool $expectedResult): void
+    public function testIsList($value, bool $expectedResult): void
     {
         $this->assertSame($expectedResult, Arr::isList($value));
+        $this->assertSame(\is_array($value) && !$expectedResult, Arr::isAssociative($value));
     }
 
     public static function isListDataProvider(): \Generator
     {
-        yield [
+        yield 'empty array' => [
+            [],
+            true,
+        ];
+
+        yield 'list' => [
             [1, 2, 3],
             true,
         ];
 
-        yield [
-            [
-                'key' => 'value',
-            ],
+        yield 'associative array' => [
+            ['key' => 'value'],
+            false,
+        ];
+
+        yield 'sparse integer keys' => [
+            [2 => 'value'],
+            false,
+        ];
+
+        yield 'mixed keys' => [
+            [0 => 'value', 'key' => 'value'],
             false,
         ];
     }


### PR DESCRIPTION
Adds support for nested options through the OptionsResolver. It supports specifying defaults using nested array syntax, for example
```php
$resolver->setDefaults([
    'foo' => [
        'bar' => 'baz',
        'test' => [
            'example' => '1234'
        ],
    ],
]);
```

Specifying the defaults will also register them as a schema, meaning that setting values that don't have defaults are rejected and log messages are emitted that they have been rejected.

To specify allowed values/types or normalizers, it's possible to use . (dots) as separators, for example:
```php
$resolver->setAllowedTypes('foo.test.example', 'string');

$resolver->setAllowedValues('foo.bar', ['baz']);
```

When setting an invalid value, it will either use the defaults if no other value exists or will fall back to the existing value