### PR TITLE
feat: support concurrent runtime contexts

### DIFF
--- a/analysis-baseline.toml
+++ b/analysis-baseline.toml
@@ -199,12 +199,6 @@ message = "Reference created from a previously undefined variable `$matches`."
 count = 1
 
 [[issues]]
-file = "src/ErrorHandler.php"
-code = "write-only-property"
-message = "Property `$reservedMemory` is written to but never read."
-count = 1
-
-[[issues]]
 file = "src/Event.php"
 code = "impossible-condition"
 message = "This condition (type `false`) will always evaluate to false."

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -112,8 +112,6 @@ final class ErrorHandler
 
     /**
      * @var string|null A portion of pre-allocated memory data that will be reclaimed in case a fatal error occurs to handle it
-     *
-     * @phpstan-ignore-next-line This property is used to reserve memory for the fatal error handler and is thus never read
      */
     private static $reservedMemory;
 
@@ -315,7 +313,10 @@ final class ErrorHandler
         self::$disableFatalErrorHandler = false;
         self::$didIncreaseMemoryLimit = false;
 
-        if (self::$handlerInstance !== null && self::$handlerInstance->isFatalErrorHandlerRegistered) {
+        if (self::$handlerInstance !== null
+            && self::$handlerInstance->isFatalErrorHandlerRegistered
+            && self::$reservedMemory === null
+        ) {
             self::$reservedMemory = str_repeat('x', self::$reservedMemorySize);
         }
     }

--- a/src/SentrySdk.php
+++ b/src/SentrySdk.php
@@ -10,6 +10,7 @@ use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 use Sentry\State\RuntimeContext;
 use Sentry\State\RuntimeContextManager;
+use Sentry\State\RuntimeContextStorageInterface;
 
 /**
  * This class is the main entry point for all the most common SDK features.
@@ -38,11 +39,13 @@ final class SentrySdk
     /**
      * Initializes the SDK by creating a new hub instance each time this method
      * gets called.
+     *
+     * @param RuntimeContextStorageInterface|null $runtimeContextStorage Storage for isolating overlapping logical executions
      */
-    public static function init(): HubInterface
+    public static function init(?RuntimeContextStorageInterface $runtimeContextStorage = null): HubInterface
     {
         self::$currentHub = new Hub();
-        self::$runtimeContextManager = new RuntimeContextManager(self::$currentHub);
+        self::$runtimeContextManager = new RuntimeContextManager(self::$currentHub, $runtimeContextStorage);
 
         return self::getCurrentHub();
     }
