### PR TITLE
fix: Add missing enable_metrics option to init() docblock

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -34,6 +34,7 @@ use Sentry\Transport\TransportInterface;
  *     default_integrations?: bool,
  *     dsn?: string|bool|Dsn|null,
  *     enable_logs?: bool,
+ *     enable_metrics?: bool,
  *     environment?: string|null,
  *     error_types?: int|null,
  *     http_client?: HttpClientInterface|null,


### PR DESCRIPTION
### Description
- The `init()` array-shape docblock in `src/functions.php` was missing the `enable_metrics` option, even though it's a fully implemented and working option (`Options::setEnableMetrics()` / `getEnableMetrics()`, resolver default `true`).

#### Issues
Resolve: #2183

#### Reminders
- Add GH Issue ID _&_ Linear ID
- PR title should use [conventional commit](https://develop.sentry.dev/engineering-practices/commit-messages/#type) style (`feat:`, `fix:`, `ref:`, `meta:`)
- For external contributors: [CONTRIBUTING.md](https://github.com/getsentry/sentry-php/blob/master/CONTRIBUTING.md), [Sentry SDK development docs](https://develop.sentry.dev/sdk/), [Discord community](https://discord.gg/Ww9hbqr)