### PR TITLE
feat: add support for guzzlehttp/psr7 and guzzlehttp/promises 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-curl": "*",
-        "guzzlehttp/psr7": "^1.8.4|^2.1.1",
+        "guzzlehttp/psr7": "^1.8.4|^2.1.1|^3.0.0",
         "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
@@ -34,7 +34,8 @@
     "require-dev": {
         "carthage-software/mago": "1.30.0",
         "friendsofphp/php-cs-fixer": "^3.4",
-        "guzzlehttp/promises": "^2.0.3",
+        "guzzlehttp/guzzle": "^7.0|^8.0",
+        "guzzlehttp/promises": "^2.0.3|^3.0.0",
         "monolog/monolog": "^1.6|^2.0|^3.0",
         "nyholm/psr7": "^1.8",
         "open-telemetry/api": "^1.1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -281,16 +281,6 @@ parameters:
 			path: src/Serializer/AbstractSerializer.php
 
 		-
-			message: "#^Call to method getResponse\\(\\) on an unknown class GuzzleHttp\\\\Exception\\\\RequestException\\.$#"
-			count: 1
-			path: src/Tracing/GuzzleTracingMiddleware.php
-
-		-
-			message: "#^Class GuzzleHttp\\\\Exception\\\\RequestException not found\\.$#"
-			count: 1
-			path: src/Tracing/GuzzleTracingMiddleware.php
-
-		-
 			message: "#^Property Sentry\\\\Tracing\\\\PropagationContext\\:\\:\\$parentSampled is never read, only written\\.$#"
 			count: 1
 			path: src/Tracing/PropagationContext.php

--- a/src/Integration/RequestFetcher.php
+++ b/src/Integration/RequestFetcher.php
@@ -22,6 +22,10 @@ final class RequestFetcher implements RequestFetcherInterface
             return null;
         }
 
-        return ServerRequest::fromGlobals();
+        try {
+            return ServerRequest::fromGlobals();
+        } catch (\InvalidArgumentException $e) {
+            return null;
+        }
     }
 }

--- a/src/Tracing/GuzzleTracingMiddleware.php
+++ b/src/Tracing/GuzzleTracingMiddleware.php
@@ -87,7 +87,7 @@ final class GuzzleTracingMiddleware
 
                     if ($responseOrException instanceof ResponseInterface) {
                         $response = $responseOrException;
-                    } elseif ($responseOrException instanceof GuzzleRequestException) {
+                    } elseif ($responseOrException instanceof GuzzleRequestException && method_exists($responseOrException, 'getResponse')) {
                         $response = $responseOrException->getResponse();
                     }
 

--- a/tests/Integration/RequestIntegrationTest.php
+++ b/tests/Integration/RequestIntegrationTest.php
@@ -273,7 +273,7 @@ final class RequestIntegrationTest extends TestCase
                 'max_request_body_size' => 'small',
             ],
             (new ServerRequest('POST', 'http://www.example.com/foo'))
-                ->withHeader('Content-Length', 10 ** 3)
+                ->withHeader('Content-Length', (string) (10 ** 3))
                 ->withBody(Utils::streamFor('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus at placerat est. Donec maximus odio augue, vitae bibendum nisi euismod nec. Nunc vel velit ligula. Ut non ultricies magna, non condimentum turpis. Donec pellentesque id nunc at facilisis. Sed fermentum ultricies nunc, id posuere ex ullamcorper quis. Sed varius tincidunt nulla, id varius nulla interdum sit amet. Pellentesque molestie sapien at mi tristique consequat. Nullam id eleifend arcu. Vivamus sed placerat neque. Ut sapien magna, elementum in euismod pretium, rhoncus vitae augue. Nam ullamcorper dui et tortor semper, eu feugiat elit faucibus. Curabitur vel auctor odio. Phasellus vestibulum ullamcorper dictum. Suspendisse fringilla, ipsum bibendum venenatis vulputate, nunc orci facilisis leo, commodo finibus mi arcu in turpis. Mauris ut ultrices est. Nam quis purus ut nulla interdum ornare. Proin in tellus egestas, commodo magna porta, consequat justo. Vivamus in convallis odio. Pellentesque porttitor, urna non gravida.')),
             [
                 'url' => 'http://www.example.com/foo',


### PR DESCRIPTION
### Description
Adds support for `guzzlehttp/psr7` v3.0 and `guzzlehttp/promises` v3.0.

Fixes header type in `Sentry\Tests\Integration\RequestIntegrationTest::testInvoke` test.

#### Issues
<!--
* resolves: #1234
* resolves: LIN-1234
-->

#### Reminders
- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-php/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)