### PR TITLE
perf: stacktrace builder improvements

### DIFF
--- a/src/FrameBuilder.php
+++ b/src/FrameBuilder.php
@@ -131,11 +131,16 @@ final class FrameBuilder
 
         $excludedAppPaths = $this->options->getInAppExcludedPaths();
         $includedAppPaths = $this->options->getInAppIncludedPaths();
+
+        if ($excludedAppPaths === [] && $includedAppPaths === []) {
+            return true;
+        }
+
         $absoluteFilePath = @realpath($file) ?: $file;
         $isInApp = true;
 
         foreach ($excludedAppPaths as $excludedAppPath) {
-            if (mb_substr($absoluteFilePath, 0, mb_strlen($excludedAppPath)) === $excludedAppPath) {
+            if (strncmp($absoluteFilePath, $excludedAppPath, \strlen($excludedAppPath)) === 0) {
                 $isInApp = false;
 
                 break;
@@ -143,7 +148,7 @@ final class FrameBuilder
         }
 
         foreach ($includedAppPaths as $includedAppPath) {
-            if (mb_substr($absoluteFilePath, 0, mb_strlen($includedAppPath)) === $includedAppPath) {
+            if (strncmp($absoluteFilePath, $includedAppPath, \strlen($includedAppPath)) === 0) {
                 $isInApp = true;
 
                 break;

--- a/src/StacktraceBuilder.php
+++ b/src/StacktraceBuilder.php
@@ -59,15 +59,15 @@ final class StacktraceBuilder
         $frames = [];
 
         foreach ($backtrace as $backtraceFrame) {
-            array_unshift($frames, $this->frameBuilder->buildFromBacktraceFrame($file, $line, $backtraceFrame));
+            $frames[] = $this->frameBuilder->buildFromBacktraceFrame($file, $line, $backtraceFrame);
 
             $file = $backtraceFrame['file'] ?? Frame::INTERNAL_FRAME_FILENAME;
             $line = $backtraceFrame['line'] ?? 0;
         }
 
         // Add a final stackframe for the first method ever of this stacktrace
-        array_unshift($frames, $this->frameBuilder->buildFromBacktraceFrame($file, $line, []));
+        $frames[] = $this->frameBuilder->buildFromBacktraceFrame($file, $line, []);
 
-        return new Stacktrace($frames);
+        return new Stacktrace(array_reverse($frames));
     }
 }

--- a/src/Tracing/DynamicSamplingContext.php
+++ b/src/Tracing/DynamicSamplingContext.php
@@ -131,8 +131,8 @@ final class DynamicSamplingContext
 
             [$key, $value] = explode('=', $keyValue, 2);
 
-            if (mb_substr($key, 0, mb_strlen(self::SENTRY_ENTRY_PREFIX)) === self::SENTRY_ENTRY_PREFIX) {
-                $samplingContext->set(rawurldecode(mb_substr($key, mb_strlen(self::SENTRY_ENTRY_PREFIX))), rawurldecode($value));
+            if (strncmp($key, self::SENTRY_ENTRY_PREFIX, \strlen(self::SENTRY_ENTRY_PREFIX)) === 0) {
+                $samplingContext->set(rawurldecode(substr($key, \strlen(self::SENTRY_ENTRY_PREFIX))), rawurldecode($value));
             }
         }
 

--- a/src/Util/PrefixStripper.php
+++ b/src/Util/PrefixStripper.php
@@ -18,8 +18,10 @@ trait PrefixStripper
         }
 
         foreach ($options->getPrefixes() as $prefix) {
-            if (mb_substr($filePath, 0, mb_strlen($prefix)) === $prefix) {
-                return mb_substr($filePath, mb_strlen($prefix));
+            $prefixLength = \strlen($prefix);
+
+            if (strncmp($filePath, $prefix, $prefixLength) === 0) {
+                return substr($filePath, $prefixLength);
             }
         }
 


### PR DESCRIPTION
Instead of building the stacktrace in the correct order by prepending elements through `array_unshift`, we can just build it fully in reverse order and then reverse it once at the end.

Also replaces `mb_*` occurrences with regular string operations because we don't need the UTF8 check in those cases. We always compare against already configured strings, so we can just compare the bytes directly