### PR TITLE
feat: ungate logs and metrics

### DIFF
--- a/src/Logs/LogsAggregator.php
+++ b/src/Logs/LogsAggregator.php
@@ -51,16 +51,6 @@ final class LogsAggregator
         $options = $client->getOptions();
         $sdkLogger = $options->getLogger();
 
-        if (!$options->getEnableLogs()) {
-            if ($sdkLogger !== null) {
-                $sdkLogger->info(
-                    'Log will be discarded because "enable_logs" is "false".'
-                );
-            }
-
-            return;
-        }
-
         $formattedMessage = Str::vsprintfOrNull($message, $values);
 
         if ($formattedMessage === null) {

--- a/src/Metrics/MetricsAggregator.php
+++ b/src/Metrics/MetricsAggregator.php
@@ -67,10 +67,6 @@ final class MetricsAggregator
             $options = $client->getOptions();
             $metricFlushThreshold = $options->getMetricFlushThreshold();
 
-            if ($options->getEnableMetrics() === false) {
-                return;
-            }
-
             $defaultAttributes = [
                 'sentry.environment' => $options->getEnvironment() ?? Event::DEFAULT_ENVIRONMENT,
                 'server.address' => $options->getServerName(),

--- a/src/Monolog/Handler.php
+++ b/src/Monolog/Handler.php
@@ -17,8 +17,8 @@ use Sentry\State\Scope;
  * hub instance.
  *
  * @deprecated since version 4.24. To be removed in version 5.0. Use {@see LogsHandler}
- *             with the `enable_logs` SDK option for Sentry logs, {@see ExceptionToSentryIssueHandler}
- *             to send Monolog exceptions to Sentry issues, and {@see LogToSentryIssueHandler}
+ *             for Sentry logs, {@see ExceptionToSentryIssueHandler} to send Monolog exceptions
+ *             to Sentry issues, and {@see LogToSentryIssueHandler}
  *             to send Monolog log messages to Sentry issues.
  *
  * @author Stefano Arlandini <sarlandini@alice.it>

--- a/src/Options.php
+++ b/src/Options.php
@@ -151,7 +151,12 @@ final class Options
     /**
      * Sets if logs should be enabled or not.
      *
+     * This option no longer gates the manual logging API or logging integrations.
+     * To implement a kill switch, use a `before_send_log` callback that returns `null`.
+     *
      * @param bool|null $enableLogs Boolean if logs should be enabled or not
+     *
+     * @deprecated since version 4.31. To be removed in version 5.0
      */
     public function setEnableLogs(?bool $enableLogs): self
     {
@@ -160,6 +165,11 @@ final class Options
 
     /**
      * Gets if logs is enabled or not.
+     *
+     * This option no longer gates the manual logging API or logging integrations.
+     * To implement a kill switch, use a `before_send_log` callback that returns `null`.
+     *
+     * @deprecated since version 4.31. To be removed in version 5.0
      */
     public function getEnableLogs(): bool
     {
@@ -212,14 +222,24 @@ final class Options
 
     /**
      * Sets if metrics should be enabled or not.
+     *
+     * This option no longer gates the manual metrics API or metrics integrations.
+     * To implement a kill switch, use a `before_send_metric` callback that returns `null`.
+     *
+     * @deprecated since version 4.31. To be removed in version 5.0
      */
-    public function setEnableMetrics(bool $enableTracing): self
+    public function setEnableMetrics(bool $enableMetrics): self
     {
-        return $this->updateOptions(['enable_metrics' => $enableTracing]);
+        return $this->updateOptions(['enable_metrics' => $enableMetrics]);
     }
 
     /**
      * Returns whether metrics are enabled or not.
+     *
+     * This option no longer gates the manual metrics API or metrics integrations.
+     * To implement a kill switch, use a `before_send_metric` callback that returns `null`.
+     *
+     * @deprecated since version 4.31. To be removed in version 5.0
      */
     public function getEnableMetrics(): bool
     {

--- a/tests/Logs/LogsAggregatorTest.php
+++ b/tests/Logs/LogsAggregatorTest.php
@@ -31,9 +31,7 @@ final class LogsAggregatorTest extends TestCase
      */
     public function testAttributes(array $attributes, array $expected): void
     {
-        $client = ClientBuilder::create([
-            'enable_logs' => true,
-        ])->getClient();
+        $client = ClientBuilder::create()->getClient();
 
         $hub = new Hub($client);
         SentrySdk::setCurrentHub($hub);
@@ -89,9 +87,7 @@ final class LogsAggregatorTest extends TestCase
      */
     public function testMessageFormatting(string $message, array $values, string $expected): void
     {
-        $client = ClientBuilder::create([
-            'enable_logs' => true,
-        ])->getClient();
+        $client = ClientBuilder::create()->getClient();
 
         $hub = new Hub($client);
         SentrySdk::setCurrentHub($hub);
@@ -163,7 +159,6 @@ final class LogsAggregatorTest extends TestCase
     public function testAttributesAreAddedToLogMessage(): void
     {
         $client = ClientBuilder::create([
-            'enable_logs' => true,
             'send_default_pii' => true,
             'release' => '1.0.0',
             'environment' => 'production',
@@ -214,7 +209,6 @@ final class LogsAggregatorTest extends TestCase
     public function testUserAttributesCanBeSetManuallyWithDefaultPiiOff(): void
     {
         $client = ClientBuilder::create([
-            'enable_logs' => true,
             'send_default_pii' => false,
         ])->getClient();
 
@@ -248,7 +242,6 @@ final class LogsAggregatorTest extends TestCase
 
         $transport = new StubTransport();
         $client = ClientBuilder::create([
-            'enable_logs' => true,
             'log_flush_threshold' => 2,
         ])->setTransport($transport)->getClient();
 
@@ -277,7 +270,6 @@ final class LogsAggregatorTest extends TestCase
 
         $transport = new StubTransport();
         $client = ClientBuilder::create([
-            'enable_logs' => true,
             'log_flush_threshold' => null,
         ])->setTransport($transport)->getClient();
 
@@ -295,9 +287,7 @@ final class LogsAggregatorTest extends TestCase
 
     public function testDoesNotUsePropagationContextSpanIdAsParentSpanIdWhenNoLocalSpanExists(): void
     {
-        $client = ClientBuilder::create([
-            'enable_logs' => true,
-        ])->getClient();
+        $client = ClientBuilder::create()->getClient();
 
         $propagationContext = PropagationContext::fromDefaults();
         $propagationContext->setTraceId(new TraceId('771a43a4192642f0b136d5159a501700'));
@@ -321,9 +311,7 @@ final class LogsAggregatorTest extends TestCase
 
     public function testUsesExternalPropagationContextWhenNoLocalSpanExists(): void
     {
-        $client = ClientBuilder::create([
-            'enable_logs' => true,
-        ])->getClient();
+        $client = ClientBuilder::create()->getClient();
 
         $hub = new Hub($client);
         SentrySdk::setCurrentHub($hub);

--- a/tests/Logs/LogsTest.php
+++ b/tests/Logs/LogsTest.php
@@ -11,7 +11,6 @@ use Sentry\ClientInterface;
 use Sentry\Event;
 use Sentry\Logs\Log;
 use Sentry\Logs\LogLevel;
-use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\Transport\Result;
@@ -22,29 +21,21 @@ use function Sentry\logger;
 
 final class LogsTest extends TestCase
 {
-    public function testLogNotSentWhenDisabled(): void
+    public function testLogSentWhenEnableLogsIsFalse(): void
     {
-        /** @var ClientInterface&MockObject $client */
-        $client = $this->createMock(ClientInterface::class);
-        $client->expects($this->any())
-               ->method('getOptions')
-               ->willReturn(new Options([
-                   'dsn' => 'https://public@example.com/1',
-                   'enable_logs' => false,
-               ]));
-
-        $client->expects($this->never())
-               ->method('captureEvent');
-
-        $hub = new Hub($client);
-        SentrySdk::setCurrentHub($hub);
+        $this->assertEvent(function (Event $event) {
+            $this->assertCount(1, $event->getLogs());
+            $this->assertSame('Some info message', $event->getLogs()[0]->getBody());
+        }, [
+            'enable_logs' => false,
+        ]);
 
         logger()->info('Some info message');
 
-        $this->assertNull(logger()->flush());
+        $this->assertNotNull(logger()->flush());
     }
 
-    public function testLogSentWhenEnabled(): void
+    public function testLogSentWithoutEnableLogsOption(): void
     {
         $this->assertEvent(function (Event $event) {
             $this->assertCount(1, $event->getLogs());
@@ -180,11 +171,7 @@ final class LogsTest extends TestCase
                       return new Result(ResultStatus::success(), $event);
                   });
 
-        $clientOptions = array_merge([
-            'enable_logs' => true,
-        ], $options);
-
-        $client = ClientBuilder::create($clientOptions)->setTransport($transport)->getClient();
+        $client = ClientBuilder::create($options)->setTransport($transport)->getClient();
 
         $hub = new Hub($client);
         SentrySdk::setCurrentHub($hub);

--- a/tests/Metrics/TraceMetricsTest.php
+++ b/tests/Metrics/TraceMetricsTest.php
@@ -129,7 +129,7 @@ final class TraceMetricsTest extends TestCase
         $this->assertCount(MetricsAggregator::METRICS_BUFFER_SIZE, $metrics);
     }
 
-    public function testEnableMetrics(): void
+    public function testMetricSentWhenEnableMetricsIsFalse(): void
     {
         HubAdapter::getInstance()->bindClient(new Client(new Options([
             'enable_metrics' => false,
@@ -138,7 +138,9 @@ final class TraceMetricsTest extends TestCase
         traceMetrics()->count('test-count', 2, ['foo' => 'bar']);
         traceMetrics()->flush();
 
-        $this->assertEmpty(StubTransport::$events);
+        $this->assertCount(1, StubTransport::$events);
+        $this->assertCount(1, StubTransport::$events[0]->getMetrics());
+        $this->assertSame('test-count', StubTransport::$events[0]->getMetrics()[0]->getName());
     }
 
     public function testBeforeSendMetricAltersContent(): void

--- a/tests/Monolog/LogsHandlerTest.php
+++ b/tests/Monolog/LogsHandlerTest.php
@@ -22,7 +22,7 @@ final class LogsHandlerTest extends TestCase
     {
         Logs::getInstance()->flush();
         $client = ClientBuilder::create([
-            'enable_logs' => true,
+            'enable_logs' => false,
             'before_send' => static function () {
                 return null; // we don't need to send the event, we are just testing the Monolog handler
             },
@@ -104,7 +104,7 @@ final class LogsHandlerTest extends TestCase
     {
         $transport = new StubTransport();
         $client = ClientBuilder::create([
-            'enable_logs' => true,
+            'enable_logs' => false,
         ])->setTransport($transport)
             ->getClient();
 


### PR DESCRIPTION
Deprecates and changes `enable_logs` and `enable_metrics` to be effectively no-ops. The reason for this change is that those flags were basically just kill switches for the entire feature and disabled by default. 
Users had to 
1. add a log handler or call log functions directly and 
2. enable the log feature to make sure they arrive. 

Metrics are even more explicit since one has to invoke functions to emit metrics and we don't have any integrations.

Once this is merged, adding a handler or calling a log/metric function will be considered as a signal that this type of telemetry is wanted, and we will no longer respect the flag.

For anyone using those flags as kill switches: it's possible to implement kill switches using `before_send_log` and `before_send_metric` and return `null` in those callbacks.