### PR TITLE
perf: introduce source code caching to improve duplicate frames

### DIFF
--- a/src/Integration/FrameContextifierIntegration.php
+++ b/src/Integration/FrameContextifierIntegration.php
@@ -26,6 +26,15 @@ final class FrameContextifierIntegration implements IntegrationInterface
     private $logger;
 
     /**
+     * @var array<string, array{
+     *     pre_context: string[],
+     *     context_line: string|null,
+     *     post_context: string[]
+     * }> The excerpts read while processing the current event, keyed by "file:line"
+     */
+    private $excerptCache = [];
+
+    /**
      * Creates a new instance of this integration.
      *
      * @param LoggerInterface|null $logger A PSR-3 logger
@@ -54,16 +63,20 @@ final class FrameContextifierIntegration implements IntegrationInterface
                 return $event;
             }
 
-            $stacktrace = $event->getStacktrace();
+            try {
+                $stacktrace = $event->getStacktrace();
 
-            if ($stacktrace !== null) {
-                $integration->addContextToStacktraceFrames($maxContextLines, $stacktrace);
-            }
-
-            foreach ($event->getExceptions() as $exception) {
-                if ($exception->getStacktrace() !== null) {
-                    $integration->addContextToStacktraceFrames($maxContextLines, $exception->getStacktrace());
+                if ($stacktrace !== null) {
+                    $integration->addContextToStacktraceFrames($maxContextLines, $stacktrace);
                 }
+
+                foreach ($event->getExceptions() as $exception) {
+                    if ($exception->getStacktrace() !== null) {
+                        $integration->addContextToStacktraceFrames($maxContextLines, $exception->getStacktrace());
+                    }
+                }
+            } finally {
+                $integration->excerptCache = [];
             }
 
             return $event;
@@ -122,6 +135,12 @@ final class FrameContextifierIntegration implements IntegrationInterface
      */
     private function getSourceCodeExcerpt(int $maxContextLines, string $filePath, int $lineNumber): array
     {
+        $cacheKey = $filePath . ':' . $lineNumber;
+
+        if (isset($this->excerptCache[$cacheKey])) {
+            return $this->excerptCache[$cacheKey];
+        }
+
         $frame = [
             'pre_context' => [],
             'context_line' => null,
@@ -156,6 +175,8 @@ final class FrameContextifierIntegration implements IntegrationInterface
 
                 $file->next();
             }
+
+            $this->excerptCache[$cacheKey] = $frame;
         } catch (\Throwable $exception) {
             $this->logger->warning(
                 \sprintf('Failed to get the source code excerpt for the file "%s".', $filePath),


### PR DESCRIPTION
Adds a small caching layer while processing stack frames to prevent duplicate file reads.

This change benefits recursive functions as well as laravel stacktraces. Laravel middlewares are resolved through generic closures which will be invoked once per middleware and will yield the exact same stack frames. 
Caching those means that we will have to read it only once and save n-1 reads where n is the number of total middlewares.

Uses more memory for a stacktrace with only distinct frames but uses less memory for duplicated frames since we are not re-creating data but instead they all reference the same array internally