### PR TITLE
fix: Avoid PHP 8.5 warnings when serializing INF, NAN and large floats

### DIFF
--- a/src/Serializer/RepresentationSerializer.php
+++ b/src/Serializer/RepresentationSerializer.php
@@ -49,8 +49,14 @@ class RepresentationSerializer extends AbstractSerializer implements Representat
             return 'true';
         }
 
-        if (\is_float($value) && (int) $value == $value) {
-            return $value . '.0';
+        if (\is_float($value)) {
+            if (is_nan($value)) {
+                return 'NAN';
+            }
+
+            if ($this->isCastableToInt($value) && (int) $value == $value) {
+                return $value . '.0';
+            }
         }
 
         if (is_numeric($value)) {
@@ -58,5 +64,16 @@ class RepresentationSerializer extends AbstractSerializer implements Representat
         }
 
         return (string) parent::serializeValue($value);
+    }
+
+    /**
+     * Casting a non-finite float, or one that falls outside of the integer
+     * range, raises a warning as of PHP 8.5.
+     *
+     * @param float $value The value to check
+     */
+    private function isCastableToInt(float $value): bool
+    {
+        return $value >= (float) \PHP_INT_MIN && $value < (float) \PHP_INT_MAX;
     }
 }

--- a/tests/FrameBuilderTest.php
+++ b/tests/FrameBuilderTest.php
@@ -442,4 +442,29 @@ final class FrameBuilderTest extends TestCase
         $this->assertArrayHasKey('rest', $result);
         $this->assertSame(['extra1', 'extra2', 'extra3'], $result['rest']);
     }
+
+    public function testGetFunctionArgumentsWithNonFiniteFloatValues(): void
+    {
+        $options = new Options([]);
+        $frameBuilder = new FrameBuilder($options, new RepresentationSerializer($options));
+
+        $backtraceFrame = [
+            'function' => 'testNonFiniteFloatFunction',
+            'args' => [\INF, -\INF, \NAN, 1e20, 1.0],
+        ];
+
+        $reflectionClass = new \ReflectionClass($frameBuilder);
+        $getFunctionArgumentsMethod = $reflectionClass->getMethod('getFunctionArguments');
+        if (\PHP_VERSION_ID < 80100) {
+            $getFunctionArgumentsMethod->setAccessible(true);
+        }
+
+        $result = $getFunctionArgumentsMethod->invoke($frameBuilder, $backtraceFrame);
+
+        $this->assertSame('INF', $result['param0']);
+        $this->assertSame('-INF', $result['param1']);
+        $this->assertSame('NAN', $result['param2']);
+        $this->assertSame('1.0E+20', $result['param3']);
+        $this->assertSame('1.0', $result['param4']);
+    }
 }

--- a/tests/Serializer/RepresentationSerializerTest.php
+++ b/tests/Serializer/RepresentationSerializerTest.php
@@ -126,6 +126,37 @@ final class RepresentationSerializerTest extends AbstractSerializerTest
     }
 
     /**
+     * @dataProvider serializeAllObjectsDataProvider
+     */
+    public function testSerializeNonFiniteFloat(bool $serializeAllObjects): void
+    {
+        $serializer = $this->createSerializer();
+
+        if ($serializeAllObjects) {
+            $serializer->setSerializeAllObjects(true);
+        }
+
+        $this->assertSame('INF', $serializer->representationSerialize(\INF));
+        $this->assertSame('-INF', $serializer->representationSerialize(-\INF));
+        $this->assertSame('NAN', $serializer->representationSerialize(\NAN));
+    }
+
+    /**
+     * @dataProvider serializeAllObjectsDataProvider
+     */
+    public function testSerializeFloatOutsideOfIntegerRange(bool $serializeAllObjects): void
+    {
+        $serializer = $this->createSerializer();
+
+        if ($serializeAllObjects) {
+            $serializer->setSerializeAllObjects(true);
+        }
+
+        $this->assertSame('1.0E+20', $serializer->representationSerialize(1e20));
+        $this->assertSame('-1.0E+20', $serializer->representationSerialize(-1e20));
+    }
+
+    /**
      * @return RepresentationSerializer
      */
     protected function createSerializer(): AbstractSerializer


### PR DESCRIPTION
A Symfony console command in our app running on PHP 8.5 failed for an unrelated reason, but reporting that exception to Sentry raised a second issue:

`Warning: The float INF is not representable as an int, cast occurred`

...with the serializer at the top of the stack.

The command in question forces a cache recompute via `CacheInterface::get($key, $callback, INF)`, so `INF` was sitting in the frame arguments of the thrown exception.