### PR TITLE
Refactor: Replace jean85/pretty-package-versions with native Composer\InstalledVersions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
+        "composer-runtime-api": "^2.0",
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-curl": "*",
         "guzzlehttp/psr7": "^1.8.4|^2.1.1",
-        "jean85/pretty-package-versions": "^1.5|^2.0.4",
         "psr/log": "^1.0|^2.0|^3.0",
         "symfony/options-resolver": "^4.4.30|^5.0.11|^6.0|^7.0|^8.0"
     },

--- a/src/Integration/ModulesIntegration.php
+++ b/src/Integration/ModulesIntegration.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Sentry\Integration;
 
 use Composer\InstalledVersions;
-use Jean85\PrettyVersions;
 use Sentry\Event;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
@@ -47,7 +46,11 @@ final class ModulesIntegration implements IntegrationInterface
         if (empty(self::$packages)) {
             foreach (self::getInstalledPackages() as $package) {
                 try {
-                    self::$packages[$package] = PrettyVersions::getVersion($package)->getPrettyVersion();
+                    $prettyVersion = InstalledVersions::getPrettyVersion($package);
+
+                    if ($prettyVersion !== null) {
+                        self::$packages[$package] = $prettyVersion;
+                    }
                 } catch (\Throwable $exception) {
                     continue;
                 }
@@ -64,21 +67,6 @@ final class ModulesIntegration implements IntegrationInterface
     {
         if (class_exists(InstalledVersions::class)) {
             return InstalledVersions::getInstalledPackages();
-        }
-
-        $versionsClass = 'PackageVersions\\Versions';
-
-        if (class_exists($versionsClass)) {
-            // BC layer for Composer 1, using a transient dependency
-            /** @var mixed $versions */
-            $versions = \constant($versionsClass . '::VERSIONS');
-
-            if (\is_array($versions)) {
-                /** @var string[] $packages */
-                $packages = array_keys($versions);
-
-                return $packages;
-            }
         }
 
         // this should not happen


### PR DESCRIPTION
## Summary
Now that Composer 2 is standard across the ecosystem, `Composer\InstalledVersions` (provided natively via `composer-runtime-api` ^2.0) is available out of the box.

This PR removes our dependency on `jean85/pretty-package-versions` and updates `ModulesIntegration.php` to call `Composer\InstalledVersions::getPrettyVersion()` directly.

## Rationale

* Native Runtime API: Composer 2 provides `Composer\InstalledVersions` natively, making third-party helper wrappers unnecessary for Composer 2+ environments.
* Supply-Chain Security & Reduced Footprint: Preferring native APIs maintained directly by official project organizations (like Composer itself) helps minimize our overall dependency footprint and reduces potential supply-chain
  attack surface.
* Huge thanks to jean85 for maintaining pretty-package-versions over the years—it served the community fantastically through the Composer 1 era!

## Changes

 * In composer.json: Replaced `jean85/pretty-package-versions` with `"composer-runtime-api": "^2.0"`.
 * In `ModulesIntegration`: Switched version resolution to `InstalledVersions::getPrettyVersion($package)` and removed Composer 1 legacy fallback logic.
