### PR TITLE
fix: document null as an accepted metric attribute value

### DIFF
--- a/src/Attributes/Attribute.php
+++ b/src/Attributes/Attribute.php
@@ -9,7 +9,7 @@ use Sentry\Util\JSON;
 
 /**
  * @phpstan-type AttributeType 'string'|'boolean'|'integer'|'double'
- * @phpstan-type AttributeValue string|bool|int|float
+ * @phpstan-type AttributeValue string|bool|int|float|null
  */
 class Attribute
 {

--- a/src/Metrics/MetricsAggregator.php
+++ b/src/Metrics/MetricsAggregator.php
@@ -41,8 +41,8 @@ final class MetricsAggregator
     private $metrics;
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function add(
         string $type,

--- a/src/Metrics/TraceMetrics.php
+++ b/src/Metrics/TraceMetrics.php
@@ -32,8 +32,8 @@ class TraceMetrics
     }
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function count(
         string $name,
@@ -51,8 +51,8 @@ class TraceMetrics
     }
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function distribution(
         string $name,
@@ -70,8 +70,8 @@ class TraceMetrics
     }
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function gauge(
         string $name,

--- a/src/Metrics/Types/CounterMetric.php
+++ b/src/Metrics/Types/CounterMetric.php
@@ -24,8 +24,8 @@ final class CounterMetric extends Metric
     private $value;
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function __construct(
         string $name,

--- a/src/Metrics/Types/DistributionMetric.php
+++ b/src/Metrics/Types/DistributionMetric.php
@@ -24,8 +24,8 @@ final class DistributionMetric extends Metric
     private $value;
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function __construct(
         string $name,

--- a/src/Metrics/Types/GaugeMetric.php
+++ b/src/Metrics/Types/GaugeMetric.php
@@ -24,8 +24,8 @@ final class GaugeMetric extends Metric
     private $value;
 
     /**
-     * @param int|float                            $value
-     * @param array<string, int|float|string|bool> $attributes
+     * @param int|float                                 $value
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function __construct(
         string $name,

--- a/src/Metrics/Types/Metric.php
+++ b/src/Metrics/Types/Metric.php
@@ -42,7 +42,7 @@ abstract class Metric
     private $unit;
 
     /**
-     * @param array<string, int|float|string|bool> $attributes
+     * @param array<string, int|float|string|bool|null> $attributes
      */
     public function __construct(
         string $name,

--- a/tests/Metrics/TraceMetricsTest.php
+++ b/tests/Metrics/TraceMetricsTest.php
@@ -192,6 +192,20 @@ final class TraceMetricsTest extends TestCase
         $this->assertEquals(10.50, $metric->getValue());
     }
 
+    public function testNullAttributeValueIsStringified(): void
+    {
+        traceMetrics()->count('test-count', 2, ['foo' => null]);
+        traceMetrics()->flush();
+
+        $this->assertCount(1, StubTransport::$events);
+        $event = StubTransport::$events[0];
+
+        $this->assertCount(1, $event->getMetrics());
+        $metric = $event->getMetrics()[0];
+
+        $this->assertSame('null', $metric->getAttributes()->toSimpleArray()['foo']);
+    }
+
     public function testInvalidTypeIsDiscarded(): void
     {
         // @phpstan-ignore-next-line


### PR DESCRIPTION
### Description
`Attribute::tryFromValue()` already accepts `null` and converts it to the string `"null"`, but the public metric attribute type declarations (`array<string, int|float|string|bool>`) excluded `null`. This meant static analysis rejected `null` attribute values even though they work correctly at runtime, forcing callers (and wrapper implementations) to suppress type errors.

#### Issues
resolves: #2182 