@@ -89,7 +92,7 @@ final class SentrySdk
     /**
      * Executes the given callback within an isolated context.
      *
-     * If a context is already active for the current execution key, this method
+     * If a context is already active for the current logical execution, this method
      * reuses it and only executes the callback.
      *
      * @param callable $callback The callback to execute
@@ -105,11 +108,7 @@ final class SentrySdk
     public static function withContext(callable $callback, ?int $timeout = null)
     {
         $runtimeContextManager = self::getRuntimeContextManager();
-        $startedNewContext = !$runtimeContextManager->hasActiveContext();
-
-        if ($startedNewContext) {
-            $runtimeContextManager->startContext();
-        }
+        $startedNewContext = $runtimeContextManager->startContext();
 
         try {
             return $callback();

--- a/src/SentrySdk.php
+++ b/src/SentrySdk.php
@@ -44,6 +44,13 @@ final class SentrySdk
      */
     public static function init(?RuntimeContextStorageInterface $runtimeContextStorage = null): HubInterface
     {
+        if ($runtimeContextStorage !== null) {
+            // The new manager must not select a context the previous one left in host storage.
+            // The removed context is discarded unflushed, matching how reinitialization has
+            // always dropped active manager state.
+            $runtimeContextStorage->remove();
+        }
+
         self::$currentHub = new Hub();
         self::$runtimeContextManager = new RuntimeContextManager(self::$currentHub, $runtimeContextStorage);
 

--- a/src/SentrySdk.php
+++ b/src/SentrySdk.php
@@ -30,6 +30,11 @@ final class SentrySdk
     private static $runtimeContextManager;
 
     /**
+     * @var RuntimeContextStorageInterface|null
+     */
+    private static $runtimeContextStorage;
+
+    /**
      * Constructor.
      */
     private function __construct()
@@ -39,22 +44,35 @@ final class SentrySdk
     /**
      * Initializes the SDK by creating a new hub instance each time this method
      * gets called.
-     *
-     * @param RuntimeContextStorageInterface|null $runtimeContextStorage Storage for isolating overlapping logical executions
      */
-    public static function init(?RuntimeContextStorageInterface $runtimeContextStorage = null): HubInterface
+    public static function init(): HubInterface
     {
-        if ($runtimeContextStorage !== null) {
-            // The new manager must not select a context the previous one left in host storage.
-            // The removed context is discarded unflushed, matching how reinitialization has
-            // always dropped active manager state.
-            $runtimeContextStorage->remove();
+        if (self::$runtimeContextManager !== null) {
+            self::$runtimeContextManager->discardActiveContext();
         }
 
         self::$currentHub = new Hub();
-        self::$runtimeContextManager = new RuntimeContextManager(self::$currentHub, $runtimeContextStorage);
+        self::$runtimeContextManager = null;
 
         return self::getCurrentHub();
+    }
+
+    /**
+     * Registers storage for isolating runtime contexts across overlapping logical executions.
+     *
+     * The registration persists across SDK initialization. Changing it discards the active
+     * context for the current logical execution without flushing it. Concurrent runtimes
+     * should register storage before logical executions begin and must not replace it while
+     * other logical executions are active.
+     */
+    public static function setRuntimeContextStorage(?RuntimeContextStorageInterface $runtimeContextStorage): void
+    {
+        if (self::$runtimeContextManager !== null) {
+            self::$runtimeContextManager->discardActiveContext();
+        }
+
+        self::$runtimeContextStorage = $runtimeContextStorage;
+        self::$runtimeContextManager = null;
     }
 
     /**
@@ -165,7 +183,7 @@ final class SentrySdk
         }
 
         if (self::$runtimeContextManager === null) {
-            self::$runtimeContextManager = new RuntimeContextManager(self::$currentHub);
+            self::$runtimeContextManager = new RuntimeContextManager(self::$currentHub, self::$runtimeContextStorage);
         }
 
         return self::$runtimeContextManager;

--- a/src/State/RuntimeContext.php
+++ b/src/State/RuntimeContext.php
@@ -13,7 +13,8 @@ use Sentry\Metrics\MetricsAggregator;
  * A unit of work can be an HTTP request, a queue job, a worker task, or any
  * explicit lifecycle wrapped with startContext()/endContext().
  *
- * @internal
+ * Storage implementations should treat instances as opaque values owned by the
+ * SDK and must not create or mutate them directly.
  */
 final class RuntimeContext
 {
@@ -37,6 +38,9 @@ final class RuntimeContext
      */
     private $metricsAggregator;
 
+    /**
+     * @internal
+     */
     public function __construct(string $id, HubInterface $hub)
     {
         $this->id = $id;
@@ -45,26 +49,41 @@ final class RuntimeContext
         $this->metricsAggregator = new MetricsAggregator();
     }
 
+    /**
+     * @internal
+     */
     public function getId(): string
     {
         return $this->id;
     }
 
+    /**
+     * @internal
+     */
     public function getHub(): HubInterface
     {
         return $this->hub;
     }
 
+    /**
+     * @internal
+     */
     public function setHub(HubInterface $hub): void
     {
         $this->hub = $hub;
     }
 
+    /**
+     * @internal
+     */
     public function getLogsAggregator(): LogsAggregator
     {
         return $this->logsAggregator;
     }
 
+    /**
+     * @internal
+     */
     public function getMetricsAggregator(): MetricsAggregator
     {
         return $this->metricsAggregator;

--- a/src/State/RuntimeContextManager.php
+++ b/src/State/RuntimeContextManager.php
@@ -12,18 +12,14 @@ use Sentry\Tracing\PropagationContext;
 /**
  * Manages runtime-local SDK state across different execution models.
  *
- * Lifecycle model:
- * - The manager keeps a lazily initialized global context as fallback.
- * - startContext() creates an isolated runtime context for the current
- *   execution key when no context is active yet.
- * - endContext() flushes context resources and removes that context.
+ * The manager keeps a lazily initialized global context as fallback. Explicit
+ * contexts use process-local storage by default, or the configured storage for
+ * runtimes with overlapping logical executions.
  *
  * @internal
  */
 final class RuntimeContextManager
 {
-    private const PROCESS_EXECUTION_CONTEXT_KEY = 'process';
-
     /**
      * @var HubInterface
      */
@@ -35,25 +31,25 @@ final class RuntimeContextManager
     private $globalContext;
 
     /**
-     * @var array<string, RuntimeContext>
+     * @var RuntimeContext|null
      */
-    private $activeContexts = [];
+    private $runtimeContext;
 
     /**
-     * @var array<string, string>
+     * @var RuntimeContextStorageInterface|null
      */
-    private $executionContextToRuntimeContext = [];
+    private $runtimeContextStorage;
 
-    public function __construct(HubInterface $baseHub)
+    public function __construct(HubInterface $baseHub, ?RuntimeContextStorageInterface $runtimeContextStorage = null)
     {
         $this->baseHub = $baseHub;
-        $this->globalContext = null;
+        $this->runtimeContextStorage = $runtimeContextStorage;
     }
 
     /**
      * Sets the current hub with context-aware behavior.
      *
-     * If a runtime context is active for the current execution key, the hub is
+     * If a runtime context is active for the current logical execution, the hub is
      * updated only for that active context. Otherwise, the baseline/global hub
      * template is updated.
      *
@@ -61,11 +57,10 @@ final class RuntimeContextManager
      */
     public function setCurrentHub(HubInterface $hub): bool
     {
-        $executionContextKey = $this->getExecutionContextKey();
+        $runtimeContext = $this->getActiveContext();
 
-        if ($this->hasActiveContextForExecutionContextKey($executionContextKey)) {
-            $runtimeContextId = $this->executionContextToRuntimeContext[$executionContextKey];
-            $this->activeContexts[$runtimeContextId]->setHub($hub);
+        if ($runtimeContext !== null) {
+            $runtimeContext->setHub($hub);
 
             return true;
         }
@@ -86,77 +81,40 @@ final class RuntimeContextManager
 
     public function getCurrentContext(): RuntimeContext
     {
-        $executionContextKey = $this->getExecutionContextKey();
-
-        if ($this->hasActiveContextForExecutionContextKey($executionContextKey)) {
-            $runtimeContextId = $this->executionContextToRuntimeContext[$executionContextKey];
-
-            return $this->activeContexts[$runtimeContextId];
-        }
-
-        return $this->getGlobalContext();
-    }
-
-    public function hasActiveContext(): bool
-    {
-        return $this->hasActiveContextForExecutionContextKey($this->getExecutionContextKey());
+        return $this->getActiveContext() ?? $this->getGlobalContext();
     }
 
     /**
-     * Starts an isolated context for the current execution key.
+     * Starts an isolated context for the current logical execution.
+     *
+     * @return bool Whether a new context was started
      */
-    public function startContext(): void
+    public function startContext(): bool
     {
-        $executionContextKey = $this->getExecutionContextKey();
-
-        if ($this->hasActiveContextForExecutionContextKey($executionContextKey)) {
-            // Nested start calls for the same execution key should be a no-op.
-            return;
+        if ($this->getActiveContext() !== null) {
+            // Nested start calls for the same logical execution should be a no-op.
+            return false;
         }
 
         ErrorHandler::resetFatalErrorHandlerState();
 
-        $this->createContextForExecutionContextKey($executionContextKey);
+        $this->setActiveContext(new RuntimeContext($this->generateRuntimeContextId(), $this->createHubFromBaseHub()));
+
+        return true;
     }
 
     /**
-     * Ends and flushes the active context for the current execution key.
+     * Ends and flushes the active context for the current logical execution.
      *
-     * When no context is active for the key this is a no-op.
+     * When no context is active this is a no-op.
      */
     public function endContext(?int $timeout = null): void
     {
-        $executionContextKey = $this->getExecutionContextKey();
+        $runtimeContext = $this->removeActiveContext();
 
-        if (!$this->hasActiveContextForExecutionContextKey($executionContextKey)) {
+        if ($runtimeContext === null) {
             return;
         }
-
-        $runtimeContextId = $this->executionContextToRuntimeContext[$executionContextKey];
-        unset($this->executionContextToRuntimeContext[$executionContextKey]);
-
-        $this->removeContextById($runtimeContextId, $timeout);
-    }
-
-    private function createContextForExecutionContextKey(string $executionContextKey): void
-    {
-        $runtimeContextId = $this->generateRuntimeContextId();
-        $runtimeContext = new RuntimeContext($runtimeContextId, $this->createHubFromBaseHub());
-
-        $this->activeContexts[$runtimeContextId] = $runtimeContext;
-        $this->executionContextToRuntimeContext[$executionContextKey] = $runtimeContextId;
-    }
-
-    private function removeContextById(string $runtimeContextId, ?int $timeout = null): void
-    {
-        if (!isset($this->activeContexts[$runtimeContextId])) {
-            return;
-        }
-
-        $runtimeContext = $this->activeContexts[$runtimeContextId];
-        unset($this->activeContexts[$runtimeContextId]);
-        // Remove any key mappings that may still reference this context.
-        $this->removeExecutionContextMappingsForRuntimeContext($runtimeContextId);
 
         $logger = $this->getLoggerFromHub($runtimeContext->getHub());
 
@@ -205,31 +163,36 @@ final class RuntimeContextManager
         }
     }
 
-    private function removeExecutionContextMappingsForRuntimeContext(string $runtimeContextId): void
+    private function getActiveContext(): ?RuntimeContext
     {
-        foreach ($this->executionContextToRuntimeContext as $executionContextKey => $mappedRuntimeContextId) {
-            if ($mappedRuntimeContextId === $runtimeContextId) {
-                unset($this->executionContextToRuntimeContext[$executionContextKey]);
-            }
+        if ($this->runtimeContextStorage !== null) {
+            return $this->runtimeContextStorage->get();
         }
+
+        return $this->runtimeContext;
     }
 
-    private function hasActiveContextForExecutionContextKey(string $executionContextKey): bool
+    private function setActiveContext(RuntimeContext $runtimeContext): void
     {
-        if (!isset($this->executionContextToRuntimeContext[$executionContextKey])) {
-            return false;
+        if ($this->runtimeContextStorage !== null) {
+            $this->runtimeContextStorage->set($runtimeContext);
+
+            return;
         }
 
-        $runtimeContextId = $this->executionContextToRuntimeContext[$executionContextKey];
+        $this->runtimeContext = $runtimeContext;
+    }
 
-        if (!isset($this->activeContexts[$runtimeContextId])) {
-            // Mapping points to a context that was already evicted/ended; drop the stale index entry.
-            unset($this->executionContextToRuntimeContext[$executionContextKey]);
-
-            return false;
+    private function removeActiveContext(): ?RuntimeContext
+    {
+        if ($this->runtimeContextStorage !== null) {
+            return $this->runtimeContextStorage->remove();
         }
 
-        return true;
+        $runtimeContext = $this->runtimeContext;
+        $this->runtimeContext = null;
+
+        return $runtimeContext;
     }
 
     private function createHubFromBaseHub(): HubInterface
@@ -264,12 +227,6 @@ final class RuntimeContextManager
     private function generateRuntimeContextId(): string
     {
         return \sprintf('%s-%d', str_replace('.', '', uniqid('', true)), mt_rand());
-    }
-
-    private function getExecutionContextKey(): string
-    {
-        // All supported runtime modes currently use a process-local execution key.
-        return self::PROCESS_EXECUTION_CONTEXT_KEY;
     }
 
     private function getGlobalContext(): RuntimeContext

--- a/src/State/RuntimeContextManager.php
+++ b/src/State/RuntimeContextManager.php
@@ -121,6 +121,14 @@ final class RuntimeContextManager
         $this->flushRuntimeContextResources($runtimeContext, $timeout, $logger);
     }
 
+    /**
+     * Discards the active context for the current logical execution without flushing it.
+     */
+    public function discardActiveContext(): void
+    {
+        $this->removeActiveContext();
+    }
+
     private function flushRuntimeContextResources(RuntimeContext $runtimeContext, ?int $timeout, LoggerInterface $logger): void
     {
         $hub = $runtimeContext->getHub();

--- a/src/State/RuntimeContextStorageInterface.php
+++ b/src/State/RuntimeContextStorageInterface.php
@@ -21,10 +21,12 @@ use Sentry\SentrySdk;
  * context until every owner has released it. Otherwise, the child must use an
  * independent context.
  *
- * SDK initialization removes the context stored for the current logical
- * execution without flushing it. Concurrent runtimes must not reinitialize the
- * SDK while other logical executions are active, because the SDK cannot
- * enumerate host storage.
+ * Storage is registered once during framework bootstrap through
+ * {@see SentrySdk::setRuntimeContextStorage()} and remains registered across SDK
+ * initialization. SDK initialization and registration changes discard the context
+ * stored for the current logical execution without flushing it. Concurrent runtimes
+ * must not reinitialize the SDK or change the registration while other logical
+ * executions are active, because the SDK cannot enumerate host storage.
  */
 interface RuntimeContextStorageInterface
 {

--- a/src/State/RuntimeContextStorageInterface.php
+++ b/src/State/RuntimeContextStorageInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\State;
+
+use Sentry\SentrySdk;
+
+/**
+ * Stores the SDK runtime context for the current logical execution.
+ *
+ * Concurrent runtimes should back this interface with execution-local storage.
+ * They must start a context before replacing the current Hub so one execution
+ * cannot modify the process-wide baseline used by other executions.
+ *
+ * Integrations must call {@see SentrySdk::endContext()} before execution-local
+ * state is released so buffered telemetry is flushed. Storage must still release
+ * the context if an execution terminates without reaching that boundary.
+ *
+ * If a child execution shares its parent's context, storage must retain that
+ * context until every owner has released it. Otherwise, the child must use an
+ * independent context.
+ */
+interface RuntimeContextStorageInterface
+{
+    /**
+     * Gets the runtime context for the current logical execution.
+     */
+    public function get(): ?RuntimeContext;
+
+    /**
+     * Stores the runtime context for the current logical execution.
+     */
+    public function set(RuntimeContext $runtimeContext): void;
+
+    /**
+     * Removes and returns the runtime context for the current logical execution.
+     *
+     * This method must return null without side effects when no context is stored.
+     */
+    public function remove(): ?RuntimeContext;
+}

--- a/src/State/RuntimeContextStorageInterface.php
+++ b/src/State/RuntimeContextStorageInterface.php
@@ -20,6 +20,11 @@ use Sentry\SentrySdk;
  * If a child execution shares its parent's context, storage must retain that
  * context until every owner has released it. Otherwise, the child must use an
  * independent context.
+ *
+ * SDK initialization removes the context stored for the current logical
+ * execution without flushing it. Concurrent runtimes must not reinitialize the
+ * SDK while other logical executions are active, because the SDK cannot
+ * enumerate host storage.
  */
 interface RuntimeContextStorageInterface
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,6 +11,7 @@ use Sentry\Integration\OTLPIntegration;
 use Sentry\Logs\Logs;
 use Sentry\Metrics\Metrics;
 use Sentry\Metrics\TraceMetrics;
+use Sentry\State\RuntimeContextStorageInterface;
 use Sentry\State\Scope;
 use Sentry\Tracing\PropagationContext;
 use Sentry\Tracing\SpanContext;
@@ -20,6 +21,9 @@ use Sentry\Transport\TransportInterface;
 
 /**
  * Creates a new Client and Hub which will be set as current.
+ *
+ * Runtimes that execute overlapping logical executions in one process can pass
+ * a runtime context storage to isolate them from each other.
  *
  * @param array{
  *     attach_metric_code_locations?: bool,
@@ -75,11 +79,11 @@ use Sentry\Transport\TransportInterface;
  *     transport?: TransportInterface|null,
  * } $options The client options
  */
-function init(array $options = []): void
+function init(array $options = [], ?RuntimeContextStorageInterface $runtimeContextStorage = null): void
 {
     $client = ClientBuilder::create($options)->getClient();
 
-    SentrySdk::init()->bindClient($client);
+    SentrySdk::init($runtimeContextStorage)->bindClient($client);
 }
 
 /**
@@ -235,7 +239,7 @@ function endContext(?int $timeout = null): void
 /**
  * Executes the given callback within an isolated context.
  *
- * If a context is already active for the current execution key, it is reused.
+ * If a context is already active for the current logical execution, it is reused.
  *
  * @param callable $callback The callback to execute
  * @param int|null $timeout  The maximum number of seconds to wait while flushing the client transport

--- a/src/functions.php
+++ b/src/functions.php
@@ -11,7 +11,6 @@ use Sentry\Integration\OTLPIntegration;
 use Sentry\Logs\Logs;
 use Sentry\Metrics\Metrics;
 use Sentry\Metrics\TraceMetrics;
-use Sentry\State\RuntimeContextStorageInterface;
 use Sentry\State\Scope;
 use Sentry\Tracing\PropagationContext;
 use Sentry\Tracing\SpanContext;
@@ -21,9 +20,6 @@ use Sentry\Transport\TransportInterface;
 
 /**
  * Creates a new Client and Hub which will be set as current.
- *
- * Runtimes that execute overlapping logical executions in one process can pass
- * a runtime context storage to isolate them from each other.
  *
  * @param array{
  *     attach_metric_code_locations?: bool,
@@ -79,11 +75,11 @@ use Sentry\Transport\TransportInterface;
  *     transport?: TransportInterface|null,
  * } $options The client options
  */
-function init(array $options = [], ?RuntimeContextStorageInterface $runtimeContextStorage = null): void
+function init(array $options = []): void
 {
     $client = ClientBuilder::create($options)->getClient();
 
-    SentrySdk::init($runtimeContextStorage)->bindClient($client);
+    SentrySdk::init()->bindClient($client);
 }
 
 /**

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -61,6 +61,22 @@ final class FunctionsTest extends TestCase
         $this->assertNotNull(SentrySdk::getCurrentHub()->getClient());
     }
 
+    public function testInitUsesRuntimeContextStorage(): void
+    {
+        $storage = new StubRuntimeContextStorage();
+
+        init(['default_integrations' => false], $storage);
+
+        $storage->switchTo('request');
+        startContext();
+
+        $this->assertNotNull($storage->get());
+
+        endContext();
+
+        $this->assertNull($storage->get());
+    }
+
     /**
      * @dataProvider captureMessageDataProvider
      */

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -65,7 +65,8 @@ final class FunctionsTest extends TestCase
     {
         $storage = new StubRuntimeContextStorage();
 
-        init(['default_integrations' => false], $storage);
+        SentrySdk::setRuntimeContextStorage($storage);
+        init(['default_integrations' => false]);
 
         $storage->switchTo('request');
         startContext();

--- a/tests/SentrySdkExtension.php
+++ b/tests/SentrySdkExtension.php
@@ -31,6 +31,15 @@ final class SentrySdkExtension implements BeforeTestHookInterface
             $reflectionProperty->setAccessible(false);
         }
 
+        $reflectionProperty = new \ReflectionProperty(SentrySdk::class, 'runtimeContextStorage');
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(true);
+        }
+        $reflectionProperty->setValue(null, null);
+        if (\PHP_VERSION_ID < 80100) {
+            $reflectionProperty->setAccessible(false);
+        }
+
         StubTransport::$events = [];
 
         $reflectionProperty = new \ReflectionProperty(Scope::class, 'globalEventProcessors');

--- a/tests/SentrySdkTest.php
+++ b/tests/SentrySdkTest.php
@@ -251,6 +251,40 @@ final class SentrySdkTest extends TestCase
         $this->assertSame($globalHub, SentrySdk::getCurrentHub());
     }
 
+    public function testInitClearsContextStoredByPreviousManager(): void
+    {
+        /** @var ClientInterface&MockObject $secondClient */
+        $secondClient = $this->createMock(ClientInterface::class);
+        $secondClient->expects($this->once())
+            ->method('getOptions')
+            ->willReturn(new Options());
+        $secondClient->expects($this->once())
+            ->method('flush')
+            ->willReturn(new Result(ResultStatus::success()));
+
+        $storage = new StubRuntimeContextStorage();
+        SentrySdk::init($storage)->bindClient($this->createMock(ClientInterface::class));
+
+        $storage->switchTo('request');
+        SentrySdk::startContext();
+        $previousHub = SentrySdk::getCurrentHub();
+
+        $freshHub = SentrySdk::init($storage);
+
+        $this->assertNull($storage->get());
+        $this->assertNotSame($previousHub, $freshHub);
+
+        $freshHub->bindClient($secondClient);
+
+        // This end/start transition exposes a stale context as a missing client.
+        SentrySdk::endContext();
+        SentrySdk::startContext();
+
+        $this->assertSame($secondClient, SentrySdk::getCurrentHub()->getClient());
+
+        SentrySdk::endContext();
+    }
+
     public function testEndContextFlushesClientTransportWithOptionalTimeout(): void
     {
         /** @var ClientInterface&MockObject $client */

--- a/tests/SentrySdkTest.php
+++ b/tests/SentrySdkTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sentry\ClientInterface;
 use Sentry\Event;
+use Sentry\Logs\Logs;
+use Sentry\Metrics\TraceMetrics;
 use Sentry\Options;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
@@ -147,6 +149,108 @@ final class SentrySdkTest extends TestCase
         $this->assertSame($globalHub, SentrySdk::getCurrentHub());
     }
 
+    public function testRuntimeContextStorageIsolatesConcurrentExecutions(): void
+    {
+        $storage = new StubRuntimeContextStorage();
+        $globalHub = SentrySdk::init($storage);
+
+        $storage->switchTo('first');
+        SentrySdk::startContext();
+
+        $firstContext = SentrySdk::getCurrentRuntimeContext();
+        $firstLogsAggregator = $firstContext->getLogsAggregator();
+        $firstMetricsAggregator = $firstContext->getMetricsAggregator();
+        $firstHub = new Hub();
+
+        SentrySdk::setCurrentHub($firstHub);
+
+        $this->assertSame($firstHub, $firstContext->getHub());
+
+        $firstHub->configureScope(static function (Scope $scope): void {
+            $scope->setTag('execution', 'first');
+        });
+
+        $storage->switchTo('second');
+        SentrySdk::startContext();
+
+        $secondContext = SentrySdk::getCurrentRuntimeContext();
+        $secondHub = $secondContext->getHub();
+
+        $secondHub->configureScope(static function (Scope $scope): void {
+            $scope->setTag('execution', 'second');
+        });
+
+        $this->assertNotSame($firstContext, $secondContext);
+        $this->assertNotSame($firstHub, $secondHub);
+        $this->assertNotSame($firstLogsAggregator, $secondContext->getLogsAggregator());
+        $this->assertNotSame($firstMetricsAggregator, $secondContext->getMetricsAggregator());
+
+        $storage->switchTo('first');
+
+        $this->assertSame($firstContext, SentrySdk::getCurrentRuntimeContext());
+        $this->assertSame('first', $this->getCurrentScopeTag('execution'));
+
+        $storage->switchTo('second');
+
+        $this->assertSame($secondContext, SentrySdk::getCurrentRuntimeContext());
+        $this->assertSame('second', $this->getCurrentScopeTag('execution'));
+
+        SentrySdk::endContext();
+
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
+
+        $storage->switchTo('first');
+
+        $this->assertSame($firstContext, SentrySdk::getCurrentRuntimeContext());
+
+        SentrySdk::endContext();
+
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
+    }
+
+    public function testRuntimeContextStorageCanReleaseAbandonedExecutions(): void
+    {
+        $storage = new StubRuntimeContextStorage();
+        $globalHub = SentrySdk::init($storage);
+
+        $storage->switchTo('abandoned');
+        SentrySdk::startContext();
+
+        $abandonedContext = SentrySdk::getCurrentRuntimeContext();
+
+        $storage->release('abandoned');
+
+        $this->assertNotSame($abandonedContext, SentrySdk::getCurrentRuntimeContext());
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
+    }
+
+    public function testRepeatedEndContextWithRuntimeContextStorageIsNoOp(): void
+    {
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getOptions')
+            ->willReturn(new Options());
+        $client->expects($this->once())
+            ->method('flush')
+            ->willReturn(new Result(ResultStatus::success()));
+
+        $storage = new StubRuntimeContextStorage();
+        $globalHub = SentrySdk::init($storage);
+        $globalHub->bindClient($client);
+
+        $storage->switchTo('request');
+        SentrySdk::startContext();
+        SentrySdk::endContext();
+
+        $this->assertNull($storage->get());
+
+        SentrySdk::endContext();
+
+        $this->assertNull($storage->get());
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
+    }
+
     public function testEndContextFlushesClientTransportWithOptionalTimeout(): void
     {
         /** @var ClientInterface&MockObject $client */
@@ -177,6 +281,43 @@ final class SentrySdkTest extends TestCase
         SentrySdk::init()->bindClient($client);
 
         SentrySdk::flush();
+    }
+
+    public function testEndContextFlushesResourcesIndependently(): void
+    {
+        StubLogger::$logs = [];
+
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->atLeastOnce())
+            ->method('getOptions')
+            ->willReturn(new Options(['logger' => StubLogger::getInstance()]));
+        $client->expects($this->exactly(2))
+            ->method('captureEvent')
+            ->willReturnCallback(static function (Event $event): void {
+                throw new \RuntimeException('Failed capturing ' . (string) $event->getType());
+            });
+        $client->expects($this->once())
+            ->method('flush')
+            ->willThrowException(new \RuntimeException('Failed flushing transport'));
+
+        SentrySdk::init()->bindClient($client);
+        SentrySdk::startContext();
+
+        Logs::getInstance()->info('log');
+        TraceMetrics::getInstance()->count('metric', 1);
+
+        SentrySdk::endContext();
+
+        $errors = array_filter(StubLogger::$logs, static function (array $log): bool {
+            return $log['level'] === 'error';
+        });
+
+        $this->assertSame([
+            'Failed to flush logs while ending a runtime context.',
+            'Failed to flush trace metrics while ending a runtime context.',
+            'Failed to flush the client transport while ending a runtime context.',
+        ], array_column($errors, 'message'));
     }
 
     public function testWithContextReturnsCallbackResultAndRestoresGlobalHub(): void
@@ -274,5 +415,17 @@ final class SentrySdkTest extends TestCase
         });
 
         return $traceparent;
+    }
+
+    private function getCurrentScopeTag(string $key): ?string
+    {
+        $value = null;
+
+        SentrySdk::getCurrentHub()->configureScope(static function (Scope $scope) use ($key, &$value): void {
+            $event = $scope->applyToEvent(Event::createEvent());
+            $value = $event !== null ? $event->getTags()[$key] ?? null : null;
+        });
+
+        return $value;
     }
 }

--- a/tests/SentrySdkTest.php
+++ b/tests/SentrySdkTest.php
@@ -152,7 +152,8 @@ final class SentrySdkTest extends TestCase
     public function testRuntimeContextStorageIsolatesConcurrentExecutions(): void
     {
         $storage = new StubRuntimeContextStorage();
-        $globalHub = SentrySdk::init($storage);
+        SentrySdk::setRuntimeContextStorage($storage);
+        $globalHub = SentrySdk::init();
 
         $storage->switchTo('first');
         SentrySdk::startContext();
@@ -211,7 +212,8 @@ final class SentrySdkTest extends TestCase
     public function testRuntimeContextStorageCanReleaseAbandonedExecutions(): void
     {
         $storage = new StubRuntimeContextStorage();
-        $globalHub = SentrySdk::init($storage);
+        SentrySdk::setRuntimeContextStorage($storage);
+        $globalHub = SentrySdk::init();
 
         $storage->switchTo('abandoned');
         SentrySdk::startContext();
@@ -236,7 +238,8 @@ final class SentrySdkTest extends TestCase
             ->willReturn(new Result(ResultStatus::success()));
 
         $storage = new StubRuntimeContextStorage();
-        $globalHub = SentrySdk::init($storage);
+        SentrySdk::setRuntimeContextStorage($storage);
+        $globalHub = SentrySdk::init();
         $globalHub->bindClient($client);
 
         $storage->switchTo('request');
@@ -253,6 +256,11 @@ final class SentrySdkTest extends TestCase
 
     public function testInitClearsContextStoredByPreviousManager(): void
     {
+        /** @var ClientInterface&MockObject $firstClient */
+        $firstClient = $this->createMock(ClientInterface::class);
+        $firstClient->expects($this->never())
+            ->method('flush');
+
         /** @var ClientInterface&MockObject $secondClient */
         $secondClient = $this->createMock(ClientInterface::class);
         $secondClient->expects($this->once())
@@ -263,26 +271,79 @@ final class SentrySdkTest extends TestCase
             ->willReturn(new Result(ResultStatus::success()));
 
         $storage = new StubRuntimeContextStorage();
-        SentrySdk::init($storage)->bindClient($this->createMock(ClientInterface::class));
+        SentrySdk::setRuntimeContextStorage($storage);
+        SentrySdk::init()->bindClient($firstClient);
 
         $storage->switchTo('request');
         SentrySdk::startContext();
         $previousHub = SentrySdk::getCurrentHub();
 
-        $freshHub = SentrySdk::init($storage);
+        $freshHub = SentrySdk::init();
 
         $this->assertNull($storage->get());
         $this->assertNotSame($previousHub, $freshHub);
 
         $freshHub->bindClient($secondClient);
 
-        // This end/start transition exposes a stale context as a missing client.
         SentrySdk::endContext();
+
+        $this->assertNull($storage->get());
+
         SentrySdk::startContext();
 
+        $this->assertNotNull($storage->get());
         $this->assertSame($secondClient, SentrySdk::getCurrentHub()->getClient());
 
         SentrySdk::endContext();
+    }
+
+    public function testReplacingRuntimeContextStorageDiscardsContextFromPreviousStorage(): void
+    {
+        $firstStorage = new StubRuntimeContextStorage();
+        $secondStorage = new StubRuntimeContextStorage();
+
+        SentrySdk::setRuntimeContextStorage($firstStorage);
+        $globalHub = SentrySdk::init();
+        SentrySdk::startContext();
+
+        $this->assertNotNull($firstStorage->get());
+
+        SentrySdk::setRuntimeContextStorage($secondStorage);
+
+        $this->assertNull($firstStorage->get());
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
+
+        SentrySdk::startContext();
+
+        $this->assertNull($firstStorage->get());
+        $this->assertSame(SentrySdk::getCurrentRuntimeContext(), $secondStorage->get());
+
+        SentrySdk::endContext();
+    }
+
+    public function testUnregisteringRuntimeContextStorageRestoresProcessLocalContext(): void
+    {
+        $storage = new StubRuntimeContextStorage();
+
+        SentrySdk::setRuntimeContextStorage($storage);
+        $globalHub = SentrySdk::init();
+        SentrySdk::startContext();
+
+        $this->assertNotNull($storage->get());
+
+        SentrySdk::setRuntimeContextStorage(null);
+
+        $this->assertNull($storage->get());
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
+
+        SentrySdk::startContext();
+
+        $this->assertNull($storage->get());
+        $this->assertNotSame($globalHub, SentrySdk::getCurrentHub());
+
+        SentrySdk::endContext();
+
+        $this->assertSame($globalHub, SentrySdk::getCurrentHub());
     }
 
     public function testEndContextFlushesClientTransportWithOptionalTimeout(): void

--- a/tests/StubRuntimeContextStorage.php
+++ b/tests/StubRuntimeContextStorage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Tests;
+
+use Sentry\State\RuntimeContext;
+use Sentry\State\RuntimeContextStorageInterface;
+
+/**
+ * Models independently selectable execution slots and abandoned execution cleanup.
+ */
+final class StubRuntimeContextStorage implements RuntimeContextStorageInterface
+{
+    /**
+     * @var string
+     */
+    private $execution = 'default';
+
+    /**
+     * @var array<string, RuntimeContext>
+     */
+    private $contexts = [];
+
+    public function get(): ?RuntimeContext
+    {
+        return $this->contexts[$this->execution] ?? null;
+    }
+
+    public function set(RuntimeContext $runtimeContext): void
+    {
+        $this->contexts[$this->execution] = $runtimeContext;
+    }
+
+    public function remove(): ?RuntimeContext
+    {
+        $runtimeContext = $this->get();
+        unset($this->contexts[$this->execution]);
+
+        return $runtimeContext;
+    }
+
+    public function switchTo(string $execution): void
+    {
+        $this->execution = $execution;
+    }
+
+    public function release(string $execution): void
+    {
+        unset($this->contexts[$execution]);
+    }
+}

--- a/tests/phpt/error_handler_reset_fatal_error_handler_state.phpt
+++ b/tests/phpt/error_handler_reset_fatal_error_handler_state.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test that resetting the fatal error handler state re-arms OOM handling
+Test that resetting the fatal error handler state re-arms OOM handling only when the reservation was released
 --FILE--
 <?php
 
@@ -49,8 +49,21 @@ var_dump(getErrorHandlerStaticProperty('disableFatalErrorHandler'));
 var_dump(getErrorHandlerStaticProperty('didIncreaseMemoryLimit'));
 var_dump(\strlen(getErrorHandlerStaticProperty('reservedMemory')));
 
+setErrorHandlerStaticProperty('reservedMemory', 'existing reservation');
+setErrorHandlerStaticProperty('disableFatalErrorHandler', true);
+setErrorHandlerStaticProperty('didIncreaseMemoryLimit', true);
+
+ErrorHandler::resetFatalErrorHandlerState();
+
+var_dump(getErrorHandlerStaticProperty('disableFatalErrorHandler'));
+var_dump(getErrorHandlerStaticProperty('didIncreaseMemoryLimit'));
+var_dump(getErrorHandlerStaticProperty('reservedMemory'));
+
 ?>
 --EXPECT--
 bool(false)
 bool(false)
 int(1234)
+bool(false)
+bool(false)
+string(20) "existing reservation"


### PR DESCRIPTION
Hi! I’m the co-creator of [Hypervel](https://github.com/hypervel/components) and a contributor to Swoole. I’d like to include a first-party Sentry integration as part of the framework, but the SDK currently makes that difficult to do safely.

Sentry currently keeps one active runtime context for the whole PHP process. That works when requests are handled one at a time. In a server where several requests or tasks can overlap, a second request can reuse the first request’s context. The requests can then share Sentry state, logs, and metrics, and one request can flush or remove data that belongs to another.

This PR lets a runtime provide the storage used for the current request’s context. Sentry still creates the context and handles flushing; the runtime only stores and returns the context for whichever request or task is currently running.

The storage is passed when Sentry is initialized because it controls how work inside the process is kept separate. It isn’t client configuration and shouldn’t change when the client is replaced.

Nothing changes for applications that don’t provide custom storage. Their context stays process-local, and the default implementation becomes simpler: one nullable property replaces the fixed `process` key, two lookup maps, and their cleanup logic.

When custom storage is used, the SDK manager doesn’t retain active contexts itself. If a request ends unexpectedly, its runtime can release that context without leaving its Hub, logs, and metrics in memory for the rest of the worker’s lifetime.

I ran into this while working on Hypervel, but the problem isn’t specific to Swoole. The same change can be used by any async PHP runtime, including Amp and ReactPHP.

One thing I wasn’t sure about was the naming for the new public type. The SDK already has `Sentry\Context\RuntimeContext` for information attached to events. This PR exposes `Sentry\State\RuntimeContext` as the value stored for a running request, although its constructor and methods stay internal. I kept the existing name, but `ExecutionContext` might be clearer.
